### PR TITLE
feat(cli): vertical-rail flow UI for cairn init and cairn build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Vertical-rail flow UI for `cairn init` and `cairn build`.** Both commands
+  now render a clack-style vertical rail — `┌` open, `│` spacers between
+  groups, green `◆` step markers, animated sub-steps (`Scanning files`,
+  `Parsing code`, `Resolving refs`, `Persisting graph`) that settle in place,
+  and a guaranteed `└` close. Counts and durations in value positions are
+  highlighted (bold blue), while paths and identifiers are left unstyled. The
+  renderer is encoding-safe (ASCII fallback for cp1252/non-UTF-8 terminals),
+  no-op-robust (reordered/dropped progress events can never raise from the
+  renderer), and closes cleanly on every exit path including exceptions
+  (`✗ … — failed`, `└ Failed`). `cairn build` keeps its existing summary
+  panel; the rail replaces only its progress rendering. `cairn init` no
+  longer passes `verbose=True` to `build_graph`, so the per-file `print()`
+  noise the rail replaces is gone. `cairn build -v` renders the rail as plain
+  sequential lines (no live region) so verbose output can't corrupt it.
 - **Portable `.kg` database.** The code graph now stores file paths
   **repo-relative** (`files.path`, `parse_errors.file_path`,
   `skipped_files.path`, `pending_sync.path`) and `repos.path` **workspace-

