### PR TITLE
feat(memory): add supersession, exponential decay, and auto-capture

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ All AI coding agents working in this workspace should use these tools.
 ## MCP Server
 - Name: `cairn` (auto-connected at session start)
 - Transport: stdio
-- 26 tools across 5 layers: graph (9), knowledge base + compass (5), memory (7), knowledge (5)
+- 27 tools across 5 layers: graph (9), knowledge base + compass (5), memory (8), knowledge (5)
   (`explore` is the recommended first call -- it aggregates the graph layer;
   `ask_compass` is the cross-layer router)
 

--- a/docs/architecture-overview.md
+++ b/docs/architecture-overview.md
@@ -24,13 +24,13 @@
 cairn is a **local, structural, agent-first** codebase intelligence system.
 It parses your source into a typed call graph in SQLite, then layers a
 knowledge system on top (compass, wiki, memory, business knowledge). The same
-store backs a `cairn` CLI for humans and a 26-tool MCP server for AI agents.
+store backs a `cairn` CLI for humans and a 27-tool MCP server for AI agents.
 
 ```mermaid
 flowchart TB
     subgraph Clients["Clients"]
         H["Human<br/>cairn CLI"]
-        A["AI Agent<br/>MCP server (26 tools)"]
+        A["AI Agent<br/>MCP server (27 tools)"]
     end
 
     subgraph Router["Routing"]
@@ -450,7 +450,7 @@ Every concept is a markdown file with YAML frontmatter (OKF v0.2). The
 ## See also
 
 - [architecture.md](architecture.md) — per-layer deep dive, resolution model, LLM boundary.
-- [mcp-tools.md](mcp-tools.md) — all 26 MCP tools with argument schemas.
+- [mcp-tools.md](mcp-tools.md) — all 27 MCP tools with argument schemas.
 - [examples/resolution-walkthrough.md](examples/resolution-walkthrough.md) — precise vs fuzzy worked example.
 - [benchmarks.md](benchmarks.md) — how to measure retrieval quality and performance.
 - [architecture.html](../architecture.html) — interactive HTML version of these diagrams.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -15,7 +15,7 @@ cairn is a **local, structural, agent-first** code intelligence system.
   symbols and call edges, then answers queries against that graph. "Who calls
   this?" is a graph traversal, not a guess. Parsers exist for nine languages:
   Kotlin, Java, Python, Swift, TypeScript, JavaScript, Dart, Objective-C, Go.
-- **Agent-first.** The primary interface is an MCP server exposing 26 tools to
+- **Agent-first.** The primary interface is an MCP server exposing 27 tools to
   AI agents. The CLI (`cairn`) mirrors the same capability for humans and as a
   fallback. The tool surfaces are designed for an agent to call repeatedly and
   cheaply, not for one-shot human typing.

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -340,7 +340,7 @@ state, and prompts for which to install plus the config scope.
 ## Where to look next
 
 - For the **MCP server** tool surface that AI agents consume, see
-  [mcp-tools.md](./mcp-tools.md) (26 tools across 5 layers; `explore` is the
+  [mcp-tools.md](./mcp-tools.md) (27 tools across 5 layers; `explore` is the
   recommended first call).
 - For the explore-first workflow, precise-vs-fuzzy rules, and per-tool quirks,
   see `AGENTS.md` in the workspace root.

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -2,7 +2,7 @@
 
 The `cairn` MCP server (started by `cairn serve`) exposes the codebase
 intelligence graph to AI agents. It is a FastMCP server implemented in
-`src/cairn/mcp_server/` and registers **26 tools** across 5 layers,
+`src/cairn/mcp_server/` and registers **27 tools** across 5 layers,
 plus an index-status resource.
 
 > **`explore(query)` is the recommended first call** — it aggregates the
@@ -104,14 +104,14 @@ Bundle/OKF-read and cross-layer routing.
 
 > Note on grouping: all docs now use the canonical layer counts — graph (9),
 > knowledge base + compass (5: `get_compass`, `search_knowledge`, `ask_compass`,
-> `trace_flow`, `generate_flow`), memory (7), knowledge (5) — summing to 26,
+> `trace_flow`, `generate_flow`), memory (8), knowledge (5) — summing to 27,
 > which the live `mcp` instance enforces via an assertion in `server.py`.
 > `explore` is registered in the graph layer (1 of its 9) but acts as the
 > aggregator/front-door; `ask_compass` is the cross-layer router.
 
 ---
 
-## Layer 4 — Memory (7 tools)
+## Layer 4 — Memory (8 tools)
 
 Agent memory across the tiers raw → drafts → tribal → canonical. The
 session-orientation entry point is `memory_digest`, not a recall query.
@@ -119,8 +119,9 @@ session-orientation entry point is `memory_digest`, not a recall query.
 | Tool | Purpose |
 |------|---------|
 | `memory_digest(limit?)` | Top tribal memories by score. **Call this once for session orientation** before reaching for `recall_memory`. Each result shows a live `refs-verified` fraction. |
-| `recall_memory(query, tier?)` | Search past decisions, patterns, mistakes, workarounds. Increments refs. Each result shows a live `refs-verified` fraction — a low value flags a memory citing a renamed/removed symbol. |
-| `record_memory(type, title, body, resource?, confidence?)` | Capture a learning. `type`: `decision\|pattern\|mistake\|workaround`. |
+| `recall_memory(query, tier?, include_superseded?)` | Search past decisions, patterns, mistakes, workarounds. Increments refs. Each result shows a live `refs-verified` fraction — a low value flags a memory citing a renamed/removed symbol. Superseded (revised) memories are hidden by default; set `include_superseded=true` to audit revision history. |
+| `record_memory(type, title, body, resource?, confidence?)` | Capture a learning. `type`: `decision\|pattern\|mistake\|workaround`. Automatically supersedes a near-duplicate existing memory (semantic cosine ≥0.85) instead of creating a parallel record. |
+| `memory_evolve(memory_path, title?, body?)` | Revise a memory: create a new version that supersedes the old one, inheriting the version chain. The old memory is marked superseded and hidden from recall. |
 | `memory_promote(memory_path)` | Force-promote a memory to canonical (compass/wiki), bypassing tiers. |
 | `memory_demote(memory_path, tier?)` | Demote a memory to a lower tier (`raw`/`archived`); rejects promotions. |
 | `memory_delete(memory_path)` | Permanently delete a memory and its cross-session refs. **Irreversible.** |
@@ -181,7 +182,7 @@ procedural workflows.
 
 ## Resource: index status
 
-In addition to the 26 tools, the server exposes a browsable resource:
+In addition to the 27 tools, the server exposes a browsable resource:
 
 | Resource | Purpose |
 |----------|---------|

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -107,7 +107,7 @@ Desktop, Cursor, or ZCode, add it to the client's MCP config:
 }
 ```
 
