### PR TITLE
docs: lead with PyPI install; polish and surface cairn upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,13 +66,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   un-rebuilt DBs keep working until then (read paths tolerate both forms).
 
 ### Changed
-- _Nothing yet._
+- **`cairn upgrade` now uses PEP 440 version comparison and themed output.**
+  The install/update flow no longer relies on naive string equality, so
+  pre-release (`rc`), post-release (`.post1`), and local-segment (`+local`)
+  versions compare correctly. Output switched from raw `click.echo` to the
+  shared `display.*` helpers (`✓`/`⠿`/`!` glyphs) for consistency with the
+  rest of the CLI. Install-method detection (uv/pipx/pip) and the `--check`
+  flag are unchanged.
+- **`packaging` is now a declared direct dependency** (was transitive via
+  pip/setuptools). Required for the PEP 440 comparison in `cairn upgrade`.
+- **README rewritten to lead with PyPI install.** The from-source build/wheel
+  and bootstrap-script framing is retired from the user path; a new
+  **Upgrading** section documents `cairn upgrade` / `--check` / `cairn version`.
 
 ### Fixed
-- _Nothing yet._
-
-### Removed
-- _Nothing yet._
+- **README documented `scripts/install.sh` flags that the script does not
+  support.** The README listed `--agents`, `--scope`, and `--no-agents`;
+  the script only supports `--semantic` and `--venv`. The from-source
+  bootstrap block has been removed from the user-facing README.
 
 ## [0.6.0] - 2026-08-05
 

--- a/README.md
+++ b/README.md
@@ -57,13 +57,26 @@ for a worked example. Full design at
 ## Quick start
 
 ```bash
-pip install cairn-intel
-cairn update                       # parse the workspace and build the graph
-cairn def SomeSymbol               # find where a symbol is defined
-cairn ask "how does auth work"     # natural-language query across all layers
+pip install cairn-intel              # install from PyPI (the recommended path)
+cairn update                        # parse the workspace and build the graph
+cairn def SomeSymbol                # find where a symbol is defined
+cairn ask "how does auth work"      # natural-language query across all layers
 ```
 
 The graph lives under `~/.cairn` by default (override with `CAIRN_HOME`).
+
+## Upgrading
+
+cairn can update itself in place — it detects how it was installed
+(`uv tool`, `pipx`, or `pip`) and re-installs the latest version from PyPI:
+
+```bash
+cairn upgrade          # update to the latest published version
+cairn upgrade --check  # only check what's latest, don't change anything
+cairn version          # print the installed version
+```
+
+If PyPI is unreachable, `cairn upgrade` prints the manual command instead.
 
 ## Install for AI agents
 
@@ -168,6 +181,7 @@ The `cairn` command groups the main functionality. Run `cairn --help`
 | `cairn compass …` | Generate / list / validate module compass guides |
 | `cairn wiki …` | Generate / search the architecture wiki |
 | `cairn install-agents` | Drop integration files into supported AI agents |
+| `cairn upgrade` | Update cairn in place from PyPI (detects install method; `--check` to preview) |
 | `cairn bench` | Performance / scalability benchmarks (`--save`/`--compare` for regression checks) |
 
 ## Development
@@ -177,38 +191,33 @@ pip install -e ".[dev]"   # pytest + watchdog + build
 pytest -m core            # fast <3s smoke subset (one test per core function)
 ```
 
-## Build & distribute
+## Semantic search
 
-Build a wheel + sdist for distribution:
-
-```bash
-make dist        # → dist/cairn_intel-<version>-py3-none-any.whl
-```
-
-Hand the `.whl` file to a teammate or upload to PyPI. Install from a wheel:
-
-```bash
-uv tool install ./cairn_intel-<version>-py3-none-any.whl
-```
-
-Semantic search deps (torch + sentence-transformers) are a one-time separate
-download that persists in `~/.cairn/lib/` (survives reinstalls):
+The default install is network- and torch-free. Semantic search deps
+(torch + sentence-transformers) are a one-time separate download that
+persists in `~/.cairn/lib/` (survives reinstalls):
 
 ```bash
 cairn embed --install-deps    # one-time: downloads bge-m3 (~836 MB)
 cairn embed                   # builds the embedding index
 ```
 
-**Bootstrap script** (install + wire agents in one shot):
+## Development
+
+cairn is developed on GitHub and released to PyPI. The recommended install
+for end users is `pip install cairn-intel` (see Quick start above). The
+following is for contributors only:
 
 ```bash
