### PR TITLE
chore(license): add third-party NOTICE, DCO policy, and update copyright

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,6 +99,34 @@ See **AGENTS.md** for the full tool list, resolution-aware querying (precise vs
    full suite.
 4. Keep PRs scoped — one logical change each.
 
+## Contributor licensing (DCO)
+
+cairn is MIT-licensed. To keep the project's licensing clean and to protect
+every downstream user, we ask contributors to certify that they have the right
+to contribute their code under those terms, using the
+[Developer Certificate of Origin (DCO)](https://developercertificate.org/).
+
+This is the same lightweight model the Linux kernel and many other projects use.
+There is **no CLA** to sign and no copyright assignment — you keep your
+copyright. The DCO is satisfied automatically by signing off your commit:
+
+```bash
+git commit -s          # adds "Signed-off-by: Your Name <you@example.com>"
+```
+
+To set it as the default for this repo:
+
+```bash
+git config format.signoff true
+```
+
+By submitting a pull request with a `Signed-off-by:` line, you attest that you
+wrote the code yourself (or have the right to submit it), it is not a
+derivative of GPL/AGPL or proprietary code, and you are licensing it to cairn
+and its users under the MIT License. If a contribution is derived from
+third-party MIT/Apache/BSD-licensed code, retain the upstream copyright and
+license notice in the file or add it to `NOTICE`.
+
 ## Reporting issues
 
 File bugs via **GitHub Issues**. Please include:

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 Tan Le
+Copyright (c) 2025–2026 Tan Le
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,82 @@
+cairn
+Copyright (c) 2025–2026 Tan Le
+
+Licensed under the MIT License; see LICENSE for full text.
+
+This NOTICE file documents the third-party open-source software used by cairn.
+cairn depends on these packages at runtime (resolved via pip/uv from PyPI) and
+does not redistribute their source. Each package retains its own license; the
+summaries below are for convenience and are not legal substitutes for the
+upstream license texts.
+
+================================================================================
+Dependencies (by license family)
+================================================================================
+
+This product depends on software distributed under the following licenses. Each
+entry lists the package and its declared license.
+
+----------------------------------------
+MIT License
+----------------------------------------
+  annotated-types, anyio, attrs, build, h11, httpx-sse, iniconfig, jsonschema,
+  jsonschema-specifications, markdown-it-py, mcp, mdurl, pluggy, pydantic,
+  pydantic-settings, pydantic_core, PyJWT, pyproject_hooks, pytest,
+  referencing, rich, rpds-py, ruff, PyYAML, tree-sitter, tree-sitter-dart,
+  tree-sitter-go, tree-sitter-java, tree-sitter-javascript, tree-sitter-kotlin,
+  tree-sitter-objc, tree-sitter-python, tree-sitter-swift, tree-sitter-typescript,
+  typing-inspection, cffi (MIT-0)
+
+----------------------------------------
+BSD License (BSD-2-Clause / BSD-3-Clause)
+----------------------------------------
+  click (BSD-3-Clause), httpcore (BSD-3-Clause), httpx (BSD-3-Clause),
+  idna (BSD-3-Clause), pycparser (BSD-3-Clause), Pygments (BSD-2-Clause),
+  python-dotenv (BSD-3-Clause), sse-starlette (BSD-3-Clause),
+  starlette (BSD-3-Clause), uvicorn (BSD-3-Clause)
+
+----------------------------------------
+Apache License 2.0
+----------------------------------------
+  python-multipart (Apache-2.0), watchdog (Apache-2.0)
+
+----------------------------------------
+Dual: Apache License 2.0 OR BSD
+----------------------------------------
+  cryptography (Apache-2.0 OR BSD-3-Clause)
+  packaging (Apache-2.0 OR BSD-2-Clause)
+
+----------------------------------------
+Mozilla Public License 2.0 (MPL-2.0)
+----------------------------------------
+  certifi, pathspec
+  Note: MPL-2.0 is file-level weak copyleft. It is satisfied by keeping the
+  MPL-licensed files' source and notice available (they remain in the upstream
+  PyPI packages). cairn does not copy or vendor these files into its source
+  tree, so no additional obligation attaches to distributing cairn itself.
+
+----------------------------------------
+Python Software Foundation License (PSF-2.0)
+----------------------------------------
+  typing_extensions
+
+----------------------------------------
+Dual: MIT License OR Apache License 2.0
+----------------------------------------
+  sqlite-vec
+
+================================================================================
+Optional extras
+================================================================================
+
+The `[semantic]` extra (sentence-transformers, numpy) is not installed by
+default. On Linux it additionally pulls torch and its transitive NVIDIA CUDA
+runtime packages (e.g. nvidia-cublas, nvidia-cudnn, nvidia-cufft, triton),
+which are governed by NVIDIA's CUDA EULA / Apache-2.0 and torch's BSD-style
+license. These are resolved and accepted by the end user; cairn does not
+bundle or redistribute them.
+
+The embedding model `BAAI/bge-m3` (referenced by name, downloaded on demand
+to ~/.cairn/lib/ when a user runs `cg embed --install-deps`) is released
+under the MIT License on Hugging Face. cairn does not redistribute the
+model weights.

--- a/README.md
+++ b/README.md
@@ -209,6 +209,19 @@ cairn embed                   # builds the embedding index
 
 The full suite (no marker) is the CI path.
 
+## Dependency licenses
+
+cairn is MIT-licensed. Its dependencies are all permissive (MIT, BSD,
+Apache-2.0, MPL-2.0, PSF); see [NOTICE](NOTICE) for the full list.
+
+The optional `[semantic]` extra is not installed by default. If you opt into it
+on Linux, `pip` resolves `torch` and its transitive NVIDIA CUDA runtime
+packages, which carry their own licenses (torch: BSD; NVIDIA CUDA components:
+NVIDIA EULA / Apache-2.0). The embedding model `BAAI/bge-m3` (MIT) is
+downloaded on demand to `~/.cairn/lib/` and is not redistributed with cairn.
+None of these are bundled with cairn — they are resolved and accepted by the
+end user at install time.
+
 ## Status
 
 **Beta — pre-1.0 (v0.5.3).** Public surfaces (CLI flags, MCP tool shapes,
@@ -217,4 +230,4 @@ knowledge-file layout) may still shift before 1.0. Feedback welcome via
 
 ## License
 
-[MIT](LICENSE) — © 2025 Tan Le
+[MIT](LICENSE) — © 2025–2026 Tan Le


### PR DESCRIPTION
Pre-release licensing audit before making the repo public:

- Add NOTICE file enumerating all runtime dependencies grouped by license family (36 MIT, 10 BSD, 3 Apache-2.0, 2 Apache/BSD dual, 2 MPL-2.0, 1 PSF, 1 MIT/Apache dual). Documents that MPL-2.0 deps (certifi, pathspec) are not vendored and the optional [semantic] extra's torch/NVIDIA CUDA/bge-m3 chain is resolved by the end user, never bundled.

- Add Contributor licensing (DCO) section to CONTRIBUTING.md: lightweight Developer Certificate of Origin via 'git commit -s', no CLA, no copyright assignment. Protects downstream users from contributor-attribution liability once the repo is public.

- Add 'Dependency licenses' section to README.md stating all deps are permissive, linking to NOTICE, and noting the [semantic] extra's separate license acceptance (torch BSD, NVIDIA CUDA EULA/Apache, bge-m3 MIT).

- Update copyright year to 2025-2026 (LICENSE, NOTICE, README).