-The server exposes 26 tools across 5 layers (graph, compass + knowledge base +
+The server exposes 27 tools across 5 layers (graph, compass + knowledge base +
 router, memory, knowledge). The aggregator tool `explore` is the recommended
 first call for almost any question — it fans a query across the graph layer and
 returns one consolidated answer in a single round trip.
@@ -128,7 +128,7 @@ preview. To remove everything later: `cairn uninstall-agents`.
 ## Next steps
 
 - [cli-reference.md](cli-reference.md) — every `cairn` command and flag.
-- [mcp-tools.md](mcp-tools.md) — the 26 MCP tools, grouped by layer.
+- [mcp-tools.md](mcp-tools.md) — the 27 MCP tools, grouped by layer.
 - [configuration.md](configuration.md) — env vars for paths, semantic search,
   workers, and the LLM task queue.
 - [architecture.md](architecture.md) — the 5-layer design, resolution model,

--- a/src/cairn/agent_install/_common.py
+++ b/src/cairn/agent_install/_common.py
@@ -314,7 +314,7 @@ def _agents_instructions() -> str:
         "## MCP Server\n"
         "- Name: `cairn` (auto-connected at session start)\n"
         "- Transport: stdio\n"
-        "- 26 tools across 5 layers: graph (9), knowledge base + compass (4), memory (7), knowledge (5), router (1)\n"
+        "- 27 tools across 5 layers: graph (9), knowledge base + compass (4), memory (8), knowledge (5), router (1)\n"
         "  (`explore` is the recommended first call -- it aggregates the graph layer)\n"
         "\n"
     ) + _INSTRUCTIONS_BODY

--- a/src/cairn/agent_integration/skill/SKILL.md
+++ b/src/cairn/agent_integration/skill/SKILL.md
@@ -31,7 +31,7 @@ Full descriptions: `references/tools.md`. Names by layer:
 
 - **Graph (L1):** explore, semantic_search, find_definition, get_callers, get_callees, impact_analysis, search_symbols, cross_repo_deps, visualize_graph
 - **Knowledge Base + Compass (L2/3):** search_knowledge, get_compass, trace_flow, generate_flow
-- **Memory (L4):** memory_digest, recall_memory, record_memory, memory_promote, memory_demote, memory_delete, memory_decay
+- **Memory (L4):** memory_digest, recall_memory, record_memory, memory_evolve, memory_promote, memory_demote, memory_delete, memory_decay
 - **Knowledge Documents (L5):** knowledge_add, knowledge_search, knowledge_delete, knowledge_status, trace_workflow
 - **Router:** ask_compass
 

--- a/src/cairn/agent_integration/skill/references/tools.md
+++ b/src/cairn/agent_integration/skill/references/tools.md
@@ -23,7 +23,8 @@ server. SKILL.md keeps only a name index — come here for the details.
 ## Layer 4: Memory
 - `memory_digest(limit=10)` -- Top tribal memories for session orientation (the recommended first memory call in a new session)
 - `recall_memory(query, tier?)` -- Search past decisions, patterns, mistakes (symbol/title-keyed; see `references/tool-behaviors.md`)
-- `record_memory(type, title, body, resource?, confidence?)` -- Capture a learning
+- `record_memory(type, title, body, resource?, confidence?)` -- Capture a learning (auto-supersedes near-duplicates of the same type)
+- `memory_evolve(memory_path, title?, body?)` -- Revise a memory: create a new version that supersedes the old, inheriting the version chain
 - `memory_promote(memory_path)` -- Promote a memory to a higher tier (raw→drafts→tribal)
 - `memory_demote(memory_path, tier="raw")` -- Demote a memory to a lower tier (rejects promotions)
 - `memory_delete(memory_path)` -- Permanently delete a memory and its refs (irreversible)

--- a/src/cairn/cli/memory.py
+++ b/src/cairn/cli/memory.py
@@ -46,6 +46,38 @@ def memory_record(mtype, title, body, resource, confidence, db, knowledge):
     click.echo(f"Recorded {mtype} '{title}' -> {result['path']} (score={signals['score']}, tier={result['tier']})")
 
 
+@memory.command("evolve")
+@click.argument("memory_path")
+@click.option("--title", default=None, help="New title for the revised memory.")
+@click.option("--body", default=None, help="New body for the revised memory.")
+@click.option("--db", default=str(DEFAULT_DB_PATH))
+@click.option("--knowledge", default=str(DEFAULT_DB_PATH.parent / ".knowledge"))
+def memory_evolve(memory_path, title, body, db, knowledge):
+    """Revise a memory: create a new version that supersedes the old one.
+
+    The old memory is marked superseded (hidden from search unless
+    --include-superseded) and its version chain is inherited, preserving
+    the full decision history.
+    """
+    from ..memory.promotion import evolve_memory
+    from ..okf.bundle import OKFBundle
+
+    conn = get_db(db)
+    bundle = OKFBundle(knowledge)
+    result = evolve_memory(
+        conn, bundle, memory_path, new_title=title, new_body=body
+    )
+    conn.close()
+    if result is None:
+        click.echo(f"Memory not found: '{memory_path}'.")
+        return
+    signals = result["signals"]
+    click.echo(
+        f"Evolved '{memory_path}' -> {result['path']} "
+        f"(score={signals['score']}, tier={result['tier']}, superseded {result['superseded']})"
+    )
+
+
 @memory.command("search")
 @click.argument("query")
 @click.option("--tier", default=None)

--- a/src/cairn/hooks/claude_hooks.py
+++ b/src/cairn/hooks/claude_hooks.py
@@ -93,12 +93,83 @@ def session_end():
     sys.stdout.write(out or "(no memories captured)")
 
 
+def post_tool_failure():
+    """Called after a tool use fails. Auto-captures the failure as a raw
+    ``mistake`` memory so the agent (and future sessions) can recall what went
+    wrong without the agent having to explicitly call record_memory.
+
+    This is the highest-signal auto-capture: failures the agent didn't bother
+    to record. The captured memory lands in the ``raw`` tier at low confidence
+    and relies on the existing promotion/critic pipeline to promote the worthy
+    ones -- graph_verification will naturally score down memories citing
+    nonexistent symbols.
+
+    Privacy: the tool input and error text are passed through the privacy
+    filter (``strip_private_data``) before storage, so secrets in error output
+    are scrubbed.
+
+    Non-blocking: spawns the cairn CLI as a detached subprocess
+    (``start_new_session=True``) and returns immediately. The agent's next
+    prompt is never delayed.
+    """
+    data = _read_stdin()
+    # Skip interrupts -- those aren't real failures worth capturing.
+    if data.get("is_interrupt") or data.get("isInterrupt"):
+        return
+    tool_name = data.get("tool_name") or data.get("toolName") or "unknown"
+    tool_input = data.get("tool_input") or data.get("toolArgs") or {}
+    error = data.get("error") or ""
+
+    if not error:
+        return
+
+    # Privacy-filter before storage. Tool error output can contain API keys,
+    # bearer tokens, etc. from the failing command's stderr.
+    try:
+        from cairn.memory.privacy import strip_private_data
+    except ImportError:
+        # If the filter isn't importable (unlikely), bail -- never store
+        # unfiltered error output.
+        return
+
+    safe_input = strip_private_data(json.dumps(tool_input)[:4000])
+    safe_error = strip_private_data(str(error)[:4000])
+    title = f"Tool failure: {tool_name}"
+
+    # Build the memory body with the Why/How structure record_memory expects.
+    body = (
+        f"{tool_name} failed during use.\n\n"
+        f"Input: {safe_input}\n\n"
+        f"Error: {safe_error}\n\n"
+        f"Why: Auto-captured by post_tool_failure hook.\n"
+        f"How to apply: Check if this error pattern is recurring before "
+        f"using this tool the same way again."
+    )
+
+    # Detached subprocess -- fire and forget, never blocks the agent.
+    try:
+        subprocess.Popen(
+            _cg_command() + [
+                "memory", "record", "mistake", title,
+                "--body", body,
+                "--confidence", "0.3",  # low: raw capture, unreviewed
+            ],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            start_new_session=True,  # detach so it survives the hook exit
+        )
+    except (subprocess.SubprocessError, OSError):
+        pass  # never let capture break the agent
+
+
 if __name__ == "__main__":
     hook_type = sys.argv[1] if len(sys.argv) > 1 else "post_edit"
     if hook_type == "post_edit":
         post_edit()
     elif hook_type == "session_end":
         session_end()
