### PR TITLE
feat(agents): interactive checkbox picker for install-agents (v0.6.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,52 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 - _Nothing yet._
 
+## [0.6.0] - 2026-08-05
+
+> **Focus:** `install-agents` gets an interactive checkbox picker, and
+> `scripts/install.sh` no longer silently mis-installs semantic-search deps
+> or wires up AI-client hooks that fail on every invocation.
+
+### Added
+- **Interactive checkbox picker for `cairn install-agents`.** Replaces the
+  old comma-separated free-text prompt with an arrow-key navigable,
+  spacebar-toggle checklist (via `questionary`) of detected AI clients,
+  pre-checked for the ones not yet wired up. Styled with cairn's own CLI
+  color theme (cyan question, green selected, yellow pointer, dim
+  instructions). Both Ctrl+C and Ctrl+D abort cleanly with a single
+  consistent message; `--yes`/`--client`/non-TTY paths are unchanged.
+
+### Changed
+- **`scripts/install.sh` no longer wires AI coding clients.** Installing
+  cairn and wiring agents are now separate steps -- run `cairn
+  install-agents` afterward (interactively, or with `--client`/`--scope`).
+  The install.sh flags `--no-agents`, `--agents`, and `--scope` are removed
+  as a result.
+- **Progress bars share one implementation across TTY and non-TTY output.**
+  `display.progress_bar()`'s rich-backed path previously patched ad-hoc
+  attributes onto a `Progress` instance at runtime; the non-TTY path
+  implemented an unrelated class from scratch. Both now expose the same
+  small, explicit interface, and `cairn embed --install-deps`'s
+  install-progress indicator goes through this shared mechanism too instead
+  of its own hand-rolled status line.
+
+### Fixed
+- **`scripts/install.sh --semantic` installed semantic-search deps into the
+  wrong location** (the tool's own venv, or system Python) instead of the
+  shared lib dir (`~/.cairn/lib`) cairn's runtime actually resolves deps
+  from -- the deps it installed were invisible to `cairn embed`. It now
+  delegates to `cairn embed --install-deps`, the same code path cairn uses
+  internally, honoring `CAIRN_LIB`/`CAIRN_HOME` overrides.
+- **Non-TTY output (CI logs, `cairn build | tee`) could get corrupted with
+  raw carriage-return bytes** during the semantic-deps install step -- it
+  wrote `\r`-updated status lines unconditionally instead of checking
+  whether stdout was a terminal.
+- **`install-agents` wrote AI-client hook commands pointing at a
+  nonexistent Python module** (`src.hooks.claude_hooks` instead of
+  `cairn.hooks.claude_hooks`), so every PostToolUse/Stop hook it wired up
+  silently failed with `ModuleNotFoundError`. `uninstall-agents` still
+  recognizes and removes hooks written by the old, broken path.
+
 ## [0.5.3] - 2026-08-03
 
 > **Focus:** fixes `cairn serve` boot hang that prevented Claude Desktop (and

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "cairn-intel"
-version = "0.5.3"
+version = "0.6.0"
 description = "Local codebase intelligence system: structural graph + compass + wiki + agent memory"
 readme = "README.md"
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ dependencies = [
     # Progress display: spinners, progress bars, ETA/rate, themed tables.
     # Pure-Python, no network/torch -- keeps the default install lightweight.
     "rich>=13.0",
+    "questionary>=2.0",
 ]
 
 [project.optional-dependencies]

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -141,40 +141,24 @@ ok "cairn --version: $CAIRN_VERSION"
 
 # ─── Step 3: Optional — semantic search extras ─────────────────────────────
 #
-# Cairn resolves semantic deps (sentence-transformers, numpy, sqlite-vec) from
-# a shared lib dir (~/.cairn/lib by default), NOT from its own venv. This is
-# deliberate: the deps are heavy (~hundreds of MB via torch) and would be wiped
-# on every `uv tool install --force`. The shared dir survives reinstalls.
-#
-# We install to the same target that `cairn embed --install-deps` uses, so both
-# paths are interchangeable. Honor CAIRN_HOME / CAIRN_LIB overrides to match.
+# `cairn embed --install-deps` (ensure_semantic_deps in
+# src/cairn/graph/embeddings.py) is the canonical installer: it resolves the
+# shared lib dir (~/.cairn/lib by default, honoring CAIRN_HOME/CAIRN_LIB) and
+# installs sentence-transformers/numpy/sqlite-vec there, NOT into cairn's own
+# venv -- deliberate, since the deps are heavy (~hundreds of MB via torch)
+# and would be wiped on every `uv tool install --force`. Delegate to it here
+# instead of re-deriving the same lib-dir resolution and pip/uv fallback
+# logic in bash.
 if $EXTRA_SEMANTIC; then
-  info "Installing semantic search extras (sentence-transformers + numpy + sqlite-vec)..."
-
-  # Resolve the shared lib dir the same way cairn does (paths.py).
-  if [[ -n "${CAIRN_LIB:-}" ]]; then
-    LIB_DIR="$CAIRN_LIB"
-  elif [[ -n "${CAIRN_HOME:-}" ]]; then
-    LIB_DIR="$CAIRN_HOME/lib"
-  else
-    LIB_DIR="$HOME/.cairn/lib"
-  fi
-  mkdir -p "$LIB_DIR"
-
-  SEMANTIC_PKGS="sentence-transformers>=3.0 numpy>=1.24 sqlite-vec>=0.1.0"
-
   if $USE_VENV && [[ -f "$PROJECT_DIR/.venv/bin/pip" ]]; then
-    # venv mode: the venv IS the runtime, so install there directly.
-    "$PROJECT_DIR/.venv/bin/pip" install $SEMANTIC_PKGS >/dev/null 2>&1
-  elif command -v uv >/dev/null 2>&1; then
-    # uv tool mode: install to the shared lib dir (survives reinstalls).
-    uv pip install --target "$LIB_DIR" --python "$PYTHON" $SEMANTIC_PKGS 2>/dev/null || \
-      "$PYTHON" -m pip install --target "$LIB_DIR" $SEMANTIC_PKGS >/dev/null 2>&1
+    # venv mode: the venv IS the runtime, so install there directly instead
+    # of the shared lib dir `cairn embed --install-deps` targets.
+    info "Installing semantic search extras (sentence-transformers + numpy + sqlite-vec)..."
+    "$PROJECT_DIR/.venv/bin/pip" install "sentence-transformers>=3.0" "numpy>=1.24" "sqlite-vec>=0.1.0" >/dev/null 2>&1
+    ok "Semantic search extras installed into .venv"
   else
-    # No uv: install to the shared lib dir via pip --target.
-    "$PYTHON" -m pip install --target "$LIB_DIR" $SEMANTIC_PKGS >/dev/null 2>&1
+    "$CAIRN_CMD" embed --install-deps
   fi
-  ok "Semantic search extras installed to $LIB_DIR"
 fi
 
 # ─── Done ─────────────────────────────────────────────────────────────────

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,17 +1,13 @@
 #!/bin/bash
-# scripts/install.sh — Install the cairn CLI binary + wire AI coding clients.
+# scripts/install.sh — Install the cairn CLI binary.
 #
-# This script installs the `cairn` command and (optionally) wires it into your
-# AI coding clients (Claude Code, Cursor, Droid, ZCode, etc.) in one shot.
+# This script installs the `cairn` command. To wire it into AI coding
+# clients afterward, run `cairn install-agents` separately.
 #
 # Usage:
-#   ./scripts/install.sh                  # install cairn, then interactively pick agents
+#   ./scripts/install.sh                  # install cairn
 #   ./scripts/install.sh --semantic       # also install semantic search extras
 #   ./scripts/install.sh --venv           # use venv instead of uv/pipx
-#   ./scripts/install.sh --no-agents      # skip the agent-wiring step
-#   ./scripts/install.sh --agents all     # wire all detected clients (no prompt)
-#   ./scripts/install.sh --agents claude,cursor  # wire specific clients
-#   ./scripts/install.sh --scope global   # write agent configs to ~/.claude/ etc.
 #
 # Prerequisites:
 #   - Python >= 3.10 (auto-detected; not the macOS default 3.9)
@@ -34,20 +30,14 @@ fail()  { echo -e "${RED}✗${NC} $*"; exit 1; }
 # ─── Defaults ─────────────────────────────────────────────────────────────────
 EXTRA_SEMANTIC=false
 USE_VENV=false
-WIRE_AGENTS=true
-AGENTS_TARGET=""
-AGENTS_SCOPE="workspace"
 
 # ─── Parse args ───────────────────────────────────────────────────────────────
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --semantic)    EXTRA_SEMANTIC=true ;;
     --venv)         USE_VENV=true ;;
-    --no-agents)    WIRE_AGENTS=false ;;
-    --agents)       AGENTS_TARGET="$2"; shift ;;
-    --scope)        AGENTS_SCOPE="$2"; shift ;;
     -h|--help)