-./scripts/install.sh                       # install cairn + interactively pick agents
-./scripts/install.sh --agents all          # wire all detected clients
-./scripts/install.sh --scope global        # write agent configs to ~/.claude/ etc.
-./scripts/install.sh --no-agents           # install cairn only, skip agent wiring
+pip install -e ".[dev]"   # editable install: pytest + watchdog + build + ruff
+pytest -m core            # fast <3s smoke subset (one test per core function)
+pytest                    # full suite (the CI path)
+make dist                 # build wheel + sdist into dist/ (for releases)
 ```
 
-The full suite (no marker) is the CI path.
+Releases are cut by tagging `vX.Y.Z` — see the tag-triggered workflow in
+`.github/workflows/release.yml` and the pre-release checklist in
+`docs/release-checklist.md`.
 
 ## Dependency licenses
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -342,6 +342,19 @@ state, and prompts for which to install plus the config scope.
 
 `upgrade` options: `--check` (only check, don't upgrade).
 
+`cairn upgrade` updates cairn in place from PyPI. It queries
+`pypi.org/pypi/cairn-intel/json` for the latest version, compares it to the
+installed version under PEP 440, and re-installs via whichever package
+manager cairn was installed with — `uv tool`, `pipx`, or `pip` (the install
+method is auto-detected by inspecting `uv tool list` / `pipx list` / the
+current interpreter path). `--check` prints both versions without changing
+anything. If PyPI is unreachable, it prints the manual command instead
+(`pip install --upgrade cairn-intel`).
+
+`cairn version` prints the installed version from package metadata, falling
+back to the source-tree version (with a `(source checkout)` marker) for
+editable installs.
+
 ---
 
 ## Where to look next

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -40,6 +40,17 @@ Verify it landed:
 cairn --help
 ```
 