+    elif hook_type == "post_tool_failure":
+        post_tool_failure()
     else:
         sys.stderr.write(f"unknown hook: {hook_type}\n")
         sys.exit(1)

--- a/src/cairn/mcp_server/__init__.py
+++ b/src/cairn/mcp_server/__init__.py
@@ -4,7 +4,7 @@ Public API:
 
     from cairn.mcp_server import run
 
-The 26 tools live in split modules (tools_graph, tools_memory, tools_knowledge,
+The 27 tools live in split modules (tools_graph, tools_memory, tools_knowledge,
 tools_compass) and register on the shared FastMCP instance from _server_core
 when server.py imports them at boot.
 """

--- a/src/cairn/mcp_server/server.py
+++ b/src/cairn/mcp_server/server.py
@@ -1,13 +1,13 @@
 """cairn MCP server: exposes graph query tools to AI agents.
 
-Implements 26 tools across 5 layers:
+Implements 27 tools across 5 layers:
   L1 (graph): find_definition, get_callers, get_callees, impact_analysis,
               search_symbols, cross_repo_deps, explore, semantic_search
   L2/L3 (knowledge base): search_knowledge, get_compass,
                           trace_flow, generate_flow
   L4 (memory + router): recall_memory, record_memory, ask_compass,
                          visualize_graph, memory_promote, memory_demote,
-                         memory_delete, memory_decay
+                         memory_delete, memory_decay, memory_evolve
   L5 (knowledge): knowledge_add, knowledge_search, knowledge_delete,
                   knowledge_status, trace_workflow (ordered procedural
                   steps -- a knowledge doc with doc_type="workflow",
@@ -65,7 +65,7 @@ from . import tools_knowledge  # noqa: F401
 from . import tools_memory   # noqa: F401
 
 # Expected tool count - assertion fires if tools are missing due to import issues
-_EXPECTED_TOOL_COUNT = 26
+_EXPECTED_TOOL_COUNT = 27
 
 
 def _install_exit_watchdog():

--- a/src/cairn/mcp_server/tools_memory.py
+++ b/src/cairn/mcp_server/tools_memory.py
@@ -56,7 +56,7 @@ def memory_digest(limit: int = 10) -> str:
 
 @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True, destructiveHint=False, idempotentHint=True))
 @instrument
-def recall_memory(query: str, tier: str = "") -> str:
+def recall_memory(query: str, tier: str = "", include_superseded: bool = False) -> str:
     """Search past decisions, patterns, mistakes, workarounds. Increments refs.
 
     Each result shows a live-recomputed refs-verified fraction (backtick-quoted
@@ -67,6 +67,10 @@ def recall_memory(query: str, tier: str = "") -> str:
 
     Query by symbol name or title keywords (e.g. "ApiFactory", "backoff"), not
     natural-language prose -- matching is token-based with a semantic fallback.
+
+    By default superseded (revised) memories are hidden -- only the latest
+    version of a decision is returned. Set include_superseded=true to audit
+    the full revision history (each superseded memory points to its successor).
 
     Example:
         recall_memory("ApiFactory backoff")
@@ -81,7 +85,10 @@ def recall_memory(query: str, tier: str = "") -> str:
     bundle = _bundle()
     conn = _conn()
     try:
-        results = search_memory(conn, bundle, query, tier=tier or None, session_id="mcp")
+        results = search_memory(
+            conn, bundle, query, tier=tier or None, session_id="mcp",
+            include_superseded=include_superseded,
+        )
     except Exception:
         conn.close()
         raise
@@ -102,11 +109,13 @@ def recall_memory(query: str, tier: str = "") -> str:
         for c in results:
             score = c.extensions.get("memory_score", "?")
             t = c.extensions.get("memory_tier", "?")
+            superseded = c.extensions.get("memory_is_latest", True) is False
             try:
                 refs_verified = round(_graph_verification(c, conn), 3)
             except Exception:
                 refs_verified = "?"
-            out.append(f"  [{t} {score}, refs-verified={refs_verified}] {c.title}")
+            tag = " [SUPERSEDED]" if superseded else ""
+            out.append(f"  [{t} {score}, refs-verified={refs_verified}] {c.title}{tag}")
             if c.description:
                 out.append(f"    {c.description}")
     finally:
@@ -146,7 +155,45 @@ def record_memory(
     finally:
         conn.close()
     signals = result["signals"]
-    return f"Recorded {type} '{title}' -> {result['path']} (score={signals['score']}, tier={result['tier']})"
+    superseded = result.get("superseded")
+    msg = f"Recorded {type} '{title}' -> {result['path']} (score={signals['score']}, tier={result['tier']})"
+    if superseded:
+        msg += f" [superseded {superseded}]"
+    return msg
+
+
+@mcp.tool(annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=False, idempotentHint=False))
+@instrument
+def memory_evolve(memory_path: str, title: str = "", body: str = "") -> str:
+    """Revise an existing memory by creating a new version that supersedes it.
+
+    The old memory is marked superseded (hidden from recall_memory unless
+    include_superseded=true) and its version chain is inherited, so the full
+    decision history is preserved. Use this when you know a decision/pattern
+    has changed and want to record the revision explicitly rather than letting
+    record_memory's automatic near-dup detection handle it.
+
+    At least one of title or body must be provided (and differ from the old).
+    """
+    from cairn.memory.promotion import evolve_memory
+
+    bundle = _bundle()
+    conn = _rw_conn()
+    try:
+        result = evolve_memory(
+            conn, bundle, memory_path,
+            new_title=title or None,
+            new_body=body or None,
+        )
+    finally:
+        conn.close()
+    if result is None:
+        return f"Error: could not find memory at '{memory_path}'."
+    signals = result["signals"]
+    return (
+        f"Evolved '{memory_path}' -> {result['path']} "
+        f"(score={signals['score']}, tier={result['tier']}, superseded {result['superseded']})"
+    )
 
 
 @mcp.tool(annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=False, idempotentHint=False))

--- a/src/cairn/memory/privacy.py
+++ b/src/cairn/memory/privacy.py
@@ -1,0 +1,55 @@
+"""Privacy filter: strip secrets from text before storing in memory.
+
+Adapted from agentmemory's ``src/functions/privacy.ts`` — a regex-only floor
+(not a ceiling). It catches well-known secret shapes (API keys, bearer tokens,
+JWTs) and ``<private>...</private>`` tags. It does NOT do entropy analysis or
+load actual secret values from env; for stronger guarantees, callers should
+add their own env-based redaction on top.
+
+Used by the auto-capture hook (``post_tool_failure``) to ensure tool error
+output containing secrets is scrubbed before being stored as a raw ``mistake``
+memory.
+"""
+from __future__ import annotations
+
+import re
+
+# ``<private>...</private>`` tags → [REDACTED].
+_PRIVATE_TAG_RE = re.compile(r"<private>[\s\S]*?</private>", re.IGNORECASE)
+
+# Each pattern is cloned per-call (``re.compile(source, flags)``) to avoid the
+# stateful ``lastIndex`` bug that would arise from reusing a compiled ``/g``
+# regex across multiple calls. Listed verbatim from agentmemory's privacy.ts.
+_SECRET_PATTERN_SOURCES: list[str] = [
+    r"(?:api[_-]?key|secret|token|password|credential|auth)[\s]*[=:]\s*[\"']?[A-Za-z0-9_\-/.+]{20,}[\"']?",
+    r"Bearer\s+[A-Za-z0-9._\-+/=]{20,}",
+    r"sk-proj-[A-Za-z0-9\-_]{20,}",
+    r"(?:sk|pk|rk|ak)-[A-Za-z0-9][A-Za-z0-9\-_]{19,}",
+    r"sk-ant-[A-Za-z0-9\-_]{20,}",
+    r"gh[pus]_[A-Za-z0-9]{36,}",
+    r"github_pat_[A-Za-z0-9_]{22,}",
+    r"xoxb-[A-Za-z0-9\-]+",
+    r"AKIA[0-9A-Z]{16}",
+    r"AIza[A-Za-z0-9\-_]{35}",
+    r"eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}",
+    r"npm_[A-Za-z0-9]{36}",
+    r"glpat-[A-Za-z0-9\-_]{20,}",
+    r"dop_v1_[A-Za-z0-9]{64}",
+]
+
+# Pre-compile once (module load). Each is stateless because we use
+# ``re.sub`` (which resets match position), not ``.finditer`` with state.
+_COMPILED_SECRETS = [re.compile(p, re.IGNORECASE) for p in _SECRET_PATTERN_SOURCES]
+
+
+def strip_private_data(input_text: str) -> str:
+    """Strip ``<private>`` tags and known secret shapes from ``input_text``.
+
+    ``<private>...</private>`` blocks become ``[REDACTED]``.
+    Secret-shaped tokens (API keys, bearer tokens, JWTs, etc.) become
+    ``[REDACTED_SECRET]``.
+    """
+    result = _PRIVATE_TAG_RE.sub("[REDACTED]", input_text)
+    for pattern in _COMPILED_SECRETS:
+        result = pattern.sub("[REDACTED_SECRET]", result)
+    return result

--- a/src/cairn/memory/promotion.py
+++ b/src/cairn/memory/promotion.py
@@ -23,13 +23,36 @@ def capture_memory(
     confidence: float = 0.7,
     session_origin: Optional[str] = None,
     tags: Optional[List[str]] = None,
+    supersedes_threshold: float = 0.85,
 ) -> Dict:
     """Create, score, and store a new memory in one step.
 
     Shared by the CLI (`cairn memory record`/`capture`) and the MCP
     `record_memory` tool so the create -> score -> tier -> store sequence
     lives in exactly one place.
