### PR TITLE
fix(embed): stop MCP singleton from clobbering root logger; unify embed progress bar

### DIFF
--- a/src/cairn/cli/embed.py
+++ b/src/cairn/cli/embed.py
@@ -114,6 +114,15 @@ def embed(db, batch_size, limit, no_reap, build_index, install_deps, download_mo
                 bar.update(task, total=total)
             bar.update(task, completed=done)
 
+        from cairn.graph import ann_index as ann
+
+        build_ann = ann.ann_backend_enabled()
+
+        # One progress bar for the whole `cairn embed` run -- embedding and
+        # (if enabled) the ANN rebuild used to open their own separate bars
+        # back to back, which read as two unrelated progress indicators.
+        # Reuse the same bar, just retargeting its description/total for the
+        # second phase, so the terminal shows one continuous indicator.
         with display.progress_bar(description="Embedding", total=None, unit="symbols") as bar:
             bar_state["bar"] = bar
             bar_state["task"] = bar._cg_task_id
@@ -121,6 +130,16 @@ def embed(db, batch_size, limit, no_reap, build_index, install_deps, download_mo
                 conn, batch_size=batch_size, limit=limit, progress=progress, reap_orphans=not no_reap
             )
             bar_state["bar"] = None
+
+            if build_ann:
+                task_id = bar._cg_task_id
+                # bar.update(total=None) would leave the embedding phase's
+                # total in place (both backends treat total=None as "don't
+                # change it") -- reset the task directly so the ANN phase
+                # renders as a fresh indeterminate bar instead of "0/<n synced>".
+                bar.tasks[task_id].total = None
+                bar.update(task_id, description="ANN index", completed=0)
+                idx_summary = ann.rebuild_index(conn, emb.current_model())
         elapsed = time.time() - t0
 
         after = emb.embed_count(conn)
@@ -135,11 +154,7 @@ def embed(db, batch_size, limit, no_reap, build_index, install_deps, download_mo
             ],
         )
 
-        from cairn.graph import ann_index as ann
-
-        if ann.ann_backend_enabled():
-            with display.progress_bar(description="ANN index", total=None, unit=""):
-                idx_summary = ann.rebuild_index(conn, emb.current_model())
+        if build_ann:
             if idx_summary.get("skipped"):
                 display.warning(f"ANN index not built: {idx_summary['skipped']}")
             else:

--- a/src/cairn/mcp_server/_server_core.py
+++ b/src/cairn/mcp_server/_server_core.py
@@ -68,7 +68,18 @@ async def app_lifespan(server: FastMCP):
 
 # The single FastMCP instance every tools_*.py module decorates. Imported as
 # `from ._server_core import mcp` so @mcp.tool() decorators attach here.
-mcp = FastMCP("cairn", lifespan=app_lifespan)
+#
+# This module is imported by every `cairn` CLI invocation (not just `cairn
+# serve`), since `cli/__init__.py` imports `serve` unconditionally to register
+# its click command. FastMCP.__init__ defaults to log_level="INFO", which
+# calls logging.basicConfig(level="INFO", handlers=[RichHandler(...)]) --
+# unconditionally reconfiguring the *root* logger for the whole process. That
+# clobbered every other command's output: third-party INFO logs (httpx
+# request lines, sentence-transformers' "No device provided" notice, etc.)
+# started rendering through that RichHandler, interleaving with `cairn
+# embed`'s own progress bar. Pin it to WARNING so constructing this singleton
+# doesn't affect unrelated commands.
+mcp = FastMCP("cairn", lifespan=app_lifespan, log_level="WARNING")
 
 
 def _store():

--- a/tests/test_mcp_phase3.py
+++ b/tests/test_mcp_phase3.py
@@ -265,6 +265,17 @@ class TestLifespan:
     def test_fastmcp_constructed_with_lifespan(self):
         """The server passes app_lifespan to FastMCP()."""
         src = SERVER_CORE.read_text(encoding="utf-8")
-        assert 'FastMCP("cairn", lifespan=app_lifespan)' in src, (
+        assert 'FastMCP("cairn", lifespan=app_lifespan' in src, (
             "FastMCP must be constructed with lifespan=app_lifespan (Phase 3.4)"
         )
+
+    def test_fastmcp_pins_log_level(self):
+        """FastMCP's default log_level="INFO" calls logging.basicConfig() at
+        import time, clobbering the root logger for every `cairn` CLI
+        invocation (not just `cairn serve`), since this module is imported
+        eagerly to register the serve command. Pin it so constructing this
+        singleton doesn't leak third-party INFO logs into unrelated commands.
+        """
+        from cairn.mcp_server._server_core import mcp
+
+        assert mcp.settings.log_level == "WARNING"


### PR DESCRIPTION
FastMCP("cairn") is constructed at import time in _server_core.py, which every `cairn` command imports transitively (via cli/__init__.py -> serve). FastMCP defaults to log_level="INFO", which calls logging.basicConfig() on the root logger -- so any `cairn` command that happened to trigger an INFO-level third-party log (httpx HTTP requests, sentence-transformers' device/model-load notices) rendered it through a Rich handler, drowning out `cairn embed`'s own progress bar. Pin log_level="WARNING" so building the singleton doesn't leak noise into unrelated commands.

Also merge cairn embed's "Embedding" and "ANN index" phases into a single continuous progress bar instead of two bars opening back to back.