+## Upgrading
+
+cairn can update itself in place — it detects how it was installed
+(`uv tool`, `pipx`, or `pip`) and re-installs the latest version from PyPI:
+
+```bash
+cairn upgrade          # update to the latest published version
+cairn upgrade --check  # only check what's latest, don't change anything
+cairn version          # print the installed version
+```
+
 ## Build the graph
 
 From your repository root (or any subdirectory of it):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ dependencies = [
     "mcp>=0.9.0,<2.0.0",  # SSE/streamable-http + uvicorn/starlette are core deps in mcp>=0.9; the legacy [sse] extra was removed upstream
     "pydantic>=2.0",  # used directly by mcp_server/structured.py; declared explicitly (not just transitive via mcp)
     "pathspec>=0.12",
+    "packaging>=21.0",  # PEP 440 version comparison in `cairn upgrade`; declared explicitly (transitively always present via pip/setuptools, but the CLI relies on it)
     "sqlite-vec>=0.1.0",
     # Progress display: spinners, progress bars, ETA/rate, themed tables.
     # Pure-Python, no network/torch -- keeps the default install lightweight.

--- a/src/cairn/cli/upgrade.py
+++ b/src/cairn/cli/upgrade.py
@@ -8,15 +8,22 @@ import sys
 from .main import main
 
 
-@main.command()
-def version():
-    """Print the installed cairn version."""
+# --- Version helpers -------------------------------------------------------
+#
+# Version strings are PEP 440. Naive `==` comparison breaks across pre/post/
+# local segments (e.g. local "0.6.0" vs PyPI "0.6.0.post1", or "0.6.0" vs
+# "0.6.0rc1"). Use packaging.version.parse when available; degrade to string
+# equality if the import ever fails -- the upgrade command must never crash on
+# a version parse.
+
+
+def _is_up_to_date(current: str, latest: str) -> bool:
+    """True if ``current`` >= ``latest`` under PEP 440, else string equality."""
     try:
-        from importlib.metadata import version as _v
-        click.echo(f"cairn-intel {_v('cairn-intel')}")
+        from packaging.version import parse
+        return parse(current) >= parse(latest)
     except Exception:
-        from cairn import __version__
-        click.echo(f"cairn-intel {__version__} (source checkout)")
+        return current == latest
 
 
 def _installed_version() -> str:
@@ -74,6 +81,8 @@ def _detect_install_method() -> str:
 
 def _reinstall(method: str, version: str):
     """Re-install cairn-intel using the detected method."""
+    from . import display
+
     spec = f"cairn-intel=={version}"
     if method == "uv":
         cmd = ["uv", "tool", "install", "--force", spec]
@@ -82,42 +91,56 @@ def _reinstall(method: str, version: str):
     elif method == "pip":
         cmd = [sys.executable, "-m", "pip", "install", "--upgrade", spec]
     else:
-        click.echo(
+        display.warning(
             f"Cannot auto-upgrade (unknown install method). "
             f"Run manually: pip install --upgrade {spec}"
         )
         return
-    click.echo(f"Running: {' '.join(cmd)}")
+    display.info(f"Running: {' '.join(cmd)}")
     subprocess.run(cmd, check=False)
+
+
+# --- Commands --------------------------------------------------------------
+
+
+@main.command()
+def version():
+    """Print the installed cairn version."""
+    from . import display
+    try:
+        from importlib.metadata import version as _v
+        display.info(f"cairn-intel {_v('cairn-intel')}")
+    except Exception:
+        from cairn import __version__
+        display.info(f"cairn-intel {__version__} (source checkout)")
 
 
 @main.command()
 @click.option("--check", is_flag=True, help="Only check, don't upgrade")
 def upgrade(check):
     """Upgrade cairn. Detects install method and updates in place."""
+    from . import display
     current = _installed_version()
     latest = _pypi_latest()
 
     if latest is None:
         if check:
-            click.echo(f"cairn-intel {current} (could not reach PyPI)")
+            display.info(f"cairn-intel {current} (could not reach PyPI)")
         else:
-            click.echo(
+            display.warning(
                 "Cannot check for upgrades (PyPI unreachable). "
                 "Install manually: pip install --upgrade cairn-intel"
             )
         return
 
     if check:
-        click.echo(f"cairn-intel {current} (latest: {latest})")
+        display.info(f"cairn-intel {current} (latest: {latest})")
         return
 
-    if current == latest:
-        click.echo(f"cairn-intel {current} (already up to date)")
+    if _is_up_to_date(current, latest):
+        display.success(f"cairn-intel {current} (already up to date)")
         return
 
     method = _detect_install_method()
-    click.echo(f"Upgrading cairn-intel {current} -> {latest} (via {method})")
+    display.info(f"Upgrading cairn-intel {current} -> {latest} (via {method})")
     _reinstall(method, latest)
-
-

--- a/tests/test_upgrade.py
+++ b/tests/test_upgrade.py
@@ -1,0 +1,188 @@
+"""Tests for the `version` / `upgrade` CLI commands.
+
+All network and subprocess calls are stubbed -- no real PyPI lookup, no real
+reinstall. We monkeypatch the module-level helpers in upgrade.py
+(`_installed_version`, `_pypi_latest`, `_detect_install_method`, `_reinstall`)
+and `subprocess.run` for the install-method sniff.
+"""
+from __future__ import annotations
+
+import subprocess
+
+from click.testing import CliRunner
+
+from cairn.cli import main
+from cairn.cli import upgrade as upgrade_mod
+
+
+# --- Fixtures --------------------------------------------------------------
+
+def _set_versions(monkeypatch, installed=None, latest=None, reinstall=None):
+    """Stub the upgrade helpers. `reinstall` records calls instead of shelling."""
+    calls = []
+    if installed is not None:
+        monkeypatch.setattr(upgrade_mod, "_installed_version", lambda: installed)
+    if latest is not None:
+        monkeypatch.setattr(upgrade_mod, "_pypi_latest", lambda: latest)
+    if reinstall is None:
+        reinstall = lambda method, version: calls.append((method, version))
+    monkeypatch.setattr(upgrade_mod, "_reinstall", reinstall)
+    return calls
+
+
+def _stub_run(stdout="", returncode=0):
+    """Return a fake subprocess.run that yields a CompletedProcess with stdout."""
+    def fake_run(cmd, *rest, **kw):
+        return subprocess.CompletedProcess(cmd, returncode, stdout=stdout, stderr="")
+    return fake_run
+
+
+# --- `cairn version` -------------------------------------------------------
+
+def test_version_prints_installed(monkeypatch):
+    monkeypatch.setattr(
+        "importlib.metadata.version", lambda name: "1.2.3"
+    )
+    runner = CliRunner()
+    result = runner.invoke(main, ["version"])
+    assert result.exit_code == 0
+    assert "1.2.3" in result.output
+
+
+def test_version_falls_back_to_source_checkout(monkeypatch):
+    import importlib.metadata as md
+    monkeypatch.setattr(
+        md, "version", lambda name: (_ for _ in ()).throw(ModuleNotFoundError("nope"))
+    )
+    # Also force the lazy import inside `version()` to raise by pointing the
+    # looked-up name at something missing.
+    monkeypatch.setattr(
+        "importlib.metadata.version",
+        lambda name: (_ for _ in ()).throw(ModuleNotFoundError("nope")),
+    )
+    runner = CliRunner()
+    result = runner.invoke(main, ["version"])
+    assert result.exit_code == 0
+    # Falls back to cairn.__version__ with a "(source checkout)" marker.
+    assert "source checkout" in result.output
+
+
+# --- `cairn upgrade --check` ----------------------------------------------
+
+def test_upgrade_check_shows_latest(monkeypatch):
+    _set_versions(monkeypatch, installed="0.6.0", latest="0.7.0")
+    runner = CliRunner()
+    result = runner.invoke(main, ["upgrade", "--check"])
+    assert result.exit_code == 0
+    assert "0.6.0" in result.output
+    assert "0.7.0" in result.output
+    assert "latest" in result.output
+
+
+def test_upgrade_check_when_already_latest(monkeypatch):
+    _set_versions(monkeypatch, installed="0.7.0", latest="0.7.0")
+    runner = CliRunner()
+    result = runner.invoke(main, ["upgrade", "--check"])
+    assert result.exit_code == 0
+    # --check prints both versions regardless of equality.
+    assert "0.7.0" in result.output
+
+
+def test_upgrade_check_pypi_unreachable(monkeypatch):
+    _set_versions(monkeypatch, installed="0.6.0", latest=None)
+    runner = CliRunner()
+    result = runner.invoke(main, ["upgrade", "--check"])
+    assert result.exit_code == 0
+    assert "0.6.0" in result.output
+    assert "PyPI" in result.output
+
+
+# --- `cairn upgrade` (without --check) ------------------------------------
+
+def test_upgrade_noop_when_already_up_to_date(monkeypatch):
+    calls = _set_versions(monkeypatch, installed="0.7.0", latest="0.7.0")
+    runner = CliRunner()
+    result = runner.invoke(main, ["upgrade"])
+    assert result.exit_code == 0
+    assert "already up to date" in result.output
+    assert calls == []  # no reinstall attempted
+
+
+def test_upgrade_runs_reinstall_when_newer(monkeypatch):
+    calls = _set_versions(monkeypatch, installed="0.6.0", latest="0.7.0")
+    monkeypatch.setattr(upgrade_mod, "_detect_install_method", lambda: "uv")
+    runner = CliRunner()
+    result = runner.invoke(main, ["upgrade"])
+    assert result.exit_code == 0
+    assert calls == [("uv", "0.7.0")]
+    assert "0.6.0" in result.output
+    assert "0.7.0" in result.output
+
+
+def test_upgrade_when_pypi_unreachable(monkeypatch):
+    _set_versions(monkeypatch, installed="0.6.0", latest=None)
+    runner = CliRunner()
+    result = runner.invoke(main, ["upgrade"])
+    assert result.exit_code == 0
+    assert "PyPI unreachable" in result.output
+    # Message may be terminal-wrapped in non-TTY mode, so check the pieces
+    # rather than the exact "pip install --upgrade" substring.
+    assert "pip install" in result.output
+    assert "--upgrade" in result.output
+
+
+# --- install-method detection ---------------------------------------------
+
+def test_detect_install_method_uv(monkeypatch):
+    monkeypatch.setattr("subprocess.run", _stub_run(stdout="cairn-intel v0.6.0\n"))
+    assert upgrade_mod._detect_install_method() == "uv"
+
+
+def test_detect_install_method_pipx(monkeypatch):
+    # First call (uv tool list) returns nothing; second (pipx) matches.
+    def fake_run(cmd, *rest, **kw):
+        stdout = "" if cmd[0] == "uv" else "package cairn-intel 0.6.0\n"
+        return subprocess.CompletedProcess(cmd, 0, stdout=stdout, stderr="")
+    monkeypatch.setattr("subprocess.run", fake_run)
+    assert upgrade_mod._detect_install_method() == "pipx"
+
+
+def test_detect_install_method_pip(monkeypatch):
+    monkeypatch.setattr("subprocess.run", _stub_run(stdout=""))
+    monkeypatch.setattr(upgrade_mod.sys, "executable", "/home/me/venv/bin/python")
+    assert upgrade_mod._detect_install_method() == "pip"
+
+
+def test_detect_install_method_unknown(monkeypatch):
+    monkeypatch.setattr("subprocess.run", _stub_run(stdout=""))
+    monkeypatch.setattr(upgrade_mod.sys, "executable", "/usr/local/bin/python")
+    assert upgrade_mod._detect_install_method() == "unknown"
+
+
+# --- PEP 440 version comparison -------------------------------------------
+
+def test_is_up_to_date_string_equal():
+    assert upgrade_mod._is_up_to_date("0.6.0", "0.6.0") is True
+
+
+def test_is_up_to_date_local_newer():
+    assert upgrade_mod._is_up_to_date("0.7.0", "0.6.0") is True
+
+
+def test_is_up_to_date_local_older():
+    assert upgrade_mod._is_up_to_date("0.6.0", "0.7.0") is False
+
+
+def test_is_up_to_date_local_vs_release_candidate():
+    # 0.6.0 final is newer than 0.6.0rc1.
+    assert upgrade_mod._is_up_to_date("0.6.0", "0.6.0rc1") is True
+
+
+def test_is_up_to_date_post_release_is_newer():
+    # 0.6.0.post1 is newer than 0.6.0.
+    assert upgrade_mod._is_up_to_date("0.6.0", "0.6.0.post1") is False
+
+
+def test_is_up_to_date_local_version_segment():
+    # 0.6.0+local is equal-ish to 0.6.0 (local segment doesn't change ordering).
+    assert upgrade_mod._is_up_to_date("0.6.0+local", "0.6.0") is True

--- a/uv.lock
+++ b/uv.lock
@@ -76,6 +76,7 @@ source = { editable = "." }
 dependencies = [
     { name = "click" },
     { name = "mcp" },
+    { name = "packaging" },
     { name = "pathspec" },
     { name = "pydantic" },
     { name = "pyyaml" },
@@ -128,6 +129,7 @@ requires-dist = [
     { name = "grpcio-tools", marker = "extra == 'dev'", specifier = ">=1.60" },
     { name = "mcp", specifier = ">=0.9.0,<2.0.0" },
     { name = "numpy", marker = "extra == 'semantic'", specifier = ">=1.24" },
+    { name = "packaging", specifier = ">=21.0" },
     { name = "pathspec", specifier = ">=0.12" },
     { name = "protobuf", marker = "extra == 'scip'", specifier = ">=7.35.1" },
     { name = "pydantic", specifier = ">=2.0" },
@@ -357,7 +359,7 @@ name = "cuda-bindings"
 version = "13.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cuda-pathfinder", marker = "sys_platform != 'win32'" },
+    { name = "cuda-pathfinder" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a9/21/8464d133752951c154feafb3b65c297e7d80f301183d220bec4c830f1441/cuda_bindings-13.3.1-cp310-cp310-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:120fcc53d57903df529c3486962c56528cba5b7d6c57c99537320ed9922c8b86", size = 6073403, upload-time = "2026-05-29T23:11:36.22Z" },
@@ -392,43 +394,43 @@ wheels = [
 
 [package.optional-dependencies]
 cublas = [
-    { name = "nvidia-cublas", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "nvidia-cuda-nvrtc", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-cublas", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cuda-nvrtc", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 cudart = [
-    { name = "nvidia-cuda-runtime", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-cuda-runtime", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 cufft = [
-    { name = "nvidia-cufft", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-cufft", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 cufile = [
-    { name = "nvidia-cufile", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-cufile", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 cupti = [
-    { name = "nvidia-cuda-cupti", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-cuda-cupti", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 curand = [
-    { name = "nvidia-curand", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-curand", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 cusolver = [
-    { name = "nvidia-cublas", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "nvidia-cusolver", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "nvidia-cusparse", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-cublas", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cusolver", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cusparse", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 cusparse = [
-    { name = "nvidia-cusparse", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-cusparse", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 nvjitlink = [
-    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 nvrtc = [
-    { name = "nvidia-cuda-nvrtc", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-cuda-nvrtc", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 nvtx = [
-    { name = "nvidia-nvtx", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-nvtx", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 
 [[package]]
@@ -436,7 +438,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -689,7 +691,7 @@ name = "importlib-metadata"
 version = "9.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "zipp", marker = "python_full_version < '3.11'" },
+    { name = "zipp" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a9/01/15bb152d77b21318514a96f43af312635eb2500c96b55398d020c93d86ea/importlib_metadata-9.0.0.tar.gz", hash = "sha256:a4f57ab599e6a2e3016d7595cfd72eb4661a5106e787a95bcc90c7105b831efc", size = 56405, upload-time = "2026-03-20T06:42:56.999Z" }
 wheels = [
@@ -1144,7 +1146,7 @@ name = "nvidia-cublas"
 version = "13.1.1.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cuda-nvrtc", marker = "sys_platform != 'win32'" },
+    { name = "nvidia-cuda-nvrtc" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a7/a1/0bd24ee8c8d03adac032fd2909426a00c88f8c57961b1277ded97f91119f/nvidia_cublas-13.1.1.3-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:b7a210458267ac818974c53038fbec2e969d5c99f305ab15c72522fa9f001dd5", size = 542848918, upload-time = "2026-04-08T18:46:22.985Z" },
@@ -1183,7 +1185,7 @@ name = "nvidia-cudnn-cu13"
 version = "9.20.0.48"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas", marker = "sys_platform != 'win32'" },
+    { name = "nvidia-cublas" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/56/c5/83384d846b2fd17c44bd499b36c75a45ed4f095fbbb2252294e89cea5c5c/nvidia_cudnn_cu13-9.20.0.48-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:e31454ae00094b0c55319d9d15b6fa2fc50a9e1c0f5c8c80fb75258234e731e1", size = 444574296, upload-time = "2026-03-09T19:28:27.751Z" },
@@ -1195,7 +1197,7 @@ name = "nvidia-cufft"
 version = "12.0.0.61"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink", marker = "sys_platform != 'win32'" },
+    { name = "nvidia-nvjitlink" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8b/ae/f417a75c0259e85c1d2f83ca4e960289a5f814ed0cea74d18c353d3e989d/nvidia_cufft-12.0.0.61-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2708c852ef8cd89d1d2068bdbece0aa188813a0c934db3779b9b1faa8442e5f5", size = 214053554, upload-time = "2025-09-04T08:31:38.196Z" },
@@ -1225,9 +1227,9 @@ name = "nvidia-cusolver"
 version = "12.0.4.66"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas", marker = "sys_platform != 'win32'" },
-    { name = "nvidia-cusparse", marker = "sys_platform != 'win32'" },
-    { name = "nvidia-nvjitlink", marker = "sys_platform != 'win32'" },
+    { name = "nvidia-cublas" },
+    { name = "nvidia-cusparse" },
+    { name = "nvidia-nvjitlink" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/c3/b30c9e935fc01e3da443ec0116ed1b2a009bb867f5324d3f2d7e533e776b/nvidia_cusolver-12.0.4.66-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:02c2457eaa9e39de20f880f4bd8820e6a1cfb9f9a34f820eb12a155aa5bc92d2", size = 223467760, upload-time = "2025-09-04T08:33:04.222Z" },
@@ -1239,7 +1241,7 @@ name = "nvidia-cusparse"
 version = "12.6.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink", marker = "sys_platform != 'win32'" },
+    { name = "nvidia-nvjitlink" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f8/94/5c26f33738ae35276672f12615a64bd008ed5be6d1ebcb23579285d960a9/nvidia_cusparse-12.6.3.3-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:80bcc4662f23f1054ee334a15c72b8940402975e0eab63178fc7e670aa59472c", size = 162155568, upload-time = "2025-09-04T08:33:42.864Z" },
@@ -2135,10 +2137,10 @@ resolution-markers = [
     "python_full_version < '3.11' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "joblib", marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "threadpoolctl", marker = "python_full_version < '3.11'" },
+    { name = "joblib" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" } },
+    { name = "threadpoolctl" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/98/c2/a7855e41c9d285dfe86dc50b250978105dce513d6e459ea66a6aeb0e1e0c/scikit_learn-1.7.2.tar.gz", hash = "sha256:20e9e49ecd130598f1ca38a1d85090e1a600147b9c02fa6f15d69cb53d968fda", size = 7193136, upload-time = "2025-09-09T08:21:29.075Z" }
 wheels = [
@@ -2187,13 +2189,13 @@ resolution-markers = [
     "python_full_version == '3.11.*' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "joblib", marker = "python_full_version >= '3.11'" },
-    { name = "narwhals", marker = "python_full_version >= '3.11'" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
+    { name = "joblib" },
+    { name = "narwhals" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
     { name = "numpy", version = "2.5.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
+    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
     { name = "scipy", version = "1.18.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-    { name = "threadpoolctl", marker = "python_full_version >= '3.11'" },
+    { name = "threadpoolctl" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/fa/6f/37092bdb25f712817231799fc5674d8e704066a8a70c1d2d40517e18b4ab/scikit_learn-1.9.0.tar.gz", hash = "sha256:8833266989d3a5110178a9fae30783675460724d0e1efb13b14901d2c660c557", size = 7750767, upload-time = "2026-06-02T11:54:32.706Z" }
 wheels = [
@@ -2238,7 +2240,7 @@ resolution-markers = [
     "python_full_version < '3.11' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0f/37/6964b830433e654ec7485e45a00fc9a27cf868d622838f6b6d9c5ec0d532/scipy-1.15.3.tar.gz", hash = "sha256:eae3cf522bc7df64b42cad3925c876e1b0b6c35c1337c93e12c0f366f55b0eaf", size = 59419214, upload-time = "2025-05-08T16:13:05.955Z" }
 wheels = [
@@ -2298,7 +2300,7 @@ resolution-markers = [
     "python_full_version == '3.11.*' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/7a/97/5a3609c4f8d58b039179648e62dd220f89864f56f7357f5d4f45c29eb2cc/scipy-1.17.1.tar.gz", hash = "sha256:95d8e012d8cb8816c226aef832200b1d45109ed4464303e997c5b13122b297c0", size = 30573822, upload-time = "2026-02-23T00:26:24.851Z" }
 wheels = [
@@ -2375,7 +2377,7 @@ resolution-markers = [
     "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.5.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "numpy", version = "2.5.1", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a7/25/c2700dfaf6442b4effaa91af24ebce5dc9d31bb4a69706313aae70d72cd0/scipy-1.18.0.tar.gz", hash = "sha256:67b2ad2ad54c72ca6d04975a9b2df8c3638c34ddd5b28738e94fc2b57929d378", size = 30774447, upload-time = "2026-06-19T15:01:43.456Z" }
 wheels = [


### PR DESCRIPTION
Now that the tag-triggered PyPI release pipeline is in place, the user install path should be `pip install cairn-intel`, not clone-and-build. The `cairn upgrade` command already existed but was undocumented and used naive string version comparison.

upgrade.py:
- PEP 440 version comparison (packaging.version.parse) so rc/post/local segments compare correctly; string-equality fallback if packaging import ever fails.
- Output switched from raw click.echo to the shared display.* helpers (✓/⠿/! glyphs) for consistency with the rest of the CLI.
- Install-method detection (uv/pipx/pip) and the --check flag unchanged.

pyproject.toml: `packaging` declared as a direct dependency (was transitive via pip/setuptools; the CLI now relies on it).

tests/test_upgrade.py (new, 18 tests): version, --check, the up-to-date vs upgrade-needed branches, PyPI-unreachable fallback, all four install-method detections, and PEP 440 edge cases. All network and subprocess calls stubbed.

README: Quick start leads with pip install; new Upgrading section (cairn upgrade / --check / version); CLI table gains a `cairn upgrade` row; "Build & distribute" reframed as a contributor-only Development section. Removed the bootstrap-script block that documented install.sh flags (--agents/--scope/--no-agents) the script never had.

docs/quickstart.md: matching Upgrading note.
docs/cli-reference.md: expanded the `cairn upgrade` one-liner into a subsection covering detection, --check, and the unreachable fallback. CHANGELOG: Changed + Fixed entries under [Unreleased].