-      sed -n '2,15p' "$0" | sed 's/^# //' | sed 's/^#//'
+      sed -n '2,10p' "$0" | sed 's/^# //' | sed 's/^#//'
       exit 0 ;;
     *) fail "Unknown option: $1 (use --help)" ;;
   esac
@@ -150,47 +140,41 @@ CAIRN_VERSION=$("$CAIRN_CMD" --version 2>/dev/null || echo "unknown")
 ok "cairn --version: $CAIRN_VERSION"
 
 # ─── Step 3: Optional — semantic search extras ─────────────────────────────
+#
+# Cairn resolves semantic deps (sentence-transformers, numpy, sqlite-vec) from
+# a shared lib dir (~/.cairn/lib by default), NOT from its own venv. This is
+# deliberate: the deps are heavy (~hundreds of MB via torch) and would be wiped
+# on every `uv tool install --force`. The shared dir survives reinstalls.
+#
+# We install to the same target that `cairn embed --install-deps` uses, so both
+# paths are interchangeable. Honor CAIRN_HOME / CAIRN_LIB overrides to match.
 if $EXTRA_SEMANTIC; then
-  info "Installing semantic search extras (sentence-transformers + numpy)..."
+  info "Installing semantic search extras (sentence-transformers + numpy + sqlite-vec)..."
+
+  # Resolve the shared lib dir the same way cairn does (paths.py).
+  if [[ -n "${CAIRN_LIB:-}" ]]; then
+    LIB_DIR="$CAIRN_LIB"
+  elif [[ -n "${CAIRN_HOME:-}" ]]; then
+    LIB_DIR="$CAIRN_HOME/lib"
+  else
+    LIB_DIR="$HOME/.cairn/lib"
+  fi
+  mkdir -p "$LIB_DIR"
+
+  SEMANTIC_PKGS="sentence-transformers>=3.0 numpy>=1.24 sqlite-vec>=0.1.0"
+
   if $USE_VENV && [[ -f "$PROJECT_DIR/.venv/bin/pip" ]]; then
-    "$PROJECT_DIR/.venv/bin/pip" install "sentence-transformers>=3.0" "numpy>=1.24" >/dev/null 2>&1
+    # venv mode: the venv IS the runtime, so install there directly.
+    "$PROJECT_DIR/.venv/bin/pip" install $SEMANTIC_PKGS >/dev/null 2>&1
   elif command -v uv >/dev/null 2>&1; then