+
+    Supersession: before storing, the new memory is compared against all
+    existing ``memory_is_latest`` memories of the same type via semantic
+    cosine similarity. If a match exceeds ``supersedes_threshold``, the new
+    memory supersedes the old one (chains the version history and flips the
+    old to ``memory_is_latest: false``) instead of creating a parallel
+    record. This is higher quality than agentmemory's jaccard-only check
+    because it uses cairn's embedding backend, catching paraphrased revisions
+    that share no surface tokens. Returns ``superseded`` in the result dict.
     """
+    superseded_id = _find_supersession_candidate(
+        conn, bundle, type_, title, body, supersedes_threshold
+    )
+
+    supersedes_chain: list[str] = []
+    if superseded_id:
+        # Inherit the old version chain so memory_supersedes is the full history.
+        old = store_mod.get_memory(bundle, superseded_id)
+        if old is not None:
+            norm_id = _norm_cid(bundle, superseded_id)
+            old_chain = [_norm_cid(bundle, cid) for cid in (old.extensions.get("memory_supersedes") or [])]
+            supersedes_chain = [norm_id] + old_chain
+
     concept = store_mod.create_memory(
         type_=type_,
         title=title,
@@ -38,12 +61,25 @@ def capture_memory(
         confidence=confidence,
         session_origin=session_origin,
         tags=tags,
+        supersedes=supersedes_chain or None,
     )
     signals = score_memory(concept, conn, bundle)
     apply_score(concept, signals)
     tier = store_mod.tier_for_score(signals["score"])
     path = store_mod.store_memory(concept, bundle, tier=tier)
-    return {"path": path, "tier": tier, "signals": signals, "concept": concept}
+
+    # Flip the old memory to is_latest=false AFTER the new one is safely on disk.
+    if superseded_id:
+        _mark_superseded(bundle, superseded_id, path)
+        _append_promotion(concept, "supersede", signals["score"])
+
+    return {
+        "path": path,
+        "tier": tier,
+        "signals": signals,
+        "concept": concept,
+        "superseded": superseded_id,
+    }
 
 
 def record_reference(
@@ -134,6 +170,7 @@ def search_memory(
     query: str,
     tier: Optional[str] = None,
     session_id: Optional[str] = None,
+    include_superseded: bool = False,
 ) -> List[OKFConcept]:
     """Search tribal + canonical memories. Records a reference for each result.
 
@@ -142,6 +179,11 @@ def search_memory(
     matches the lexical layer cannot reach (e.g. querying "messaging" finds a
     memory titled "EventBus vs Flow"). The fallback is additive and silent:
     if the semantic extra isn't installed, behavior is unchanged.
+
+    Superseded memories (``memory_is_latest: false``) are filtered out by
+    default so recall surfaces only the current version. Pass
+    ``include_superseded=True`` to traverse the version chain (useful for
+    auditing decision history).
     """
     results = bundle.search(query, limit=20)
     # Filter to memory concepts only.
@@ -153,6 +195,14 @@ def search_memory(
     if tier:
         results = [c for c in results if c.extensions.get("memory_tier", "").startswith(tier)]
 
+    # Drop superseded versions unless explicitly requested. A memory is
+    # superseded when memory_is_latest is explicitly false; older memories
+    # written before this feature default to True (treated as latest).
+    if not include_superseded:
+        results = [
+            c for c in results if c.extensions.get("memory_is_latest", True) is not False
+        ]
+
     # Lexical broaden: if initial results are thin (empty or very few), run a
     # multi-token keyword scan over all memory concepts. This recovers matches
     # where query tokens are spread across fields (e.g. "backoff retry policy"
@@ -163,6 +213,10 @@ def search_memory(
             for cid in bundle.list_concepts(prefix="memory/")
             if (c := bundle.read_concept(cid)) is not None
         ]
+        if not include_superseded:
+            all_mem = [
+                c for c in all_mem if c.extensions.get("memory_is_latest", True) is not False
+            ]
         lexical = _lexical_memory_match(all_mem, query)
         seen = {c.concept_id for c in results}
         for c in lexical:
@@ -173,7 +227,9 @@ def search_memory(
     # Semantic fallback when lexical search comes up empty. Embeds the query
     # and cosine-ranks every memory concept by its title+description+body.
     if not results:
-        results = _semantic_memory_fallback(conn, bundle, query, tier=tier)
+        results = _semantic_memory_fallback(
+            conn, bundle, query, tier=tier, include_superseded=include_superseded
+        )
 
     # Record references for tribal/canonical (not raw/drafts) in ONE batched
     # transaction instead of one write per result. Batching avoids N
@@ -195,6 +251,7 @@ def _semantic_memory_fallback(
     query: str,
     tier: Optional[str] = None,
     limit: int = 20,
+    include_superseded: bool = False,
 ) -> List[OKFConcept]:
     """Semantic recall over memory concepts when lexical search misses.
 
@@ -218,6 +275,11 @@ def _semantic_memory_fallback(
                 or c.extensions.get("memory_tier")
             )
         ]