--- a/src/cairn/cli/core.py
+++ b/src/cairn/cli/core.py
@@ -27,68 +27,120 @@ def init(ws_arg, legacy_dir, no_build, import_docs):
     the central store (moved, not copied) so you don't rebuild the graph.
     """
     import shutil
+    import time
 
+    from . import display
     from ..paths import register_workspace, resolve_workspace
 
     ws = Path(ws_arg).resolve() if ws_arg else resolve_workspace()
     store = register_workspace(ws)
-    click.echo(f"Workspace:  {ws}")
-    click.echo(f"Store:      {store.home}")
-    click.echo(f"  .kg:         {store.db}")
-    click.echo(f"  .knowledge:  {store.knowledge}")
 
-    # Migrate legacy cairn/.kg + .knowledge if present.
-    legacy = Path(legacy_dir).resolve() if legacy_dir else ws / "cairn"
-    legacy_db = legacy / ".kg"
-    legacy_kn = legacy / ".knowledge"
-    migrated = []
-    if legacy_db.exists() and not store.db.exists():
-        size_kb = legacy_db.stat().st_size // 1024
-        store.db.parent.mkdir(parents=True, exist_ok=True)
-        shutil.move(str(legacy_db), str(store.db))
-        migrated.append(f".kg ({size_kb} KB)")
-    if legacy_kn.exists() and legacy_kn.is_dir():
-        # Merge: copy legacy knowledge tree into the store. Skip .DS_Store and
-        # files that already exist at the destination. Only count as a migration
-        # if at least one real file was copied.
-        copied = 0
-        for item in legacy_kn.rglob("*"):
-            if item.is_dir() or item.name == ".DS_Store":
-                continue
-            rel = item.relative_to(legacy_kn)
-            dst = store.knowledge / rel
-            dst.parent.mkdir(parents=True, exist_ok=True)
-            if not dst.exists():
-                shutil.copy2(str(item), str(dst))
-                copied += 1
-        if copied:
-            migrated.append(f".knowledge/ ({copied} files)")
-    if migrated:
-        click.echo(f"Migrated from {legacy}: {', '.join(migrated)}")
+    with display.rail("Initializing cairn") as r:
+        r.step("Initialized in", str(ws))
+        r.step("Store", str(store.home))
+        r.detail(".kg", str(store.db))
+        r.detail(".knowledge", str(store.knowledge))
 
-    if not no_build and not store.db.exists():
-        click.echo("")
-        click.echo("Building graph...")
-        summary = builder.build_graph(workspace=str(ws), db_path=str(store.db), verbose=True)
-        click.echo(f"Built: {summary['repos']} repos, {summary['symbols']} symbols.")
-    elif store.db.exists():
-        click.echo("Graph already present. Use `cairn build` to rebuild.")
+        # Migrate legacy cairn/.kg + .knowledge if present.
+        legacy = Path(legacy_dir).resolve() if legacy_dir else ws / "cairn"
+        legacy_db = legacy / ".kg"
+        legacy_kn = legacy / ".knowledge"
+        migrated = []
+        if legacy_db.exists() and not store.db.exists():
+            size_kb = legacy_db.stat().st_size // 1024
+            store.db.parent.mkdir(parents=True, exist_ok=True)
+            shutil.move(str(legacy_db), str(store.db))
+            migrated.append(f".kg ({size_kb} KB)")
+        if legacy_kn.exists() and legacy_kn.is_dir():
+            # Merge: copy legacy knowledge tree into the store. Skip .DS_Store
+            # and files that already exist at the destination. Only count as a
+            # migration if at least one real file was copied.
+            copied = 0
+            for item in legacy_kn.rglob("*"):
+                if item.is_dir() or item.name == ".DS_Store":
+                    continue
+                rel = item.relative_to(legacy_kn)
+                dst = store.knowledge / rel
+                dst.parent.mkdir(parents=True, exist_ok=True)
+                if not dst.exists():
+                    shutil.copy2(str(item), str(dst))
+                    copied += 1
+            if copied:
+                migrated.append(f".knowledge/ ({copied} files)")
+        if migrated:
+            r.step(f"Migrated from {legacy}", ", ".join(migrated))
 
-    # Auto-discover and ingest docs/**/*.md as knowledge.
-    if import_docs:
-        from cairn.knowledge.store import import_directory
-        from cairn.okf.bundle import OKFBundle
+        if not no_build and not store.db.exists():
+            # Scan completes before the first progress event fires, so open the
+            # sub-step before calling build_graph and settle it on `scan`.
+            r.start("Scanning files")
+            phase_state = {"scan_done": False, "resolve_started": False}
 
-        docs_dir = ws / "docs"
-        if docs_dir.is_dir():
-            store.ensure()
-            bundle = OKFBundle(str(store.knowledge))
-            imported = import_directory(bundle, str(docs_dir), doc_type="spec")
-            click.echo(f"Imported {len(imported)} doc(s) from docs/ as knowledge.")
-        else:
-            click.echo("No docs/ directory found; skipping --import-docs.")
+            def on_progress(phase, **kw):
+                if phase == "scan":
+                    files = kw.get("files", 0)
+                    r.tick(f"{files:,} found")
+                    r.finish(f"{files:,} found")
+                    r.start("Parsing code")
+                    phase_state["scan_done"] = True
+                elif phase == "parse_progress":
+                    total = kw.get("total", 0) or 1
+                    pct = 50 * kw.get("done", 0) // total
+                    r.tick(f"{pct}%")
+                elif phase == "insert_progress":
+                    total = kw.get("total", 0) or 1
+                    pct = 50 + 50 * kw.get("done", 0) // total
+                    r.tick(f"{pct}%")
+                elif phase == "resolve_start":
+                    if not phase_state["resolve_started"]:
+                        r.finish("done")
+                        r.start("Resolving refs")
+                        phase_state["resolve_started"] = True
+                    r.tick(kw.get("repo", ""))
+                elif phase == "persist":
+                    r.finish("done")
+                    r.start("Persisting graph")
 
-    click.echo("\nDone. `cairn config` to verify; `cairn serve` for the MCP server.")
+            t0 = time.time()
+            # verbose stays False: the rail replaces the per-file print() noise,
+            # and a stray writer would corrupt the live region. `cairn build -v`
+            # remains the way to get per-file detail.
+            summary = builder.build_graph(
+                workspace=str(ws), db_path=str(store.db), verbose=False,
+                progress=on_progress,
+            )
+            elapsed = time.time() - t0
+            # build_graph emits persist as its last event but never closes the
+            # sub-step; settle it before the closing lines.
+            r.finish("done")
+            if not summary.get("files"):
+                r.warn("No source files found")
+            else:
+                r.step(f"Indexed {summary['files']:,} files")
+                r.stat(
+                    f"{summary['symbols']:,} nodes, {summary['edges']:,} edges "
+                    f"in {elapsed:.1f}s"
+                )
+        elif store.db.exists():
+            r.warn("Graph already present. Use `cairn build` to rebuild.")
+
+        # Auto-discover and ingest docs/**/*.md as knowledge.
+        if import_docs:
+            from cairn.knowledge.store import import_directory
+            from cairn.okf.bundle import OKFBundle
+
+            docs_dir = ws / "docs"
+            if docs_dir.is_dir():
+                store.ensure()
+                bundle = OKFBundle(str(store.knowledge))
+                imported = import_directory(bundle, str(docs_dir), doc_type="spec")
+                r.step(f"Imported {len(imported)} doc(s) from docs/")
+            else:
+                r.warn("No docs/ directory found; skipping --import-docs")
+
+    # Trailing hint prints after the rail closes so `└ Done` stays the last
+    # rail line.
+    display.dim("`cairn config` to verify; `cairn serve` for the MCP server.")
 
 
 # --------------------------------------------------------------------------
@@ -186,103 +238,103 @@ def build(repo, workspace, db, verbose, staging):
 
     target_db = db + ".tmp" if staging else db
 
-    # Phase-event handler: drive one progress bar across all phases
-    # (scan -> parse -> insert -> resolve -> persist).
-    bar_state = {"bar": None, "task": None, "phase": None}
-
-    def on_progress(phase, **kw):
-        bar = bar_state["bar"]
-        if bar is None:
-            return
-        if phase == "scan":
-            total_files = kw.get("files", 0)
-            bar.set_total(total_files * 2)  # parse + insert each touch every file
-            bar.set_description("Parsing")
-        elif phase == "parse_progress":
-            bar.set_description("Parsing")
-            # Parse phase is the first half of the bar.
-            bar.update(bar_state["task"], completed=kw.get("done", 0))
-        elif phase == "parse_done":
-            # Nothing to render here; insert phase takes over below.
-            pass
-        elif phase == "insert_progress":
-            bar.set_description("Indexing")
-            done = kw.get("done", 0)
-            total = kw.get("total", done)
-            # Insert phase is the second half of the bar.
-            bar.update(bar_state["task"], completed=total + done)
-        elif phase == "resolve_start":
-            bar.set_description(f"Resolving {kw.get('repo', '')}")
-        elif phase == "resolve_done":
-            bar.set_description("Resolving")
-        elif phase == "persist":
-            # Set the bar to its final completed state so the (non-TTY)
-            # summary line shows "Indexed N/N" rather than "Persisting".
-            bar.set_description("Indexed")
-            total = bar.tasks[bar_state["task"]].total or 0
-            bar.update(bar_state["task"], completed=total)
-
     import time
     t0 = time.time()
 
-    with display.progress_bar(description="Scanning", total=None, unit="files") as bar:
-        bar_state["bar"] = bar
-        bar_state["task"] = bar._cg_task_id
+    # One rail across the whole flow. animate=not verbose: the -v path turns
+    # on builder._log's raw print(), which would corrupt a live region.
+    with display.rail("Building graph", animate=not verbose) as r:
+        r.start("Scanning files")
+        phase_state = {"scan_done": False, "resolve_started": False}
+
+        def on_progress(phase, **kw):
+            if phase == "scan":
+                files = kw.get("files", 0)
+                r.tick(f"{files:,} found")
+                r.finish(f"{files:,} found")
+                r.start("Parsing code")
+                phase_state["scan_done"] = True
+            elif phase == "parse_progress":
+                total = kw.get("total", 0) or 1
+                pct = 50 * kw.get("done", 0) // total
+                r.tick(f"{pct}%")
+            elif phase == "insert_progress":
+                total = kw.get("total", 0) or 1
+                pct = 50 + 50 * kw.get("done", 0) // total
+                r.tick(f"{pct}%")
+            elif phase == "resolve_start":
+                if not phase_state["resolve_started"]:
+                    r.finish("done")
+                    r.start("Resolving refs")
+                    phase_state["resolve_started"] = True
+                r.tick(kw.get("repo", ""))
+            elif phase == "persist":
+                r.finish("done")
+                r.start("Persisting graph")
+
         try:
             summary = builder.build_graph(
                 workspace=workspace, repo_filter=repo, db_path=target_db,
                 verbose=verbose, progress=on_progress,
             )
         except Exception:
-            bar_state["bar"] = None
             # --staging writes to a temp DB; remove the half-built temp DB on
-            # failure so a failed staging build doesn't leak.
+            # failure so a failed staging build doesn't leak. The rail's
+            # context manager closes as "└ Failed" on the re-raise.
             if staging and os.path.exists(target_db):
                 try:
                     os.remove(target_db)
                 except OSError:
                     pass
             raise
-        bar_state["bar"] = None
-    elapsed = time.time() - t0
+        # build_graph's last event (persist) opens a sub-step it never closes;
+        # settle it before the derived-index phases.
+        r.finish("done")
 
-    # Derived indexes: dataflow + transitive closure. Dataflow calls
-    # impact_analysis per public symbol and can be slow on large workspaces,
-    # so we show a live progress bar. Transitive closure is pure SQL and fast.
-    df_count = tc_count = None
-    df_error = None
-    conn = None
-    try:
-        conn = get_db(target_db)
-        from ..graph.dataflow import build_dataflow_index, build_transitive_closure
+        # Derived indexes: dataflow + transitive closure. Dataflow calls
+        # impact_analysis per public symbol and can be slow on large workspaces,
+        # so it gets its own animated sub-step. Transitive closure is pure SQL.
+        df_count = tc_count = None
+        df_error = None
+        conn = None
+        try:
+            conn = get_db(target_db)
+            from ..graph.dataflow import build_dataflow_index, build_transitive_closure
 
-        # Count public symbols first so the bar is determinate.
-        from ..graph.dataflow import _public_symbols
-        pub_total = len(_public_symbols(conn))
+            # Count public symbols first so the sub-step ticks are meaningful.
+            from ..graph.dataflow import _public_symbols
+            pub_total = len(_public_symbols(conn))
 
-        if pub_total > 0:
-            with display.progress_bar(description="Dataflow index", total=pub_total, unit="symbols") as bar:
-                bar_df_id = bar._cg_task_id
-                df_count = build_dataflow_index(conn, progress=lambda done: bar.update(bar_df_id, completed=done))
-            with display.progress_bar(description="Transitive closure", total=None, unit="") as bar:
+            if pub_total > 0:
+                r.start("Dataflow index")
+                df_count = build_dataflow_index(
+                    conn, progress=lambda done: r.tick(f"{done:,}/{pub_total:,}")
+                )
+                r.finish(f"{df_count:,} symbols")
+                r.start("Transitive closure")
                 tc_count = build_transitive_closure(conn)
-        else:
-            df_count = 0
-            tc_count = build_transitive_closure(conn)
+                r.finish(f"{tc_count:,} edges")
+            else:
+                df_count = 0
+                tc_count = build_transitive_closure(conn)
 
-        conn.execute("PRAGMA wal_checkpoint(TRUNCATE);")
-    except Exception as e:
-        df_error = str(e)
-    finally:
-        # Always close: a leaked connection can hold SQLite's writer lock and
-        # lock out subsequent `cairn build`/`cairn embed`.
-        if conn is not None:
-            conn.close()
+            conn.execute("PRAGMA wal_checkpoint(TRUNCATE);")
+        except Exception as e:
+            df_error = str(e)
+        finally:
+            # Always close: a leaked connection can hold SQLite's writer lock
+            # and lock out subsequent `cairn build`/`cairn embed`.
+            if conn is not None:
+                conn.close()
+
+    elapsed = time.time() - t0
 
     if staging:
         os.replace(target_db, db)
 
-    # Final summary panel.
+    # Final summary panel (unchanged): repos/files/symbols/edges/imports +
+    # resolution breakdown + staging note. The rail replaced the progress
+    # rendering, not this detail table.
     kv_pairs = [
         ("repos", str(summary["repos"])),
         ("files", f"{summary['files']:,}"),

--- a/src/cairn/cli/display.py
+++ b/src/cairn/cli/display.py
@@ -7,12 +7,14 @@ to plain ``N/M`` text.
 """
 from __future__ import annotations
 