-    uv pip install --system "sentence-transformers>=3.0" "numpy>=1.24" 2>/dev/null || \
-      "$PYTHON" -m pip install "sentence-transformers>=3.0" "numpy>=1.24" >/dev/null 2>&1
+    # uv tool mode: install to the shared lib dir (survives reinstalls).
+    uv pip install --target "$LIB_DIR" --python "$PYTHON" $SEMANTIC_PKGS 2>/dev/null || \
+      "$PYTHON" -m pip install --target "$LIB_DIR" $SEMANTIC_PKGS >/dev/null 2>&1
   else
-    "$PYTHON" -m pip install "sentence-transformers>=3.0" "numpy>=1.24" >/dev/null 2>&1
+    # No uv: install to the shared lib dir via pip --target.
+    "$PYTHON" -m pip install --target "$LIB_DIR" $SEMANTIC_PKGS >/dev/null 2>&1
   fi
-  ok "Semantic search extras installed"
-fi
-
-# ─── Step 4: Wire AI coding clients ─────────────────────────────────────────
-if $WIRE_AGENTS; then
-  echo ""
-  echo -e "${BOLD}Step 4: Wire AI coding clients${NC}"
-  echo ""
-
-  WS_DIR="$(pwd)"
-
-  if [[ -n "$AGENTS_TARGET" ]]; then
-    # --agents was passed: use it directly, no prompt.
-    info "Wiring agents: $AGENTS_TARGET (scope: $AGENTS_SCOPE)"
-    "$CAIRN_CMD" install-agents --client "$AGENTS_TARGET" --scope "$AGENTS_SCOPE" --workspace "$WS_DIR"
-  elif [[ ! -t 0 ]]; then
-    # Non-interactive (piped/scripted): auto-install detected-not-installed.
-    info "Wiring agents (non-interactive: detected, not yet installed)"
-    "$CAIRN_CMD" install-agents --yes --scope "$AGENTS_SCOPE" --workspace "$WS_DIR"
-  else
-    # Interactive: show detection, let the user choose.
-    # First, run install-agents which shows the detection table + prompts.
-    "$CAIRN_CMD" install-agents --scope "$AGENTS_SCOPE" --workspace "$WS_DIR"
-  fi
-
-  echo ""
-  if [[ $? -eq 0 ]]; then
-    ok "Agent wiring complete"
-  else
-    warn "Agent wiring had issues (you can re-run: cairn install-agents)"
-  fi
+  ok "Semantic search extras installed to $LIB_DIR"
 fi
 
 # ─── Done ─────────────────────────────────────────────────────────────────
@@ -201,12 +185,9 @@ echo "  Binary: $CAIRN_CMD"
 echo ""
 echo "  Next steps:"
 echo "    1. cairn init                      # register workspace + build graph"
-echo "    2. cairn embed --install-deps      # one-time: semantic deps (bge-m3)"
-echo "    3. cairn embed                     # build the embedding index"
-echo ""
-echo "  Or reconfigure agents anytime:"
-echo "    cairn install-agents               # interactive client picker"
-echo "    cairn install-agents --scope global   # write to ~/.claude/ etc."
+echo "    2. cairn install-agents            # wire AI coding clients (interactive)"
+echo "    3. cairn embed --install-deps      # one-time: semantic deps (bge-m3)"
+echo "    4. cairn embed                     # build the embedding index"
 echo ""
 echo "  Verify:"
 echo "    cairn --version"

--- a/src/cairn/__init__.py
+++ b/src/cairn/__init__.py
@@ -1,3 +1,3 @@
 """Cairn: local codebase intelligence system."""
-__version__ = "0.5.3"
+__version__ = "0.6.0"
 __package_name__ = "cairn-intel"

--- a/src/cairn/agent_install/_common.py
+++ b/src/cairn/agent_install/_common.py
@@ -106,18 +106,22 @@ def mcp_config_json(transport: str = "stdio", sse_url: str | None = None) -> dic
 
 
 def _python_for_hooks() -> str:
-    """Absolute python path for `python -m src.hooks.claude_hooks` invocations."""
+    """Absolute python path for `python -m cairn.hooks.claude_hooks` invocations."""
     return sys.executable
 
 
 def _claude_hook_command(entrypoint: str) -> str:
-    """Build a hook command string: `<python> -m src.hooks.claude_hooks <entry>`."""
-    return f"{_python_for_hooks()} -m src.hooks.claude_hooks {entrypoint}"
+    """Build a hook command string: `<python> -m cairn.hooks.claude_hooks <entry>`."""
+    return f"{_python_for_hooks()} -m cairn.hooks.claude_hooks {entrypoint}"
 
 
 def _hook_markers() -> list[str]:
     """Substrings that identify a cairn hook command, path-independently."""
     return [
+        "cairn.hooks.claude_hooks post_edit",
+        "cairn.hooks.claude_hooks session_end",
+        # Legacy markers from before the module path fix (kept so
+        # uninstall-agents can still strip hooks written by older installs).
         "src.hooks.claude_hooks post_edit",
         "src.hooks.claude_hooks session_end",
     ]

--- a/src/cairn/agent_install/merge.py
+++ b/src/cairn/agent_install/merge.py
@@ -333,7 +333,7 @@ def _strip_mcp_opencode(path: Path, res) -> None:
 def _strip_hooks(path: Path, res: InstallResult) -> None:
     """Remove cairn hook entries from .claude/settings.json.
 
-    Matches on `src.hooks.claude_hooks <entrypoint>` so it strips entries
+    Matches on `cairn.hooks.claude_hooks <entrypoint>` so it strips entries
     regardless of how the python path was written (absolute, venv-relative,
     cd-prefixed).
     """