+        if not include_superseded:
+            concepts = [
+                c for c in concepts
+                if c.extensions.get("memory_is_latest", True) is not False
+            ]
         if tier:
             concepts = [
                 c for c in concepts
@@ -381,6 +443,148 @@ def memory_stats(bundle: OKFBundle) -> Dict:
         avg = sum(scores) / len(scores) if scores else 0
         stats[tier] = {"count": len(mems), "avg_score": round(avg, 3)}
     return stats
+
+
+# --- supersession helpers ------------------------------------------------
+
+
+def _norm_cid(bundle: OKFBundle, concept_id: str) -> str:
+    """Normalize an (possibly absolute) concept_id to bundle-relative.
+
+    OKFConcept.from_file sets concept_id to an absolute path; the supersession
+    chain should store relative ids so it survives a workspace move.
+    """
+    try:
+        return str(Path(concept_id).resolve().relative_to(Path(bundle.root).resolve()))
+    except (ValueError, TypeError):
+        return concept_id
+
+
+def _find_supersession_candidate(
+    conn: sqlite3.Connection,
+    bundle: OKFBundle,
+    type_: str,
+    title: str,
+    body: str,
+    threshold: float = 0.85,
+) -> Optional[str]:
+    """Find the best existing memory that the new one supersedes.
+
+    Strategy (adapted from agentmemory's two-tier check, but using cairn's
+    semantic backend instead of jaccard):
+    1. Cheap blocking: only compare against memories of the same ``type``
+       that are ``memory_is_latest``.
+    2. Quick lexical title-exact match → immediate supersession (same title
+       is a strong signal of revision, like agentmemory's jaccard >0.7).
+    3. Otherwise embed the new text + each candidate and take the top cosine;
+       supersede if >= threshold (paraphrase detection).
+    Returns the concept_id of the candidate, or None.
+    """
+    candidates: list[OKFConcept] = []
+    for cid in bundle.list_concepts(prefix="memory/"):
+        c = bundle.read_concept(cid)
+        if c is None:
+            continue
+        if c.extensions.get("memory_type") != type_:
+            continue
+        if c.extensions.get("memory_is_latest", True) is False:
+            continue
+        candidates.append(c)
+    if not candidates:
+        return None
+
+    # Tier 1: exact title match (case-insensitive) — strongest lexical signal.
+    title_lower = (title or "").strip().lower()
+    for c in candidates:
+        if (c.title or "").strip().lower() == title_lower and title_lower:
+            return c.concept_id
+
+    # Tier 2: semantic cosine. Reuses the same backend as search_memory's
+    # semantic fallback so dimensions line up. Silently returns None if the
+    # embedding backend isn't available (no torch) — supersession is an
+    # enhancement, not a correctness requirement.
+    try:
+        from cairn.graph import embeddings as emb
+        from cairn.retrieval import cosine_scan
+
+        if not emb.embeddings_available():
+            return None
+        new_text = " ".join(filter(None, [title, body]))
+        q_blob, dim = emb.embed_query(new_text)
+        cand_texts = [
+            " ".join(filter(None, [c.title, c.description, c.body]))
+            for c in candidates
+        ]
+        blobs, _ = emb._embed(cand_texts)
+        rows = [
+            (blob if isinstance(blob, bytes) else bytes(blob), len(blob) // 4, c)
+            for c, blob in zip(candidates, blobs)
+        ]
+        scored = cosine_scan(q_blob, dim, rows, threshold=threshold)
+        if scored:
+            return scored[0][1].concept_id
+    except Exception:
+        pass
+    return None
+
+
+def _mark_superseded(bundle: OKFBundle, old_id: str, new_id: str) -> None:
+    """Flip memory_is_latest=false on the old memory and link it to the new."""
+    old = store_mod.get_memory(bundle, old_id)
+    if old is None:
+        return
+    old.extensions["memory_is_latest"] = False
+    old.extensions["memory_superseded_by"] = new_id
+    old_id_norm = old.concept_id
+    try:
+        old_id_norm = str(Path(old_id_norm).relative_to(bundle.root))
+    except ValueError:
+        pass
+    # Re-write in place (same path) so the version chain is durable on disk.
+    bundle.write_concept(old)
+
+
+def evolve_memory(
+    conn: sqlite3.Connection,
+    bundle: OKFBundle,
+    memory_path: str,
+    new_title: Optional[str] = None,
+    new_body: Optional[str] = None,
+) -> Optional[Dict]:
+    """Explicit revision: create a new version that supersedes ``memory_path``.
+
+    Unlike the insert-time supersession (which fires automatically when
+    record_memory detects a near-duplicate), this is the agent-initiated path
+    -- the agent knows it is updating a specific decision. Mirrors
+    agentmemory's ``mem::evolve``: chains ``memory_supersedes``, flips the old
+    to ``memory_is_latest: false``, and stores the new version.
+
+    At least one of new_title / new_body must differ from the old memory.
+    """
+    old = store_mod.get_memory(bundle, memory_path)
+    if old is None:
+        return None
+    mtype = old.extensions.get("memory_type", "decision")
+    norm_old = _norm_cid(bundle, old.concept_id)
+    old_chain = [_norm_cid(bundle, cid) for cid in (old.extensions.get("memory_supersedes") or [])]
+    chain = [norm_old] + old_chain
+    confidence = old.extensions.get("memory_signals", {}).get("agent_confidence", 0.7)
+    concept = store_mod.create_memory(
+        type_=mtype,
+        title=new_title or old.title or "memory",
+        body=new_body or old.body or "",
+        resource=old.resource,
+        confidence=confidence,
+        tags=old.tags,
+        supersedes=chain,
+    )
+    signals = score_memory(concept, conn, bundle)
+    apply_score(concept, signals)
+    tier = store_mod.tier_for_score(signals["score"])
+    new_path = store_mod.store_memory(concept, bundle, tier=tier)
+    _mark_superseded(bundle, old.concept_id, new_path)
+    _append_promotion(concept, "evolve", signals["score"])
+    return {"path": new_path, "tier": tier, "signals": signals, "superseded": old.concept_id}
 
 
 # --- helpers -------------------------------------------------------------

--- a/src/cairn/memory/scoring.py
+++ b/src/cairn/memory/scoring.py
@@ -1,11 +1,19 @@
-"""Memory scoring engine: 6-signal weighted score.
+"""Memory scoring engine: 7-signal weighted score.
 
 score = 0.25*graph_verification + 0.20*cross_session_refs
-      + 0.15*agent_confidence + 0.20*critic_score + 0.10*freshness
-      + 0.10*authority
+      + 0.15*agent_confidence + 0.20*critic_score + 0.05*freshness
+      + 0.05*reinforcement + 0.10*authority
+
+Freshness uses exponential decay (exp(-λ·age)) rather than the earlier linear
+ramp; a new reinforcement signal rewards memories that are accessed
+frequently (adapted from agentmemory's temporalDecay + reinforcementBoost
+model, but folded into cairn's existing single-score system rather than
+running as a parallel retention scorer).
 """
 from __future__ import annotations
 
+import math
+import os
 import sqlite3
 from datetime import datetime, timezone
 from typing import Dict, Optional
@@ -18,7 +26,8 @@ WEIGHTS = {
     "cross_session_refs": 0.20,
     "agent_confidence": 0.15,
     "critic_score": 0.20,
-    "freshness": 0.10,
+    "freshness": 0.05,
+    "reinforcement": 0.05,
     "authority": 0.10,
 }
 
@@ -43,6 +52,7 @@ def score_memory(
     refs_signal = min(refs / 5.0, 1.0)
     critic = critic_score if critic_score is not None else signals.get("critic_score", 0.5)
     freshness = _freshness(concept)
+    reinforcement = _reinforcement(concept, conn)
     authority = _authority(concept)
 
     signals = {
@@ -52,6 +62,7 @@ def score_memory(
         "agent_confidence": round(confidence, 3),
         "critic_score": round(critic, 3),
         "freshness": round(freshness, 3),
+        "reinforcement": round(reinforcement, 3),
         "authority": round(authority, 3),
     }
     signals["score"] = round(compute_score(signals), 3)
@@ -71,6 +82,7 @@ def compute_score(signals: Dict) -> float:
         + WEIGHTS["agent_confidence"] * signals["agent_confidence"]
         + WEIGHTS["critic_score"] * signals["critic_score"]
         + WEIGHTS["freshness"] * signals["freshness"]
+        + WEIGHTS["reinforcement"] * signals.get("reinforcement", 0.0)
         + WEIGHTS["authority"] * signals.get("authority", 0.5)
     )
 
@@ -83,6 +95,7 @@ def apply_score(concept: OKFConcept, signals: Dict):
         "agent_confidence": signals["agent_confidence"],
         "critic_score": signals["critic_score"],
         "freshness": signals["freshness"],
+        "reinforcement": signals["reinforcement"],
         "authority": signals["authority"],
     }
     concept.extensions["memory_score"] = signals["score"]
@@ -164,7 +177,14 @@ DEFAULT_FRESHNESS_WINDOW_DAYS = 90
 
 
 def _freshness(concept: OKFConcept) -> float:
-    """1.0 if recent, decays linearly to 0 over a type-dependent window.
+    """Exponential decay: exp(-λ·age) where λ = ln(2)/half_life.
+
+    The half-life is the type-dependent freshness window, so a memory reaches
+    0.5 at the window boundary (e.g. 90 days for a decision) rather than
+    hitting 0 as the old linear ramp did. This is adapted from agentmemory's
+    temporalDecay = exp(-lambda * daysSinceCreation), but keeps cairn's
+    type-dependent windows so a `workaround` decays 3x slower than a
+    `decision`.
 
     Human-authored documents (doc_source == "manual") never age out.
     """
@@ -174,15 +194,62 @@ def _freshness(concept: OKFConcept) -> float:
     if concept.extensions.get("doc_source") == "manual":
         return 1.0
     try:
-        # Parse ISO 8601 (strip Z).
         dt = datetime.fromisoformat(ts.replace("Z", "+00:00"))
     except ValueError:
         return 0.5
     now = datetime.now(timezone.utc)
     days = (now - dt).total_seconds() / 86400.0
     mtype = concept.extensions.get("memory_type", "decision")
-    window = FRESHNESS_WINDOW_DAYS.get(mtype, DEFAULT_FRESHNESS_WINDOW_DAYS)
-    return max(0.0, 1.0 - days / window)
+    half_life = FRESHNESS_WINDOW_DAYS.get(mtype, DEFAULT_FRESHNESS_WINDOW_DAYS)
+    if half_life <= 0:
+        return 1.0
+    lam = math.log(2) / half_life
+    return math.exp(-lam * days)
+
+
+def _reinforcement(concept: OKFConcept, conn: sqlite3.Connection) -> float:
+    """Reward signal from how recently and often this memory was recalled.
+
+    Adapted from agentmemory's reinforcementBoost = sigma * Σ(1/daysSince(ts)),
+    but driven by cairn's memory_refs table (which records a row on every
+    recall hit). The boost saturates at 1.0, so a frequently-recalled memory
+    stays warm even as its freshness decays -- pure exponential decay would
+    forget everything eventually; this rewards reuse.
+
+    Returns 0.0 for a never-recalled memory (or when memory_refs is empty).
+    """
+    if not concept.concept_id:
+        return 0.0
+    cur = conn.cursor()
+    # memory_refs.memory_path may be stored as absolute (from_file sets
+    # absolute concept_id) or relative. Query both forms to be robust.
+    cid = concept.concept_id
+    cids = [cid]
+    if os.path.isabs(cid) and "memory/" in cid:
+        # Strip everything before the last "memory/" to get the relative form.
+        rel = "memory/" + cid.split("memory/")[-1]
+        if rel != cid:
+            cids.append(rel)
+    placeholders = ",".join("?" * len(cids))
+    rows = cur.execute(
+        f"SELECT referenced_at FROM memory_refs WHERE memory_path IN ({placeholders})",
+        cids,
+    ).fetchall()
+    if not rows:
+        return 0.0
+    now = datetime.now(timezone.utc)
+    sigma = 0.3  # scaling constant (same default as agentmemory)
+    boost = 0.0
+    for row in rows:
+        ts = row["referenced_at"] if isinstance(row, sqlite3.Row) else row[0]
+        try:
+            dt = datetime.fromisoformat(str(ts).replace("Z", "+00:00"))
+            days_since = (now - dt).total_seconds() / 86400.0
+            if days_since > 0:
+                boost += 1.0 / days_since
+        except (ValueError, TypeError):
+            continue
+    return min(1.0, boost * sigma)
 
 
 def _authority(concept: OKFConcept) -> float:

--- a/src/cairn/memory/store.py
+++ b/src/cairn/memory/store.py
@@ -47,8 +47,16 @@ def create_memory(
     session_origin: Optional[str] = None,
     tags: Optional[List[str]] = None,
     score: Optional[float] = None,
+    supersedes: Optional[List[str]] = None,
 ) -> OKFConcept:
-    """Build a memory OKF concept with lifecycle frontmatter."""
+    """Build a memory OKF concept with lifecycle frontmatter.
+
+    ``supersedes`` is the concept_id(s) of the prior version(s) this memory
+    replaces. When set, the new memory is marked ``memory_is_latest: true``
+    and the superseded chain is inherited + extended. Callers are responsible
+    for flipping ``memory_is_latest`` to false on the old memory (see
+    ``evolve_memory`` in promotion.py).
+    """
     tier = tier_for_score(score if score is not None else confidence)
     ts = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
     okf_type = f"{TIER_TYPE_PREFIX[tier]}-{type_}"
@@ -67,6 +75,13 @@ def create_memory(
         "promotion_history": [
             {"date": ts, "action": "captured", "score": round(confidence, 3), "tier": tier}
         ],
+        # Supersession: a memory is "latest" by default. When it supersedes
+        # an older memory, memory_supersedes chains the version history (like
+        # agentmemory's mem::evolve). The old memory gets memory_superseded_by
+        # set and memory_is_latest flipped to false by the caller.
+        "memory_is_latest": True,
+        "memory_supersedes": list(supersedes) if supersedes else [],
+        "memory_superseded_by": None,
     }
     return OKFConcept(
         type=okf_type,

--- a/tests/test_agent_surface.py
+++ b/tests/test_agent_surface.py
@@ -454,8 +454,8 @@ def test_skill_tool_index_lists_all_registered_tools():
     """
     registered = _scrape_mcp_tool_names()
     assert registered, "no @mcp.tool() functions scraped from tools_*.py"
-    assert len(registered) == 26, (
-        f"expected 26 registered tools, scraper found {len(registered)}: "
+    assert len(registered) == 27, (
+        f"expected 27 registered tools, scraper found {len(registered)}: "
         f"{sorted(registered)}"
     )
 

--- a/tests/test_memory_lifecycle.py
+++ b/tests/test_memory_lifecycle.py
@@ -1,0 +1,308 @@
+"""Tests for memory lifecycle features: supersession, decay, and auto-capture.
+
+Covers the three features adapted from the agentmemory comparison:
+  1. Supersession: insert-time near-dup detection, evolve_memory, version
+     chains, search filtering of superseded memories.
+  2. Exponential freshness + reinforcement signal: 7-signal scoring with
+     exp(-λ·age) decay and reinforcement boost from recall refs.
+  3. Privacy filter: strip_private_data regex redaction (used by the
+     post_tool_failure auto-capture hook).
+"""
+from __future__ import annotations
+
+import os
+import sqlite3
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from cairn.graph.schema import _apply_schema
+from cairn.memory.privacy import strip_private_data
+from cairn.memory.promotion import (
+    capture_memory,
+    evolve_memory,
+    search_memory,
+)
+from cairn.memory.scoring import (
+    WEIGHTS,
+    _freshness,
+    _reinforcement,
+    compute_score,
+    score_memory,
+)
+from cairn.okf.bundle import OKFBundle
+from cairn.okf.concept import OKFConcept
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def bundle(tmp_path):
+    return OKFBundle(str(tmp_path / "knowledge"))
+
+
+@pytest.fixture
+def db():
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    _apply_schema(conn)
+    yield conn
+    conn.close()
+
+
+# ---------------------------------------------------------------------------
+# FEATURE 1: Supersession
+# ---------------------------------------------------------------------------
+
+class TestSupersessionInsert:
+    """record_memory auto-supersedes near-duplicates of the same type."""
+
+    def test_same_title_same_type_supersedes(self, db, bundle):
+        """Recording a memory with the same title+type supersedes the old."""
+        r1 = capture_memory(db, bundle, type_="decision", title="Use JWT", body="v1", confidence=0.8)
+        r2 = capture_memory(db, bundle, type_="decision", title="Use JWT", body="v2 revised", confidence=0.85)
+
+        assert r2["superseded"] is not None
+        # Old memory is marked superseded.
+        old = bundle.read_concept(r1["path"])
+        assert old.extensions["memory_is_latest"] is False
+        assert old.extensions["memory_superseded_by"] == r2["path"]
+        # New memory is latest and chains the old.
+        new = bundle.read_concept(r2["path"])
+        assert new.extensions["memory_is_latest"] is True
+        assert r1["path"] in new.extensions["memory_supersedes"]
+
+    def test_different_type_does_not_supersede(self, db, bundle):
+        """Same title but different type creates a parallel memory."""
+        capture_memory(db, bundle, type_="decision", title="X", body="d", confidence=0.8)
+        r2 = capture_memory(db, bundle, type_="pattern", title="X", body="p", confidence=0.8)
+        assert r2["superseded"] is None
+
+    def test_version_chain_inherited(self, db, bundle):
+        """A 3rd revision inherits the full chain, not just the immediate predecessor."""
+        capture_memory(db, bundle, type_="decision", title="auth", body="v1", confidence=0.8)
+        capture_memory(db, bundle, type_="decision", title="auth", body="v2", confidence=0.85)
+        r3 = capture_memory(db, bundle, type_="decision", title="auth", body="v3", confidence=0.9)
+        final = bundle.read_concept(r3["path"])
+        chain = final.extensions["memory_supersedes"]
+        assert len(chain) == 2
+        # Chain is relative paths, not absolute.
+        assert all(not c.startswith("/") for c in chain)
+
+    def test_chain_ids_are_relative(self, db, bundle):
+        """Supersession chain stores bundle-relative concept_ids."""
+        capture_memory(db, bundle, type_="decision", title="chain test", body="v1", confidence=0.8)
+        r2 = capture_memory(db, bundle, type_="decision", title="chain test", body="v2", confidence=0.85)
+        new = bundle.read_concept(r2["path"])
+        for cid in new.extensions["memory_supersedes"]:
+            assert not os.path.isabs(cid), f"chain id {cid} must be relative"
+
+
+class TestSupersessionSearch:
+    """search_memory hides superseded memories by default."""
+
+    def test_default_hides_superseded(self, db, bundle):
+        capture_memory(db, bundle, type_="decision", title="unique decision alpha", body="v1", confidence=0.8)
+        capture_memory(db, bundle, type_="decision", title="unique decision alpha", body="v2", confidence=0.85)
+        results = search_memory(db, bundle, "unique decision alpha", session_id="t")
+        assert len(results) == 1
+        assert results[0].extensions.get("memory_is_latest", True) is not False
+
+    def test_include_superseded_shows_all(self, db, bundle):
+        capture_memory(db, bundle, type_="decision", title="unique decision beta", body="v1", confidence=0.8)
+        capture_memory(db, bundle, type_="decision", title="unique decision beta", body="v2", confidence=0.85)
+        results = search_memory(db, bundle, "unique decision beta", session_id="t", include_superseded=True)
+        assert len(results) >= 2
+
+    def test_old_memory_without_is_latest_treated_as_latest(self, db, bundle):
+        """Pre-feature memories (no memory_is_latest field) default to latest."""
+        # Manually create a memory without the new fields.
+        concept = OKFConcept(
+            type="Tribal-decision", title="legacy", body="legacy memory",
+            concept_id="memory/tribal/legacy-abc123",
+            extensions={"memory_tier": "tribal", "memory_type": "decision"},
+        )
+        bundle.write_concept(concept)
+        results = search_memory(db, bundle, "legacy", session_id="t")
+        assert any(r.title == "legacy" for r in results)
+
+
+class TestEvolveMemory:
+    """evolve_memory creates explicit revisions."""
+
+    def test_evolve_creates_new_version(self, db, bundle):
+        r1 = capture_memory(db, bundle, type_="pattern", title="evolve test", body="original", confidence=0.7)
+        result = evolve_memory(db, bundle, r1["path"], new_body="revised body")
+        assert result is not None
+        assert result["superseded"] is not None
+        old = bundle.read_concept(r1["path"])
+        assert old.extensions["memory_is_latest"] is False
+
+    def test_evolve_nonexistent_returns_none(self, db, bundle):
+        result = evolve_memory(db, bundle, "memory/tribal/nonexistent", new_body="x")
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# FEATURE 2: Exponential freshness + reinforcement
+# ---------------------------------------------------------------------------
+
+class TestScoringWeights:
+    """The 7-signal weight table sums to 1.0 and includes reinforcement."""
+
+    def test_weights_sum_to_one(self):
+        assert abs(sum(WEIGHTS.values()) - 1.0) < 1e-9
+
+    def test_reinforcement_weight_exists(self):
+        assert "reinforcement" in WEIGHTS
+        assert WEIGHTS["reinforcement"] > 0
+
+    def test_freshness_weight_reduced(self):
+        """Freshness weight dropped from 0.10 to 0.05 to make room for reinforcement."""
+        assert WEIGHTS["freshness"] == 0.05
+        assert WEIGHTS["reinforcement"] == 0.05
+
+
+class TestExponentialFreshness:
+    """_freshness uses exp(-λ·age), not linear decay."""
+
+    def test_brand_new_memory_freshness_near_one(self):
+        ts = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+        c = OKFConcept(type="Tribal-decision", title="x", body="x", timestamp=ts,
+                       extensions={"memory_type": "decision"})
+        assert _freshness(c) > 0.99
+
+    def test_decision_at_90_days_near_half(self):
+        """90-day-old decision ≈ 0.5 (half-life)."""
+        ts = (datetime.now(timezone.utc) - timedelta(days=90)).strftime("%Y-%m-%dT%H:%M:%SZ")
+        c = OKFConcept(type="Tribal-decision", title="x", body="x", timestamp=ts,
+                       extensions={"memory_type": "decision"})
+        f = _freshness(c)
+        assert 0.4 < f < 0.6
+
+    def test_workaround_decays_slower_than_decision(self):
+        """270-day half-life vs 90-day: at 90 days, workaround is fresher."""
+        ts = (datetime.now(timezone.utc) - timedelta(days=90)).strftime("%Y-%m-%dT%H:%M:%SZ")
+        dec = OKFConcept(type="Tribal-decision", title="x", body="x", timestamp=ts,
+                         extensions={"memory_type": "decision"})
+        work = OKFConcept(type="Tribal-workaround", title="x", body="x", timestamp=ts,
+                          extensions={"memory_type": "workaround"})
+        assert _freshness(work) > _freshness(dec)
+
+    def test_manual_doc_never_ages(self):
+        ts = (datetime.now(timezone.utc) - timedelta(days=365)).strftime("%Y-%m-%dT%H:%M:%SZ")
+        c = OKFConcept(type="Tribal-decision", title="x", body="x", timestamp=ts,
+                       extensions={"memory_type": "decision", "doc_source": "manual"})
+        assert _freshness(c) == 1.0
+
+
+class TestReinforcement:
+    """_reinforcement rewards memories that have been recalled."""
+
+    def test_never_recalled_is_zero(self, db, bundle):
+        r = capture_memory(db, bundle, type_="decision", title="unrecalled", body="x", confidence=0.8)
+        concept = bundle.read_concept(r["path"])
+        assert _reinforcement(concept, db) == 0.0
+
+    def test_recalled_is_positive(self, db, bundle):
+        r = capture_memory(db, bundle, type_="decision", title="recalled mem", body="x", confidence=0.8)
+        search_memory(db, bundle, "recalled", session_id="s1")
+        concept = bundle.read_concept(r["path"])
+        assert _reinforcement(concept, db) > 0.0
+
+    def test_reinforcement_saturates_at_one(self, db, bundle):
+        """Many recent recalls cap at 1.0."""
+        r = capture_memory(db, bundle, type_="decision", title="saturate test", body="x", confidence=0.8)
+        # Record many refs with recent (1-day-ago) timestamps directly.
+        # Use 1 day ago so days_since > 0 (the guard skips same-day accesses).
+        from datetime import datetime, timezone
+        ts = (datetime.now(timezone.utc) - timedelta(days=1)).isoformat()
+        for i in range(20):
+            db.execute(
+                "INSERT INTO memory_refs (id, memory_path, session_id, referenced_at, context) VALUES (?, ?, ?, ?, ?)",
+                (f"id{i}", r["path"], f"s{i}", ts, ""),
+            )
+        db.commit()
+        concept = bundle.read_concept(r["path"])
+        # 20 refs at 1 day ago: boost = 0.3 * 20 * (1/1.0) = 6.0, capped at 1.0
+        assert _reinforcement(concept, db) == 1.0
+
+
+class TestSevenSignalScore:
+    """score_memory returns 7 signals including reinforcement."""
+
+    def test_signals_include_reinforcement(self, db, bundle):
+        r = capture_memory(db, bundle, type_="decision", title="sig test", body="x", confidence=0.8)
+        concept = bundle.read_concept(r["path"])
+        signals = score_memory(concept, db, bundle)
+        assert "reinforcement" in signals
+        assert "freshness" in signals
+        assert "score" in signals
+
+    def test_compute_score_includes_reinforcement(self):
+        signals = {
+            "graph_verification": 1.0,
+            "cross_session_refs_signal": 0.0,
+            "agent_confidence": 0.5,
+            "critic_score": 0.5,
+            "freshness": 1.0,
+            "reinforcement": 1.0,
+            "authority": 0.5,
+        }
+        score = compute_score(signals)
+        # Manually verify: 0.25*1 + 0 + 0.15*0.5 + 0.20*0.5 + 0.05*1 + 0.05*1 + 0.10*0.5
+        expected = 0.25 + 0.075 + 0.10 + 0.05 + 0.05 + 0.05
+        assert abs(score - expected) < 1e-6
+
+
+# ---------------------------------------------------------------------------
+# FEATURE 3: Privacy filter
+# ---------------------------------------------------------------------------
+
+class TestPrivacyFilter:
+
+    def test_strips_api_key(self):
+        text = "api_key=sk-1234567890abcdef1234567890abcdef"
+        result = strip_private_data(text)
+        assert "sk-1234" not in result
+        assert "REDACTED_SECRET" in result
+
+    def test_strips_bearer_token(self):
+        text = "Authorization: Bearer abcdefghijklmnopqrstuvwxyz1234567890"
+        result = strip_private_data(text)
+        assert "Bearer abcdef" not in result
+        assert "REDACTED_SECRET" in result
+
+    def test_strips_private_tags(self):
+        text = "before <private>secret stuff</private> after"
+        result = strip_private_data(text)
+        assert "secret stuff" not in result
+        assert "REDACTED" in result
+        assert "before" in result
+        assert "after" in result
+
+    def test_strips_github_token(self):
+        text = "token ghp_abcdefghijklmnopqrstuvwxyz0123456789ABCD"
+        result = strip_private_data(text)
+        assert "ghp_" not in result
+
+    def test_strips_jwt(self):
+        text = "jwt=eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"
+        result = strip_private_data(text)
+        assert "eyJhbGci" not in result
+
+    def test_preserves_normal_text(self):
+        text = "The function foo() calls bar() in src/main.py"
+        result = strip_private_data(text)
+        assert result == text
+
+    def test_strips_multiple_secrets(self):
+        text = "key=sk-1234567890abcdef1234567890 token=xoxb-1234567890abcdef"
+        result = strip_private_data(text)
+        assert "sk-1234" not in result
+        assert "xoxb-1234" not in result
+
+    def test_empty_string(self):
+        assert strip_private_data("") == ""

--- a/tests/test_tool_annotations.py
+++ b/tests/test_tool_annotations.py
@@ -127,8 +127,8 @@ def test_every_decorator_has_annotations_kwarg():
             all_tools[m.group("name")] = f.name
 
     assert all_tools, "no @mcp.tool(...) decorators found in tools_*.py"
-    assert len(all_tools) == 26, (
-        f"expected 26 @mcp.tool(...) registrations, found {len(all_tools)}: "
+    assert len(all_tools) == 27, (
+        f"expected 27 @mcp.tool(...) registrations, found {len(all_tools)}: "
         f"{sorted(all_tools)}"
     )
 


### PR DESCRIPTION
Three L4 memory lifecycle features adapted from the agentmemory comparison, closing gaps in lifecycle intelligence while preserving cairn's graph-grounding moat:

1. Supersession: memory_is_latest/supersedes/superseded_by frontmatter on every memory. record_memory auto-supersedes near-duplicates of the same type (title-exact or semantic cosine >= 0.85). New evolve_memory function and memory_evolve MCP tool (27th) for explicit revisions. recall_memory hides superseded versions by default (include_superseded param to audit history).

2. Exponential decay: _freshness uses exp(-ln2/half_life * days) instead of linear ramp (decision hits 0.5 at 90-day half-life). New 7th reinforcement signal (sigma * sum(1/daysSince(ts)) from memory_refs) rewards frequently-recalled memories. Weights rebalanced: freshness 0.05 + reinforcement 0.05.

3. Auto-capture: privacy filter (14 secret regex patterns) + new post_tool_failure hook that records failures as raw mistake memories via detached subprocess, never blocking the agent.

Tool count bumped 26 -> 27 across server, docs, installer blurb, SKILL.md, and two regression tests. 29 new tests in test_memory_lifecycle.py.