### PR TITLE
ci: add tag-triggered PyPI release workflow with Trusted Publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,122 @@
+name: Release
+
+# Publish cairn-intel to PyPI on tag push (v*), then cut a GitHub Release.
+# Uses PyPI Trusted Publishing -- no API tokens. Configure once:
+#   https://pypi.org/manage/project/cairn-intel/settings/publishing/
+#   GitHub publisher: tanlnm512/cairn, environment: pypi, default branch: main
+#
+# Release flow (see docs/release-checklist.md for the full pre-release pass):
+#   1. bump version in pyproject.toml
+#   2. move CHANGELOG [Unreleased] -> [X.Y.Z] - YYYY-MM-DD
+#   3. git commit -am "release: X.Y.Z"
+#   4. git tag vX.Y.Z && git push origin vX.Y.Z   # triggers this workflow
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write   # softprops/action-gh-release creates the GitHub Release
+
+# Serialize releases: two tags landing close together must not publish
+# concurrently (PyPI rejects a same-version double-upload, and GitHub
+# Releases would race on the same target).
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build wheel + sdist
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v6
+
+      # Matches `make dist`. uv build respects the setuptools backend in
+      # pyproject.toml and produces a pure-python py3-none-any wheel.
+      - name: Build distributions
+        run: uv build
+
+      - name: Verify the wheel imports
+        run: |
+          python -m pip install --upgrade pip
+          pip install dist/*.whl
+          python -c "import cairn; print('wheel ok')"
+
+      - uses: actions/upload-artifact@v5
+        with:
+          name: dist
+          path: dist/
+
+  publish-pypi:
+    name: Publish to PyPI
+    runs-on: ubuntu-latest
+    needs: build
+    environment:
+      name: pypi             # must match the Trusted Publisher environment name
+      url: https://pypi.org/project/cairn-intel/
+    permissions:
+      id-token: write        # Trusted Publishing needs OIDC; no API token
+    steps:
+      - uses: actions/download-artifact@v5
+        with:
+          name: dist
+          path: dist/
+
+      # PyPA's official action. With Trusted Publishing it exchanges the
+      # OIDC token from the `pypi` environment for an upload credential --
+      # no PYPI_API_TOKEN secret required.
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          attestations: true   # SLSA build attestations on each artifact
+
+  github-release:
+    name: GitHub Release
+    runs-on: ubuntu-latest
+    needs: publish-pypi
+    steps:
+      - uses: actions/download-artifact@v5
+        with:
+          name: dist
+          path: dist/
+
+      - name: Extract version from tag
+        id: ver
+        run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+
+      # Pull just this release's section out of CHANGELOG.md (keep-a-changelog
+      # format: `## [X.Y.Z] - YYYY-MM-DD` headers). Stops at the next version
+      # header so the body contains only this release's notes, not the whole
+      # changelog.
+      - name: Extract changelog section for this version
+        env:
+          VERSION: ${{ steps.ver.outputs.version }}
+        run: |
+          awk -v v="$VERSION" '
+            /^## \[/ {
+              if ($0 ~ "\\["v"\\]") { in_section=1; print; next }
+              else { in_section=0 }
+            }
+            in_section { print }
+          ' CHANGELOG.md > release-notes.md
+          test -s release-notes.md || \
+            echo "No CHANGELOG.md section for $VERSION -- check the release flow." >&2
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          name: ${{ steps.ver.outputs.version }}
+          body_path: release-notes.md
+          files: dist/*
+          draft: false
+          prerelease: false


### PR DESCRIPTION
Publishes cairn-intel to PyPI on `v*` tag push via OIDC Trusted Publishing (no API token), then cuts a GitHub Release with the matching CHANGELOG.md section attached.

- build: uv build (matches `make dist`), wheel import-verified
- publish-pypi: pypa/gh-action-pypi-publish, SLSA attestations on the `pypi` environment (configure publisher once on pypi.org)
- github-release: softprops/action-gh-release, extracts just this version's section from CHANGELOG.md (keep-a-changelog aware)

Workflow actions match existing CI conventions (checkout v5, setup-python v6, upload/download-artifact v5).