+import re
 import sys
 import time
 from contextlib import contextmanager
 from typing import Iterator, Optional
 
 from rich.console import Console
+from rich.live import Live
 from rich.progress import (
     BarColumn,
     MofNCompleteColumn,
@@ -24,6 +26,7 @@ from rich.progress import (
     TimeRemainingColumn,
 )
 from rich.table import Table
+from rich.text import Text
 from rich.theme import Theme
 
 # One console for the whole CLI process. Pass through whatever stdout is so
@@ -275,12 +278,263 @@ def progress_bar(
             yield _RichProgressHandle(progress, task_id)
 
 
+# --- Vertical-rail flow ----------------------------------------------------
+# A clack-style continuous rail for multi-step CLI flows (init, build):
+# `┌` open, `│` spacers between groups, `◆` step markers, an animated
+# sub-step that settles in place, and a guaranteed `└` close.
+
+_GLYPHS = {
+    "open":      ("┌", "+"),
+    "rail":      ("│", "|"),
+    "close":     ("└", "+"),
+    "step":      ("◆", "*"),
+    "active":    ("⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏", "|/-\\"),
+    "stat":      ("●", "o"),
+    "failed":    ("✗", "x"),
+    "warn":      ("!", "!"),
+    "separator": ("—", "-"),
+}
+
+_NUM_RE = re.compile(r"(?<![\w./-])\d[\d,]*(?:\.\d+)?[a-z]{0,2}\b")
+
+
+def _unicode_ok() -> bool:
+    """True iff the active console's encoding can encode the rail glyphs.
+
+    Probed once per Rail instance (not at import time) so ``CliRunner`` and
+    piped output re-resolve correctly against the console they're given.
+    """
+    enc = (getattr(console, "encoding", None) or "utf-8").lower()
+    try:
+        "┌│└◆●✗".encode(enc)
+        return True
+    except (UnicodeEncodeError, LookupError):
+        return False
+
+
+def _value(s: str) -> Text:
+    """Build a Text with numbers (counts, durations) highlighted as ``number``.
+
+    Values are never passed as rich markup strings — a workspace path
+    containing ``[`` would corrupt markup, and init/build print user paths.
+    """
+    t = Text(s)
+    t.highlight_regex(_NUM_RE, "number")
+    return t
+
+
+class _ActiveLine:
+    """Renderable for the single in-progress sub-step: ``<frame> <label>``."""
+
+    def __init__(self, label: str, value: str, frame: str, ok: bool):
+        self.label = label
+        self.value = value
+        self.frame = frame
+        self.ok = ok
+
+    def __rich__(self) -> Text:
+        style = "info" if self.ok else "error"
+        t = Text()
+        t.append(self.frame, style=style)
+        t.append(" ")
+        t.append(self.label)
+        if self.value:
+            t.append(" — ")
+            t.append(_value(self.value))
+        return t
+
+
+class Rail:
+    """Imperative vertical-rail renderer. See :func:`rail`."""
+
+    def __init__(self, glyphs_ok: bool, animate: bool = True):
+        u = glyphs_ok
+        self._g = {k: (v[0] if u else v[1]) for k, v in _GLYPHS.items()}
+        self._frames = _GLYPHS["active"][0] if u else _GLYPHS["active"][1]
+        self._animate = animate and u
+        self._live: Optional[Live] = None
+        self._active: Optional[_ActiveLine] = None
+        self._prev_depth: Optional[int] = None
+        self._closed = False
+
+    # --- settled lines (permanent, printed through the console) ------------
+
+    def _spacer_if_needed(self, depth: int) -> None:
+        # A rail-only `│` line precedes every depth-0 line and the first
+        # depth-1 line of a run. detail() is invisible to this rule.
+        if depth == 0 or depth != self._prev_depth:
+            console.print(self._g["rail"], style="dim")
+
+    def _settle_active(self) -> None:
+        """Settle whatever sub-step is open, defaulting its value to "done".
+
+        The implicit settle path (a depth-0 call or a new ``start()`` while a
+        sub-step is open) treats the open sub-step as ``finish()`` with its
+        default value — so callers never have to track state.
+        """
+        if self._active is None:
+            return
+        a = self._active
+        self._stop_live()
+        value = a.value or "done"
+        line = Text()
+        line.append(f"{self._g['rail']}  ", style="dim")
+        line.append(self._g["step"], style="success")
+        line.append(f" {a.label}")
+        line.append(f" {self._g['separator']} ", style="dim")
+        line.append(_value(value))
+        console.print(line)
+        self._active = None
+        self._prev_depth = 1
+
+    def step(self, text: str, value: Optional[str] = None) -> None:
+        """Depth-0 success line: ``◆ text`` (optionally ``— value``)."""
+        self._settle_active()
+        self._spacer_if_needed(0)
+        line = Text(self._g["step"], style="success")
+        line.append(f" {text}")
+        if value is not None:
+            line.append(f" {self._g['separator']} ", style="dim")
+            line.append(_value(value))
+        console.print(line)
+        self._prev_depth = 0
+
+    def detail(self, label: str, value: str) -> None:
+        """Dim continuation line under the previous step (no marker)."""
+        line = Text()
+        line.append(f"{self._g['rail']}    ", style="dim")
+        line.append(f"{label:12}", style="dim")
+        # _value() returns a Text with numbers highlighted; copy it so the
+        # surrounding dim style stays applied without overriding 'number'.
+        line.append_text(_value(value))
+        console.print(line)
+
+    def warn(self, text: str) -> None:
+        """Depth-0 warning line: ``! text``."""
+        self._settle_active()
+        self._spacer_if_needed(0)
+        console.print(f"[warning]{self._g['warn']}[/warning] {text}")
+        self._prev_depth = 0
+
+    def stat(self, text: str) -> None:
+        """Depth-0 info line: ``● text``."""
+        self._settle_active()
+        self._spacer_if_needed(0)
+        line = Text(self._g["stat"], style="info")
+        line.append(" ")
+        line.append(_value(text))
+        console.print(line)
+        self._prev_depth = 0
+
+    # --- animated sub-step -------------------------------------------------
+
+    def start(self, label: str) -> None:
+        """Open an indented animated sub-step. Implicitly settles any open one."""
+        self._settle_active()
+        self._spacer_if_needed(1)
+        self._active = _ActiveLine(label, "", self._frame(), ok=True)
+        self._prev_depth = 1
+        if self._animate:
+            self._live = Live(
+                self._render_active(), console=console, transient=True,
+                refresh_per_second=10,
+            )
+            self._live.start()
+
+    def tick(self, value: str) -> None:
+        """Update the active sub-step's value (no-op if none open).
+
+        Does not force a redraw — the live refresh thread coalesces events."""
+        if self._active is None:
+            return
+        self._active.value = value
+        if self._live is not None:
+            self._live.update(self._render_active())
+
+    def finish(self, value: str = "done", ok: bool = True) -> None:
+        """Settle the active sub-step as ``◆ label — value``."""
+        if self._active is None:
+            return
+        self._active.value = value
+        self._active.ok = ok
+        self._settle_active()
+
+    # --- internals ---------------------------------------------------------
+
+    def _frame(self) -> str:
+        return self._frames[int(time.monotonic() * 8) % len(self._frames)]
+
+    def _render_active(self):
+        if self._live is not None and self._animate:
+            self._active.frame = self._frame()
+        return self._active
+
+    def _stop_live(self) -> None:
+        if self._live is not None:
+            try:
+                self._live.stop()
+            except Exception:
+                pass
+            self._live = None
+
+    # --- lifecycle (called by the rail() context manager) ------------------
+
+    def _open(self, title: str) -> None:
+        console.print(f"[bold]{self._g['open']} {title}[/bold]")
+        self._prev_depth = None
+
+    def _fail(self) -> None:
+        """Settle the active step as ✗ … — failed, then prepare the close."""
+        if self._active is not None:
+            self._active.value = "failed"
+            self._active.ok = False
+            self._stop_live()
+            line = Text()
+            line.append(f"{self._g['rail']}  ", style="dim")
+            line.append(self._g["failed"], style="error")
+            line.append(f" {self._active.label}")
+            line.append(f" {self._g['separator']} ", style="dim")
+            line.append("failed", style="error")
+            console.print(line)
+            self._active = None
+
+    def _close(self, label: str = "Done") -> None:
+        if self._closed:
+            return
+        self._closed = True
+        self._stop_live()
+        if self._active is not None:
+            # Unsettled on normal exit: settle as done.
+            self._settle_active()
+        console.print(f"{self._g['rail']}", style="dim")
+        console.print(f"[success]{self._g['close']} {label}[/success]")
+
+
+@contextmanager
+def rail(title: str, animate: bool = True) -> Iterator[Rail]:
+    """Render a vertical-rail flow; ``└`` is written on every exit path.
+
+    Do not open a :func:`progress_bar` while a sub-step is active: rich permits
+    only one live display at a time per console. ``animate=False`` (used by
+    ``cairn build -v``) renders settled lines only, with no live region, so the
+    verbose path's raw ``print()`` output can't corrupt it.
+    """
+    r = Rail(_unicode_ok(), animate=animate)
+    r._open(title)
+    try:
+        yield r
+    except BaseException:  # includes KeyboardInterrupt
+        r._fail()
+        r._close("Failed")
+        raise
+    r._close("Done")
+
+
 # --- Banner / panel for final summaries -----------------------------------
 
 def summary_panel(title: str, kv_pairs: list[tuple[str, str]], subtitle: Optional[str] = None) -> None:
     """Print a final summary as a styled panel with ``kv_pairs`` lines inside."""
     from rich.panel import Panel
-    from rich.text import Text
 
     body = Text()
     for i, (label, value) in enumerate(kv_pairs):

--- a/tests/test_cli_init_rail.py
+++ b/tests/test_cli_init_rail.py
@@ -1,0 +1,82 @@
+"""End-to-end smoke test for the `cairn init` rail UI via CliRunner.
+
+Per docs/init-ui-plan.md §Verification #6: assert exit_code == 0, the rail
+open/close glyphs are present, "Initialized in" appears, and no ANSI escapes
+leak into piped/CliRunner output.
+"""
+from __future__ import annotations
+
+import re
+import tempfile
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from cairn.cli import main
+
+
+def _fixture_workspace(tmp: Path) -> Path:
+    ws = tmp / "ws"
+    repo = ws / "demo"
+    (repo / ".git").mkdir(parents=True)
+    (repo / "Hello.kt").write_text("class Hello { fun go() {} }\n")
+    return ws
+
+
+def test_init_no_build_renders_rail_open_and_close():
+    runner = CliRunner()
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
+        ws = _fixture_workspace(tmp_path)
+        result = runner.invoke(
+            main,
+            ["init", "--workspace", str(ws), "--no-build"],
+            env={"CAIRN_HOME": str(tmp_path / "cairn_home")},
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0
+        out = result.output
+        # Rail opens and closes.
+        assert "┌ Initializing cairn" in out
+        assert "└ Done" in out
+        # Depth-0 step lines appear.
+        assert "Initialized in" in out
+        # Detail lines carry the rail continuation.
+        assert ".kg" in out and ".knowledge" in out
+        # Trailing hint prints after the rail closes.
+        assert "`cairn config`" in out
+
+
+def test_init_piped_output_has_no_ansi_escapes():
+    runner = CliRunner()
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
+        ws = _fixture_workspace(tmp_path)
+        result = runner.invoke(
+            main,
+            ["init", "--workspace", str(ws), "--no-build"],
+            env={"CAIRN_HOME": str(tmp_path / "cairn_home")},
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0
+        # CliRunner output is non-TTY: no cursor/SGR escapes should appear.
+        assert not re.search(r"\x1b\[[0-9;]*[A-Za-z]", result.output)
+
+
+def test_init_with_build_shows_indexed_summary():
+    runner = CliRunner()
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
+        ws = _fixture_workspace(tmp_path)
+        result = runner.invoke(
+            main,
+            ["init", "--workspace", str(ws)],
+            env={"CAIRN_HOME": str(tmp_path / "cairn_home")},
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0
+        out = result.output
+        # The build sub-steps render and a stats line closes the flow.
+        assert "Scanning files" in out
+        assert "Indexed" in out
+        assert "nodes" in out

--- a/tests/test_display_rail.py
+++ b/tests/test_display_rail.py
@@ -1,0 +1,214 @@
+"""Tests for the vertical-rail flow renderer (``display.rail`` / ``Rail``).
+
+Covers the regression net called out in docs/init-ui-plan.md §Verification:
+golden non-TTY output, the exception path, the ASCII fallback, no-op
+robustness, and number highlighting. All cases force a non-animated path
+(animate=False or a non-TTY console) so output is deterministic.
+"""
+from __future__ import annotations
+
+from io import BytesIO, StringIO
+from textwrap import dedent
+
+import pytest
+from rich.console import Console
+
+from cairn.cli import display
+
+
+def _capture(**console_kwargs) -> str:
+    """Replace ``display.console`` with a capturing Console and return output."""
+    buf = StringIO()
+    kwargs = {"file": buf, "width": 100, "force_terminal": False, "theme": display.THEME}
+    kwargs.update(console_kwargs)
+    display.console = Console(**kwargs)
+    display.is_tty = lambda: False
+    return buf
+
+
+@pytest.fixture(autouse=True)
+def _restore_console():
+    orig_console = display.console
+    orig_istty = display.is_tty
+    orig_unicode_ok = display._unicode_ok
+    yield
+    display.console = orig_console
+    display.is_tty = orig_istty
+    display._unicode_ok = orig_unicode_ok
+
+
+# ---------------------------------------------------------------------------
+# 1. Non-TTY golden output
+# ---------------------------------------------------------------------------
+
+def test_golden_non_tty_output():
+    """The full depth-0 + depth-1 + detail/stat flow renders verbatim."""
+    buf = _capture()
+    with display.rail("Initializing cairn", animate=False) as r:
+        r.step("Initialized in", "/Users/x/proj")
+        r.step("Store", "/home/.cairn/abc")
+        r.detail(".kg", "/home/.cairn/abc/.kg")
+        r.detail(".knowledge", "/home/.cairn/abc/.knowledge")
+        r.start("Scanning files")
+        r.tick("3,295 found")
+        r.finish("3,295 found")
+        r.start("Parsing code")
+        r.finish("done")
+        r.step("Indexed 3,295 files")
+        r.stat("80,445 nodes, 165,182 edges in 3.1s")
+
+    expected = dedent("""\
+        ┌ Initializing cairn
+        │
+        ◆ Initialized in — /Users/x/proj
+        │
+        ◆ Store — /home/.cairn/abc
+        │    .kg         /home/.cairn/abc/.kg
+        │    .knowledge  /home/.cairn/abc/.knowledge
+        │
+        │  ◆ Scanning files — 3,295 found
+        │  ◆ Parsing code — done
+        │
+        ◆ Indexed 3,295 files
+        │
+        ● 80,445 nodes, 165,182 edges in 3.1s
+        │
+        └ Done
+        """)
+    assert buf.getvalue() == expected
+
+
+def test_step_without_value_renders_label_only():
+    buf = _capture()
+    with display.rail("T", animate=False) as r:
+        r.step("Just a label")
+    out = buf.getvalue()
+    assert "◆ Just a label\n" in out
+    # No trailing separator when value is None.
+    assert "—" not in out
+
+
+def test_warn_uses_warning_glyph():
+    buf = _capture()
+    with display.rail("T", animate=False) as r:
+        r.warn("Graph already present")
+    out = buf.getvalue()
+    assert "! Graph already present" in out
+
+
+# ---------------------------------------------------------------------------
+# 2. Exception path
+# ---------------------------------------------------------------------------
+
+def test_exception_path_closes_as_failed_and_reraises():
+    """Raising inside the rail re-raises and the rail closes as └ Failed."""
+    buf = _capture()
+    with pytest.raises(RuntimeError, match="boom"):
+        with display.rail("Initializing", animate=False) as r:
+            r.start("Parsing code")
+            r.tick("50%")
+            raise RuntimeError("boom")
+    out = buf.getvalue()
+    assert "✗ Parsing code — failed" in out
+    assert out.rstrip().endswith("└ Failed")
+
+
+# ---------------------------------------------------------------------------
+# 3. ASCII fallback
+# ---------------------------------------------------------------------------
+
+def test_ascii_fallback_when_encoding_unsupported():
+    """A cp1252 console must not raise and must use ASCII glyphs."""
+    import io
+    raw = BytesIO()
+    wrapper = io.TextIOWrapper(raw, encoding="cp1252")
+    display.console = Console(file=wrapper, width=100, force_terminal=False,
+                              theme=display.THEME)
+    display.is_tty = lambda: False
+    display._unicode_ok = lambda: False  # force ASCII glyph set
+
+    with display.rail("Init", animate=False) as r:
+        r.step("Done", "3 files")
+        r.stat("100 nodes in 1.2s")
+    wrapper.flush()
+    out = raw.getvalue().decode("cp1252")
+    # cp1252 can encode ASCII but not the box glyphs; no UnicodeEncodeError,
+    # and the ASCII replacements appear.
+    assert "+" in out and "|" in out and "*" in out
+    assert "●" not in out and "◆" not in out
+
+
+# ---------------------------------------------------------------------------
+# 4. No-op robustness
+# ---------------------------------------------------------------------------
+
+def test_tick_and_finish_with_no_active_step_are_noops():
+    buf = _capture()
+    with display.rail("T", animate=False) as r:
+        r.tick("anything")          # no active sub-step
+        r.finish("done")            # no active sub-step
+        r.finish()                  # double-finish safety
+        r.step("After")
+    out = buf.getvalue()
+    assert "◆ After" in out
+    # No stray sub-step lines leaked from the no-op calls.
+    assert "│  ◆ anything" not in out
+
+
+def test_start_implicitly_settles_prior_sub_step():
+    """Opening a new sub-step settles the open one as 'done'."""
+    buf = _capture()
+    with display.rail("T", animate=False) as r:
+        r.start("First")
+        r.start("Second")   # 'First' must be settled automatically
+        r.finish("ok")
+    out = buf.getvalue()
+    assert "◆ First — done" in out
+    assert "◆ Second — ok" in out
+
+
+def test_step_mid_substep_settles_it():
+    """A depth-0 call mid-phase marks the open sub-step done."""
+    buf = _capture()
+    with display.rail("T", animate=False) as r:
+        r.start("Parsing code")
+        r.step("Indexed 10 files")   # implicitly finishes 'Parsing code'
+    out = buf.getvalue()
+    assert "◆ Parsing code — done" in out
+    assert "◆ Indexed 10 files" in out
+
+
+def test_double_close_writes_one_close_glyph():
+    buf = _capture()
+    r = display.Rail(display._unicode_ok(), animate=False)
+    r._open("T")
+    r._close("Done")
+    r._close("Done")  # idempotent
+    out = buf.getvalue()
+    assert out.count("└ Done") == 1
+
+
+# ---------------------------------------------------------------------------
+# 5. Number highlighting
+# ---------------------------------------------------------------------------
+
+def test_numbers_highlighted_and_paths_are_not():
+    """Counts and durations get the 'number' style; embedded path digits don't."""
+    console = Console(record=True, width=100, force_terminal=True, theme=display.THEME)
+    display.console = console
+    display.is_tty = lambda: False
+    display._unicode_ok = lambda: True
+    with display.rail("T", animate=False) as r:
+        r.stat("80,445 nodes, 165,182 edges in 3.1s")
+        r.step("Scanned", "/Users/a/proj2/repo2024")
+    # export_text() clears the record buffer on each call, so capture both
+    # forms up front from the styled one (it embeds the plain text too).
+    styled = console.export_text(styles=True)
+    # \x1b[1;34m is THEME's "number" = bold blue.
+    assert "\x1b[1;34m80,445\x1b[0m" in styled
+    assert "\x1b[1;34m3.1s\x1b[0m" in styled
+    # A path like proj2 / repo2024 should NOT carry a bold-blue run: assert
+    # the literals appear unstyled (no escape wrap around them).
+    assert "proj2" in styled
+    assert "repo2024" in styled
+    assert "\x1b[1;34mproj2\x1b[0m" not in styled


### PR DESCRIPTION
Replace cairn init's raw click.echo output and cairn build's progress_bar() blocks with a shared clack-style vertical rail: ┌ open, │ spacers, green ◆ step markers, animated sub-steps that settle in place, and a guaranteed └ close on every exit path (including exceptions → ✗ … — failed, └ Failed).

display.py:
- rail() context manager + Rail imperative renderer (~250 new lines, nothing removed; progress_bar() kept for embed).
- Encoding-safe: ASCII glyph fallback for cp1252/non-UTF-8 terminals via _unicode_ok() probe at Rail construction time.
- No-op-robust: tick()/finish() with no active step are no-ops; start() and depth-0 methods implicitly settle any open sub-step as done.
- Numbers (counts, durations) highlighted as bold blue via _value(); paths and identifiers left unstyled.

core.py:
- init: drives the rail for scan→parse→resolve→persist, drops verbose=True (removes the per-file print() noise the rail replaces), guards the stats line for the empty-workspace early return.
- build: one rail across scan→parse→resolve→persist→dataflow→transitive; animate=not verbose so -v renders plain sequential lines (raw print() can't corrupt a non-existent live region). summary_panel() unchanged.

Tests: golden non-TTY output, exception path, ASCII fallback, no-op robustness, number highlighting (tests/test_display_rail.py); CliRunner end-to-end on init --no-build and init-with-build (tests/test_cli_init_rail.py).

Implements docs/init-ui-plan.md. Full suite: 526 passed, 1 skipped.