--- a/src/cairn/cli/agents.py
+++ b/src/cairn/cli/agents.py
@@ -91,6 +91,8 @@ def install_agents(clients, ws_arg, scope_arg, force, dry_run, git_hooks, sse, s
             import questionary
             from prompt_toolkit.styles import Style as PtStyle
 
+            from .display import PROMPT_TOOLKIT_COLORS as C
+
             choices = [
                 {"name": c, "checked": c in not_yet_installed, "value": c}
                 for c in detected
@@ -101,14 +103,14 @@ def install_agents(clients, ws_arg, scope_arg, force, dry_run, git_hooks, sse, s
             # (warning) so the highlighted row stands out, and instructions
             # fade to dim so they recede behind the choices.
             cb_style = PtStyle([
-                ("qmark", "fg:ansicyan bold"),
-                ("question", "fg:ansicyan bold"),
-                ("pointer", "fg:ansiyellow bold"),
-                ("selected", "fg:ansigreen bold"),          # ● checked item
-                ("unselected", "fg:ansibrightblack"),       # ○ unchecked item
-                ("highlighted", "fg:ansiyellow bold"),      # » current row
-                ("answer", "fg:ansigreen bold"),
-                ("instruction", "fg:ansibrightblack italic"),
+                ("qmark", f"fg:{C['info']} bold"),
+                ("question", f"fg:{C['info']} bold"),
+                ("pointer", f"fg:{C['warning']} bold"),
+                ("selected", f"fg:{C['success']} bold"),    # ● checked item
+                ("unselected", f"fg:{C['dim']}"),           # ○ unchecked item
+                ("highlighted", f"fg:{C['warning']} bold"), # » current row
+                ("answer", f"fg:{C['success']} bold"),
+                ("instruction", f"fg:{C['dim']} italic"),
             ])
             # Suppress questionary's own "Aborted." so we print a single,
             # consistent message for both Ctrl+C (returns None) and Ctrl+D

--- a/src/cairn/cli/agents.py
+++ b/src/cairn/cli/agents.py
@@ -87,28 +87,23 @@ def install_agents(clients, ws_arg, scope_arg, force, dry_run, git_hooks, sse, s
             target_clients = not_yet_installed
             click.echo(f"Installing for: {', '.join(target_clients)} (detected, not yet installed)")
         else:
-            # Interactive prompt: ask for clients.
-            default_str = ",".join(not_yet_installed)
-            click.echo("Install cairn for which clients?")
-            click.echo("  Options: client names (comma-separated), 'all', or Enter for detected-not-installed.")
-            try:
-                answer = click.prompt("Clients", default=default_str, show_default=True).strip()
-            except click.exceptions.Abort:
+            # Interactive prompt: ask for clients (checkbox multi-select).
+            import questionary
+
+            choices = [
+                {"name": c, "checked": c in not_yet_installed, "value": c}
+                for c in detected
+            ]
+            answer = questionary.checkbox(
+                "Select clients to install cairn for:",
+                choices=choices,
+            ).ask()
+
+            if answer is None:  # Ctrl+C
                 click.echo("\nAborted.")
                 return
 
-            if answer.lower() == "all":
-                target_clients = detected
-            elif answer:
-                # Validate names.
-                names = [n.strip() for n in answer.split(",") if n.strip()]
-                bad = [n for n in names if n not in CLIENTS]
-                if bad:
-                    click.echo(f"Unknown client(s): {bad}. Valid: {', '.join(CLIENTS)}")
-                    return
-                target_clients = names
-            else:
-                target_clients = not_yet_installed
+            target_clients = answer if answer else not_yet_installed
 
             # Interactive prompt: ask for scope (only if --scope wasn't passed).
             if scope is None:

--- a/src/cairn/cli/agents.py
+++ b/src/cairn/cli/agents.py
@@ -37,7 +37,7 @@ def install_agents(clients, ws_arg, scope_arg, force, dry_run, git_hooks, sse, s
     Scope: --scope workspace (default) writes to ./.claude/, ./.cursor/ etc.
     --scope global writes to ~/.claude/, ~/.cursor/ etc. (all projects inherit).
     """
-    from ..agent_install import install, detect_clients, check_installed, CLIENTS
+    from ..agent_install import install, detect_clients, check_installed
 
     if sse and stdio:
         click.echo("Error: --sse and --stdio are mutually exclusive.")
@@ -89,21 +89,52 @@ def install_agents(clients, ws_arg, scope_arg, force, dry_run, git_hooks, sse, s
         else:
             # Interactive prompt: ask for clients (checkbox multi-select).
             import questionary
+            from prompt_toolkit.styles import Style as PtStyle
 
             choices = [
                 {"name": c, "checked": c in not_yet_installed, "value": c}
                 for c in detected
             ]
-            answer = questionary.checkbox(
-                "Select clients to install cairn for:",
-                choices=choices,
-            ).ask()
+            # Custom style aligned with the cairn CLI theme (see display.py):
+            # the question mark + question text use cyan (info), the selected
+            # indicator turns bold green (success), the pointer is bold yellow
+            # (warning) so the highlighted row stands out, and instructions
+            # fade to dim so they recede behind the choices.
+            cb_style = PtStyle([
+                ("qmark", "fg:ansicyan bold"),
+                ("question", "fg:ansicyan bold"),
+                ("pointer", "fg:ansiyellow bold"),
+                ("selected", "fg:ansigreen bold"),          # ● checked item
+                ("unselected", "fg:ansibrightblack"),       # ○ unchecked item
+                ("highlighted", "fg:ansiyellow bold"),      # » current row
+                ("answer", "fg:ansigreen bold"),
+                ("instruction", "fg:ansibrightblack italic"),
+            ])
+            # Suppress questionary's own "Aborted." so we print a single,
+            # consistent message for both Ctrl+C (returns None) and Ctrl+D
+            # (raises EOFError, which questionary does not catch).
+            try:
+                answer = questionary.checkbox(
+                    "Select clients to install cairn for:",
+                    choices=choices,
+                    style=cb_style,
+                    instruction="(↑↓ navigate · space toggle · a all · i invert · enter confirm)",
+                ).ask(kbi_msg="")
+            except (KeyboardInterrupt, EOFError):
+                answer = None
 
-            if answer is None:  # Ctrl+C
-                click.echo("\nAborted.")
+            if answer is None:  # Ctrl+C or Ctrl+D
+                click.echo("Aborted.")
                 return
 
-            target_clients = answer if answer else not_yet_installed
+            # Respect the selection as-is. An explicitly empty selection
+            # (user unchecked everything) installs nothing, rather than
+            # silently falling back to the detected defaults (which is what
+            # install() would do if we passed an empty/None clients list).
+            if not answer:
+                click.echo("Nothing selected. Use --client <name> to target a specific client.")
+                return
+            target_clients = answer
 
             # Interactive prompt: ask for scope (only if --scope wasn't passed).
             if scope is None:

--- a/src/cairn/cli/display.py
+++ b/src/cairn/cli/display.py
@@ -18,6 +18,7 @@ Design notes:
 from __future__ import annotations
 
 import sys
+import time
 from contextlib import contextmanager
 from typing import Iterator, Optional
 
@@ -49,6 +50,18 @@ THEME = Theme({
 })
 
 console = Console(theme=THEME)
+
+# Semantic roles as prompt_toolkit ansi color names, for questionary/
+# prompt_toolkit-based prompts (e.g. install-agents' checkbox). Kept next to
+# THEME -- rather than derived from it -- because rich Style objects and
+# prompt_toolkit style strings use incompatible color models; update both if
+# the palette changes.
+PROMPT_TOOLKIT_COLORS = {
+    "info": "ansicyan",
+    "success": "ansigreen",
+    "warning": "ansiyellow",
+    "dim": "ansibrightblack",
+}
 
 
 def is_tty() -> bool:
@@ -112,6 +125,158 @@ def print_table(title: Optional[str], columns: list[str], rows: list[list]) -> N
     console.print(table)
 
 
+# --- Non-TTY single-line progress -----------------------------------------
+# Rich's Progress, when stdout isn't a TTY, prints a NEW line on every refresh
+# instead of updating in place. That produces garbled multi-line output in CI
+# logs and pipes. This lightweight class mimics the slice of the Progress API
+# that cairn callers use (update/advance/set_total/set_description/tasks) but
+# renders a single line with \r so the line updates in place.
+
+class _SimpleTask:
+    __slots__ = ("description", "total", "completed", "unit")
+
+    def __init__(self, description: str, total: Optional[int], unit: str):
+        self.description = description
+        self.total = total
+        self.completed = 0
+        self.unit = unit
+
+
+class _PlainTextProgress:
+    """A minimal Progress-compatible renderer for non-TTY (piped/CI) output.
+
+    Renders one line that updates in place via carriage return. Redraws at
+    most once per 0.5s (time-throttled) to keep piped/CI output compact,
+    regardless of how frequently the caller updates. Description changes
+    (phase transitions) are drawn immediately but lightly throttled to 0.2s.
+    On context-exit, emits a final ``\n``.
+
+    Exposes the same attributes/methods cairn callers rely on:
+    ``_cg_task_id``, ``update()``, ``advance()``, ``set_total()``,
+    ``set_description()``, and ``tasks`` (list-indexed by task id).
+    """
+
+    def __init__(self, description: str, total: Optional[int], unit: str):
+        self.tasks = [_SimpleTask(description, total, unit)]
+        self._cg_task_id = 0
+        self._last_desc = None
+        self._t0 = time.time()
+        # Start _last_draw at _t0 so the first non-forced draw is throttled
+        # (prevents a burst of draws during rapid initial updates).
+        self._last_draw = self._t0
+
+    def update(self, task_id: int, *, completed: Optional[int] = None,
+               total: Optional[int] = None, description: Optional[str] = None,
+               advance: Optional[int] = None) -> None:
+        task = self.tasks[task_id]
+        # Only treat description as a "force" draw if it actually changed.
+        # Callers like cairn build call set_description("Parsing") on every
+        # per-file callback; without this guard, force=True bypasses the time
+        # throttle and we draw once per file.
+        desc_changed = False
+        if description is not None and description != task.description:
+            task.description = description
+            desc_changed = True
+        if total is not None:
+            task.total = total
+        if completed is not None:
+            task.completed = completed
+        if advance is not None:
+            task.completed += advance
+        self._maybe_draw(force=desc_changed)
+
+    def advance(self, amount: int = 1) -> None:
+        self.update(self._cg_task_id, advance=amount)
+
+    def set_total(self, new_total: int) -> None:
+        self.update(self._cg_task_id, total=new_total)
+
+    def set_description(self, desc: str) -> None:
+        self.update(self._cg_task_id, description=desc)
+
+    def _maybe_draw(self, force: bool = False) -> None:
+        task = self.tasks[self._cg_task_id]
+
+        # Time-based throttle is the PRIMARY gate: never draw more than once
+        # per 0.5s. This is what keeps piped/CI output compact — even if the
+        # caller updates every file, we only emit ~2 lines/second. Description
+        # changes bypass the throttle (so phase transitions like "Parsing" →
+        # "Indexing" are visible immediately), but only if >0.2s has passed
+        # to avoid back-to-back draws during rapid phase switches.
+        now = time.time()
+        elapsed_since_draw = now - self._last_draw
+        desc_changed = task.description != self._last_desc
+
+        should_draw = (
+            force
+            or elapsed_since_draw >= 0.5
+            or (desc_changed and elapsed_since_draw >= 0.2)
+        )
+        if not should_draw:
+            return
+
+        self._last_desc = task.description
+        self._last_draw = now
+
+        # Build the line.
+        elapsed = now - self._t0
+        if task.total:
+            pct = int(100 * task.completed / task.total)
+            bar_width = 20
+            filled = bar_width * task.completed // max(task.total, 1)
+            bar = "█" * filled + "░" * (bar_width - filled)
+            unit_str = f" {task.unit}" if task.unit else ""
+            line = (
+                f"\r{task.description}  [{bar}] "
+                f"{task.completed:,}/{task.total:,}{unit_str}  {pct}%  {elapsed:.0f}s"
+            )
+        else:
+            # Indeterminate: show count + elapsed.
+            unit_str = f" {task.unit}" if task.unit else ""
+            line = f"\r{task.description}  {task.completed:,}{unit_str}  {elapsed:.0f}s"
+
+        sys.stdout.write(line)
+        sys.stdout.flush()
+
+    def start(self) -> None:
+        self._maybe_draw(force=True)
+
+    def stop(self) -> None:
+        # Final draw at current state, then newline.
+        self._maybe_draw(force=True)
+        sys.stdout.write("\n")
+        sys.stdout.flush()
+
+
+class _RichProgressHandle:
+    """Adapts a rich ``Progress`` + its one task to ``_PlainTextProgress``'s
+    API (``update``/``advance``/``set_total``/``set_description``/``tasks``/
+    ``_cg_task_id``), so ``progress_bar()`` callers see the same contract on
+    both backends instead of relying on attributes monkey-patched onto the
+    ``Progress`` instance at runtime.
+    """
+
+    def __init__(self, progress: Progress, task_id: int):
+        self._progress = progress
+        self._cg_task_id = task_id
+
+    @property
+    def tasks(self):
+        return self._progress.tasks
+
+    def update(self, task_id: int, **kwargs) -> None:
+        self._progress.update(task_id, **kwargs)
+
+    def advance(self, amount: int = 1) -> None:
+        self._progress.update(self._cg_task_id, advance=amount)
+
+    def set_total(self, new_total: int) -> None:
+        self._progress.update(self._cg_task_id, total=new_total)
+
+    def set_description(self, desc: str) -> None:
+        self._progress.update(self._cg_task_id, description=desc)
+
+
 # --- Progress bar context manager -----------------------------------------
 # Used by cairn build (parse/insert/resolve phases) and cairn embed (batch loop).
 
@@ -121,30 +286,28 @@ def progress_bar(
     total: Optional[int] = None,
     unit: str = "files",
     transient: bool = True,
-) -> Iterator[Progress]:
-    """Yield a rich Progress configured for the cairn CLI.
+) -> Iterator:
+    """Yield a progress bar configured for the cairn CLI.
 
     ``description``: the label shown to the left of the bar (e.g. "Parsing").
     ``total``: if known up-front, the bar shows determinate progress + ETA.
                If None, the caller must ``.update(task_id, total=N)`` later.
     ``unit``: shown after the count ("1,234 files", "64 symbols").
-    ``transient``: when True (default), the live bar is erased on success
-                   and replaced by a one-line summary -- cleaner scrollback.
-                   Pass False to keep the completed bar in the log.
+    ``transient``: when True (default, TTY only), the live bar is erased on
+                   success and replaced by a one-line summary. Ignored in
+                   non-TTY mode (the line stays, then a newline is emitted).
 
-    In a non-TTY (CI/pipe), rich automatically renders one line per refresh
-    instead of animating, so the progress is still visible in logs.
+    **TTY mode:** uses rich's animated ``Progress`` (spinner, bar, ETA).
+    **Non-TTY mode:** uses ``_PlainTextProgress`` which renders a single line
+    updated in place via ``\\r`` — one line of progress, not one per refresh.
     """
     if not is_tty():
-        # Non-TTY: still use Progress so callers have a consistent API, but
-        # disable the spinner (would render as a frozen glyph) and the bar's
-        # in-place refresh. TimeRemainingColumn is useless without a TTY.
-        columns = [
-            TextColumn("[bold]{task.description}[/bold]"),
-            MofNCompleteColumn(),
-            TextColumn(unit),
-            TimeElapsedColumn(),
-        ]
+        bar = _PlainTextProgress(description, total, unit)
+        bar.start()
+        try:
+            yield bar
+        finally:
+            bar.stop()
     else:
         columns = [
             SpinnerColumn(style="info"),
@@ -156,20 +319,10 @@ def progress_bar(
             TimeElapsedColumn(),
             TimeRemainingColumn(),
         ]
-    progress = Progress(*columns, console=console, transient=transient and is_tty())
-    task_id = progress.add_task(description, total=total)
-    try:
-        # Attach the task_id to the progress object so callers can do
-        # `bar.advance(bar._task_id)` or `bar.update(bar._task_id, ...)`
-        # without needing to thread the id through their own state.
-        progress._cg_task_id = task_id  # type: ignore[attr-defined]
-        progress.advance = lambda amount: progress.update(task_id, advance=amount)  # type: ignore[assignment]
-        progress.set_total = lambda new_total: progress.update(task_id, total=new_total)  # type: ignore[assignment]
-        progress.set_description = lambda desc: progress.update(task_id, description=desc)  # type: ignore[assignment]
+        progress = Progress(*columns, console=console, transient=transient and is_tty())
+        task_id = progress.add_task(description, total=total)
         with progress:
-            yield progress
-    finally:
-        pass
+            yield _RichProgressHandle(progress, task_id)
 
 
 # --- Banner / panel for final summaries -----------------------------------

--- a/src/cairn/graph/embeddings.py
+++ b/src/cairn/graph/embeddings.py
@@ -339,6 +339,44 @@ def _clear_import_cache(package_names: list[str]) -> None:
             sys.modules.pop(k, None)
 
 
+def _run_install_with_progress(cmd: list[str], lib_dir) -> None:
+    """Run a pip/uv install subprocess with a single-line progress indicator.
+
+    pip/uv don't expose per-package progress callbacks, so we show an
+    indeterminate status via ``cli.display.progress_bar`` (TTY-aware: an
+    animated spinner on a terminal, a throttled single ``\\r``-updated line
+    under CI/pipes). pip's own verbose output is suppressed (captured) so
+    the log stays clean. On failure, the captured output is printed so the
+    user can see the error.
+    """
+    import subprocess
+    import time
+
+    from ..cli.display import progress_bar
+
+    print(f"Installing semantic deps into {lib_dir} (one-time, ~hundreds of MB via torch)...")
+    proc = subprocess.Popen(
+        cmd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+
+    # We can't know pip's internal progress, so just tick elapsed time.
+    # progress_bar's own throttling caps the actual redraw rate.
+    with progress_bar("Installing semantic deps", total=None, unit="") as bar:
+        while proc.poll() is None:
+            bar.advance(0)
+            time.sleep(0.2)
+
+    output = proc.stdout.read() if proc.stdout else ""
+    if proc.returncode != 0:
+        # Print captured output so the user sees the actual pip error.
+        if output:
+            print(output)
+        raise subprocess.CalledProcessError(proc.returncode, cmd, output)
+
+
 def ensure_semantic_deps(auto_install: bool = True) -> bool:
     """Ensure sentence-transformers is installed.
 
@@ -358,13 +396,11 @@ def ensure_semantic_deps(auto_install: bool = True) -> bool:
 
     import importlib.util
     import shutil
-    import subprocess
     import sys
 
     from ..paths import shared_lib_path
 
     lib_dir = shared_lib_path()
-    print(f"sentence-transformers not found. Installing semantic deps into {lib_dir} (one-time)...")
     packages = ["sentence-transformers", "numpy", "sqlite-vec"]
     try:
         if importlib.util.find_spec("pip") is not None:
@@ -372,8 +408,9 @@ def ensure_semantic_deps(auto_install: bool = True) -> bool:
             # prepended to sys.path at import time (paths.py). This keeps the
             # deps OUTSIDE the tool's own venv so they survive reinstalls.
             lib_dir.mkdir(parents=True, exist_ok=True)
-            subprocess.check_call(
-                [sys.executable, "-m", "pip", "install", "--target", str(lib_dir), *packages]
+            _run_install_with_progress(
+                [sys.executable, "-m", "pip", "install", "--target", str(lib_dir), *packages],
+                lib_dir,
             )
         else:
             # No pip in this interpreter (uv tool env). Use uv pip install
@@ -385,10 +422,9 @@ def ensure_semantic_deps(auto_install: bool = True) -> bool:
                     "install pip or run: uv pip install --target "
                     f"{lib_dir} sentence-transformers numpy sqlite-vec"
                 )
-            print(f"No pip in this interpreter; installing via uv into {lib_dir}...")
-            lib_dir.mkdir(parents=True, exist_ok=True)
-            subprocess.check_call(
-                [uv, "pip", "install", "--target", str(lib_dir), *packages]
+            _run_install_with_progress(
+                [uv, "pip", "install", "--target", str(lib_dir), *packages],
+                lib_dir,
             )
         # Verify the import resolves now (from the shared lib dir, which
         # paths.py already added to sys.path at startup).

--- a/uv.lock
+++ b/uv.lock
@@ -71,7 +71,7 @@ wheels = [
 
 [[package]]
 name = "cairn-intel"
-version = "0.5.3"
+version = "0.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },

--- a/uv.lock
+++ b/uv.lock
@@ -78,6 +78,7 @@ dependencies = [
     { name = "mcp" },
     { name = "pathspec" },
     { name = "pyyaml" },
+    { name = "questionary" },
     { name = "rich" },
     { name = "sqlite-vec" },
     { name = "tree-sitter" },
@@ -125,6 +126,7 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0" },
     { name = "pytest", marker = "extra == 'test'", specifier = ">=7.0" },
     { name = "pyyaml", specifier = ">=6.0" },
+    { name = "questionary", specifier = ">=2.0" },
     { name = "rich", specifier = ">=13.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.6" },
     { name = "sentence-transformers", marker = "extra == 'semantic'", specifier = ">=3.0" },
@@ -1185,6 +1187,18 @@ wheels = [
 ]
 
 [[package]]
+name = "prompt-toolkit"
+version = "3.0.53"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "wcwidth" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/ea/39b988c938f75cb75d7045b5c69f8bfed47ee2152c8837fb403de29d6fb8/prompt_toolkit-3.0.53.tar.gz", hash = "sha256:9ec8a0ad96d5c56148b3f914aa79c1564c3fde5d2e6b876e7bc327e353cf8fa6", size = 435492, upload-time = "2026-07-26T20:56:14.758Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/6f/84908cad2d6aa5144abcf7b42709fe4fdb459bc640ec7ac5786e7693dabc/prompt_toolkit-3.0.53-py3-none-any.whl", hash = "sha256:01c0891d7f9237d5e339f7d3e42cdae80b7534abb1c7c0e3352efba6231492f2", size = 392288, upload-time = "2026-07-26T20:56:12.512Z" },
+]
+
+[[package]]
 name = "pycparser"
 version = "3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1496,6 +1510,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
     { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
     { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
+name = "questionary"
+version = "2.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "prompt-toolkit" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f6/45/eafb0bba0f9988f6a2520f9ca2df2c82ddfa8d67c95d6625452e97b204a5/questionary-2.1.1.tar.gz", hash = "sha256:3d7e980292bb0107abaa79c68dd3eee3c561b83a0f89ae482860b181c8bd412d", size = 25845, upload-time = "2025-08-28T19:00:20.851Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3c/26/1062c7ec1b053db9e499b4d2d5bc231743201b74051c973dadeac80a8f43/questionary-2.1.1-py3-none-any.whl", hash = "sha256:a51af13f345f1cdea62347589fbb6df3b290306ab8930713bfae4d475a7d4a59", size = 36753, upload-time = "2025-08-28T19:00:19.56Z" },
 ]
 
 [[package]]
@@ -2799,6 +2825,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/07/f6/d0e5b343768e8bcb4cda79f0f2f55051bf26177ecd5651f84c07567461cf/watchdog-6.0.0-py3-none-win32.whl", hash = "sha256:07df1fdd701c5d4c8e55ef6cf55b8f0120fe1aef7ef39a1c6fc6bc2e606d517a", size = 79065, upload-time = "2024-11-01T14:07:09.525Z" },
     { url = "https://files.pythonhosted.org/packages/db/d9/c495884c6e548fce18a8f40568ff120bc3a4b7b99813081c8ac0c936fa64/watchdog-6.0.0-py3-none-win_amd64.whl", hash = "sha256:cbafb470cf848d93b5d013e2ecb245d4aa1c8fd0504e863ccefa32445359d680", size = 79070, upload-time = "2024-11-01T14:07:10.686Z" },
     { url = "https://files.pythonhosted.org/packages/33/e8/e40370e6d74ddba47f002a32919d91310d6074130fe4e17dabcafc15cbf1/watchdog-6.0.0-py3-none-win_ia64.whl", hash = "sha256:a1914259fa9e1454315171103c6a30961236f508b9b623eae470268bbcc6a22f", size = 79067, upload-time = "2024-11-01T14:07:11.845Z" },
+]
+
+[[package]]
+name = "wcwidth"
+version = "0.8.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/34/74/c6428f875774288bec1396f5bfcbc2d925700a4dad61727fd5f2b12f249d/wcwidth-0.8.2.tar.gz", hash = "sha256:91fbef97204b96a3d4d421609b80340b760cf33e26da123ff243d76b1fda8dda", size = 1466253, upload-time = "2026-06-29T18:11:11.601Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/96/42/3e5985a0a7e57de470b320c6d6a1a67c844f6737a587f3d44dd13d1819e7/wcwidth-0.8.2-py3-none-any.whl", hash = "sha256:d63947694a0539a1d51e01eda7caf800c291020e6cdd7e28ad7b14dd33ad4f85", size = 323166, upload-time = "2026-06-29T18:11:09.888Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Replace `install-agents`' free-text client prompt with an interactive, arrow-key/spacebar checkbox picker (`questionary`), styled with cairn's own CLI color theme and pre-checked for not-yet-installed clients.
- `scripts/install.sh` no longer wires AI clients as part of installing cairn — that's now a separate `cairn install-agents` step. Also fixes `--semantic` installing deps into the wrong location (tool venv/system Python instead of the shared `~/.cairn/lib` dir cairn actually reads from) by delegating to `cairn embed --install-deps`.
- Unify TTY and non-TTY progress bars in `cli/display.py` behind one explicit interface (`_RichProgressHandle`) instead of runtime-patched attributes on rich's `Progress`, and route the semantic-deps install's progress indicator through it — fixes raw `\r` bytes leaking into piped/CI logs.
- Fix `install-agents` writing hook commands that pointed at a nonexistent module (`src.hooks.claude_hooks` → `cairn.hooks.claude_hooks`), which silently broke every PostToolUse/Stop hook it wired up.
- Bump version to `0.6.0` and update `CHANGELOG.md`.

## Test plan
- [x] `cairn install-agents` interactively — verify checkbox navigation (arrows/space/`a`/`i`/enter), styling, and Ctrl+C/Ctrl+D abort behavior
- [x] `cairn install-agents --yes` / `--client <name>` / piped (non-TTY) — confirm unchanged, prompt-free behavior
- [x] `./scripts/install.sh --semantic` — confirm deps land in `~/.cairn/lib` (or `$CAIRN_LIB`/`$CAIRN_HOME/lib`) and `cairn embed` picks them up
- [x] `cairn build` / `cairn embed --install-deps` in a piped context (e.g. `| tee log`) — confirm no raw `\r` bytes in the log
- [x] Fresh `cairn install-agents` run — verify generated `.claude/settings.json` hook commands use `cairn.hooks.claude_hooks` and actually fire (check `post_edit`/`session_end` execute without `ModuleNotFoundError`)
- [x] `cairn uninstall-agents` — confirm it still strips hooks written by older, pre-fix installs