### PR TITLE
feat(scip): Swift indexing + auto-generation + tree-sitter coexistence

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,7 +120,7 @@ jobs:
           pip install dist/*.whl
           python -c "import cairn; print('ok')"
 
-      - uses: actions/upload-artifact@v5
+      - uses: actions/upload-artifact@v6
         with:
           name: dist
           path: dist/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,7 @@ jobs:
           pip install dist/*.whl
           python -c "import cairn; print('wheel ok')"
 
-      - uses: actions/upload-artifact@v5
+      - uses: actions/upload-artifact@v6
         with:
           name: dist
           path: dist/
@@ -67,7 +67,7 @@ jobs:
     permissions:
       id-token: write        # Trusted Publishing needs OIDC; no API token
     steps:
-      - uses: actions/download-artifact@v5
+      - uses: actions/download-artifact@v6
         with:
           name: dist
           path: dist/
@@ -85,7 +85,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: publish-pypi
     steps:
-      - uses: actions/download-artifact@v5
+      - uses: actions/download-artifact@v6
         with:
           name: dist
           path: dist/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,13 +56,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     is regenerated).
 - **Automatic SCIP index generation (bounded, opt-in).** When `cairn.json`
   declares a SCIP index for a language but the file is *missing*, and a known
-  indexer (`scip-swift`, `scip-kotlin`, `scip-typescript`) is on `PATH`,
-  `cairn build` runs the indexer once to produce it before importing — the one
-  bounded exception to "cairn never generates indexes". An existing index is
-  never rebuilt; a missing/failing/timeout indexer logs (under `-v`) and falls
-  back to tree-sitter for that language, so generation never breaks the build.
-  Swift is a new known indexer target alongside Kotlin/TypeScript. See
-  `docs/scip.md` § "Automatic generation".
+  indexer is on `PATH`, `cairn build` runs the indexer once to produce it
+  before importing — the one bounded exception to "cairn never generates
+  indexes". An existing index is never rebuilt; a missing/failing/timeout
+  indexer logs (under `-v`) and falls back to tree-sitter for that language, so
+  generation never breaks the build. Known indexers: `scip-swift` (Swift),
+  `scip-java` (Java **and** Kotlin — scip-kotlin is merged in and deprecated),
+  `scip-typescript` (TypeScript/JS), `scip-python` (Python, npm pkg),
+  `scip-go` (Go), `rust-analyzer scip` (Rust). Dart/PHP indexers exist but lack
+  an `--output` flag, so they're generate-out-of-band only. See `docs/scip.md`
+  § "Automatic generation".
 - **Portable `.kg` database.** The code graph now stores file paths
   **repo-relative** (`files.path`, `parse_errors.file_path`,
   `skipped_files.path`, `pending_sync.path`) and `repos.path` **workspace-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,11 +88,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   survive the merge (SCIP has no inheritance role); its fuzzy `calls` edges are
   replaced by SCIP's exact ones. Matching by `(file_id, name, line_start)` with
   name normalization (e.g. `greet()` → `greet`).
-  - **Limitation:** scip-swift's opaque USRs (`` `s:...` ``) don't match
-    tree-sitter's human-readable names, so Swift SCIP data lands as standalone
-    `source='scip'` rows rather than merged. Indexers with human-readable
-    descriptors (scip-java, scip-typescript, scip-python, scip-go) merge
-    correctly. Validated end-to-end against real scip-java 0.10.4 output.
+  - **Per-language fallback:** when an indexer's symbol names don't match
+    tree-sitter's (merge rate ~0, e.g. scip-swift's opaque USRs), coexistence
+    duplicates are harmful — two disconnected graphs for the same logical
+    symbol break `get_callers` for both name forms. The build detects the zero
+    merge rate and reverts that language to pure-SCIP (removes tree-sitter
+    symbols, keeps SCIP intact). Languages whose indexers have human-readable
+    descriptors (scip-java, scip-typescript, scip-python, scip-go) keep the
+    coexistence merge. Validated end-to-end against real scip-java 0.10.4
+    (4/7 symbols merged) and scip-swift 0.1.2 (reverted to pure-SCIP).
 
 ### Fixed
 - **SCIP `project_root` now handles `file://` URLs.** scip-swift writes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,7 +78,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   un-rebuilt DBs keep working until then (read paths tolerate both forms).
 
 ### Changed
-- _Nothing yet._
+- **SCIP / tree-sitter coexistence (replaces hybrid skip).** `cairn build` no
+  longer skips tree-sitter for SCIP-covered languages. Both sources now run:
+  tree-sitter parses every file (providing modifiers, body, inheritance edges,
+  parent_scope that SCIP can't emit), then SCIP's exact-resolution edges and
+  richer qualified_name are merged onto the tree-sitter symbol rows. The result
+  is one row per symbol (`source='merged'`) carrying the strengths of both —
+  no query-layer dedup needed. Tree-sitter's `implements`/`extends` edges
+  survive the merge (SCIP has no inheritance role); its fuzzy `calls` edges are
+  replaced by SCIP's exact ones. Matching by `(file_id, name, line_start)` with
+  name normalization (e.g. `greet()` → `greet`).
+  - **Limitation:** scip-swift's opaque USRs (`` `s:...` ``) don't match
+    tree-sitter's human-readable names, so Swift SCIP data lands as standalone
+    `source='scip'` rows rather than merged. Indexers with human-readable
+    descriptors (scip-java, scip-typescript, scip-python, scip-go) merge
+    correctly. Validated end-to-end against real scip-java 0.10.4 output.
 
 ### Fixed
 - **SCIP `project_root` now handles `file://` URLs.** scip-swift writes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     back to tree-sitter for an edited SCIP-covered file (bounded, self-healing
     staleness — the next full build restores `source='scip'` once the index
     is regenerated).
+- **Automatic SCIP index generation (bounded, opt-in).** When `cairn.json`
+  declares a SCIP index for a language but the file is *missing*, and a known
+  indexer (`scip-swift`, `scip-kotlin`, `scip-typescript`) is on `PATH`,
+  `cairn build` runs the indexer once to produce it before importing — the one
+  bounded exception to "cairn never generates indexes". An existing index is
+  never rebuilt; a missing/failing/timeout indexer logs (under `-v`) and falls
+  back to tree-sitter for that language, so generation never breaks the build.
+  Swift is a new known indexer target alongside Kotlin/TypeScript. See
+  `docs/scip.md` § "Automatic generation".
 - **Portable `.kg` database.** The code graph now stores file paths
   **repo-relative** (`files.path`, `parse_errors.file_path`,
   `skipped_files.path`, `pending_sync.path`) and `repos.path` **workspace-
@@ -69,7 +78,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - _Nothing yet._
 
 ### Fixed
-- _Nothing yet._
+- **SCIP `project_root` now handles `file://` URLs.** scip-swift writes
+  `Metadata.project_root` as `URL(fileURLWithPath:).absoluteString`
+  (`file:///abs/path`); the importer treated it as a relative path (joined it
+  verbatim onto the workspace root) and silently mis-attributed every Swift
+  document to the wrong repo id. The value is now scheme-stripped before
+  resolution, so absolute paths, workspace-relative paths, and `file://` URLs
+  (including the `file://localhost/` form) all resolve correctly.
 
 ### Removed
 - _Nothing yet._

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   document to the wrong repo id. The value is now scheme-stripped before
   resolution, so absolute paths, workspace-relative paths, and `file://` URLs
   (including the `file://localhost/` form) all resolve correctly.
+  (Found by validating against real scip-swift output.)
+- **SCIP importer no longer crashes on file-level occurrences.** A reference
+  with no enclosing definition (top-level code in a Swift `main.swift`, a
+  reference before any definition) used to insert `edges.source_id = NULL`,
+  violating the NOT NULL FK and crashing the whole import. Now skipped,
+  matching the tree-sitter path's "file-level call with no owning symbol"
+  handling. (Found against real scip-swift output.)
+- **SCIP `Document.language` now falls back to the file extension.** scip-java
+  0.10.4 emits an empty `language` field for both Java and Kotlin documents;
+  the importer stored `'scip'`, breaking the hybrid skip logic (which keys off
+  `files.language`). The language is now derived from the extension when the
+  document omits it, and normalized to lowercase (scip-swift emits `"Swift"`).
+  (Found against real scip-java output.)
 
 ### Removed
 - _Nothing yet._

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ The default install is dependency-light and network-free. Opt in with extras:
 |-------|------|-------------|
 | `[semantic]` | `sentence-transformers` + `numpy` — real embeddings and CrossEncoder reranking | `CAIRN_RERANK=1`; fusion is governed by `CAIRN_FUSION` (default on) |
 | `[ann]` | `sqlite-vec` — native approximate-nearest-neighbour index for large corpora | `CAIRN_ANN_BACKEND=sqlite-vec` |
-| `[scip]` | `protobuf` — consume pre-built [SCIP](docs/scip.md) indexes for compiler-grade exact call edges (Kotlin/Java/TypeScript) alongside tree-sitter | declare indexes in `cairn.json` under `scip` |
+| `[scip]` | `protobuf` — consume pre-built [SCIP](docs/scip.md) indexes for compiler-grade exact call edges (Kotlin/Java/Swift/TypeScript) alongside tree-sitter | declare indexes in `cairn.json` under `scip` |
 | `[watch]` | `watchdog` — live graph rebuilds on filesystem change | — |
 
 ## Architecture (5 layers)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -108,7 +108,7 @@ ignored (forward-compatible). Recognized keys:
 | `exclude` | list of gitignore globs | Patterns to skip during indexing, matched against repo-root-relative paths. Combined with the built-in skip set and `.gitignore`. |
 | `include` | list of gitignore globs | Patterns to force-include, overriding `exclude` and the default skip set. Use to pull a checked-in vendored dir back into the graph. |
 | `repo_namespaces` | object `prefix -> repo id` | Maps import-path prefixes to owning repo ids, used by `cairn deps` / `cross_repo_deps` to detect cross-repo links. When empty, falls back to the built-in default map and `CAIRN_REPO_NAMESPACES`. |
-| `scip` | object `language -> index path` | Maps a language to a pre-built [SCIP](https://github.com/sourcegraph/scip) index file (relative to workspace root). At build time, languages whose index file exists are skipped by tree-sitter and imported from SCIP instead (compiler-grade exact resolution); a missing file falls back to tree-sitter for that language. Requires the optional `[scip]` extra. Keys must match scanner language names exactly (lowercase: `kotlin`, `typescript`, `java`, …) — an unrecognized key is warned about and skipped. See [scip.md](./scip.md). |
+| `scip` | object `language -> index path` | Maps a language to a pre-built [SCIP](https://github.com/sourcegraph/scip) index file (relative to workspace root). At build time, languages whose index file exists are skipped by tree-sitter and imported from SCIP instead (compiler-grade exact resolution); a missing file falls back to tree-sitter for that language. Requires the optional `[scip]` extra. Keys must match scanner language names exactly (lowercase: `kotlin`, `typescript`, `java`, `swift`, …) — an unrecognized key is warned about and skipped. If a known indexer (`scip-swift`, `scip-kotlin`, `scip-typescript`) is on `PATH`, a missing index is auto-generated once before the fallback kicks in. See [scip.md](./scip.md). |
 
 Example:
 
@@ -123,7 +123,8 @@ Example:
   },
   "scip": {
     "kotlin": "build/scip/kotlin.scip",
-    "typescript": "build/scip/ts.scip"
+    "typescript": "build/scip/ts.scip",
+    "swift": "build/scip/swift.scip"
   }
 }
 ```

--- a/docs/scip.md
+++ b/docs/scip.md
@@ -2,8 +2,10 @@
 
 cairn can consume pre-built **SCIP** (Sourcegraph Code Intelligence Protocol)
 indexes for languages where compiler-grade symbol bindings beat tree-sitter's
-heuristic resolver — Kotlin, Java, and TypeScript in particular. Cairn stays a
-**consumer** of SCIP indexes; it never generates them.
+heuristic resolver — Kotlin, Java, Swift, and TypeScript in particular. Cairn
+stays a **consumer** of SCIP indexes; it never generates them (with one bounded
+exception for a missing index — see [Automatic generation](#automatic-generation-opt-in)
+below).
 
 When an index is configured **and present**, `cairn build` skips tree-sitter
 parsing for that language and imports the SCIP data instead (exact resolution —
@@ -21,6 +23,9 @@ scip-kotlin index --output build/scip/kotlin.scip .
 
 # TypeScript (scip-typescript)
 scip-typescript index --output build/scip/typescript.scip .
+
+# Swift (scip-swift)
+scip-swift index /path/to/repo --output build/scip/swift.scip
 ```
 
 See the [SCIP indexer list](https://github.com/sourcegraph/scip#indexers) for
@@ -28,6 +33,55 @@ Java, Scala, Python, Go, Rust, etc. The output is a protobuf `.scip` file.
 
 > Commit the `.scip` file (or produce it in CI) — cairn reads it at build time
 > and never triggers regeneration.
+
+### Swift / scip-swift notes
+
+`scip-swift` builds the target repo with indexing enabled
+(`swift build --enable-index-store` or
+`xcodebuild ... COMPILER_INDEX_STORE_ENABLE=YES`), then reads the resulting
+IndexStore. Two consequences worth knowing:
+
+- **macOS only.** Indexing anything that imports Apple-only frameworks
+  (`UIKit`, `WatchKit`, `WidgetKit`) requires Xcode + the iOS/watchOS SDK, which
+  Apple ships only on macOS. Generate the index on a Mac; cairn can consume the
+  `.scip` file on any platform.
+- **Opaque symbol identity.** scip-swift embeds the compiler's raw USR (e.g.
+  `_$s5Hello7GreeterC7sayHelloyySSF`) as an opaque, escaped descriptor rather
+  than a demangled `Hello.Greeter.sayHello()` chain. Cross-references still
+  resolve exactly (USR is compiler-guaranteed unique), but the symbol strings
+  are not human-readable the way `scip-kotlin`'s are.
+- **No call-specific role.** SCIP's `SymbolRole` has no call bit, so Swift call
+  sites are marked `ReadAccess` like any other reference. cairn therefore tags
+  Swift call edges as `kind='reference'`, not `kind='call'` — call-graph queries
+  (`get_callers`, `impact_analysis` keyed on `call` edges) will under-report for
+  Swift. This is inherent to the SCIP spec, not a bug.
+
+Build/install it from source on a Mac: <https://github.com/phuongddx/scip-swift>
+
+## Automatic generation (opt-in)
+
+Normally you generate the index out-of-band (CI, a make target) and commit it.
+As a convenience, if `cairn.json` declares a SCIP index for a language but the
+**file is missing** and a known indexer binary is on `PATH`, `cairn build` will
+run the indexer once to produce it before importing. This is the one bounded
+exception to "cairn never generates indexes".
+
+- **Bounded.** An existing index is never rebuilt — the user (or CI) owns the
+  regeneration cadence. Generation triggers only when the index is configured
+  *and absent*.
+- **Silent fallback.** If the indexer is missing, fails, times out, or exits
+  nonzero, cairn logs it (visible under `cairn build -v`) and falls back to
+  tree-sitter for that language. A generation failure never breaks the build.
+
+Known indexers cairn can drive:
+
+| Language   | Tool              | Install / source                                            |
+|------------|-------------------|-------------------------------------------------------------|
+| `swift`    | `scip-swift`      | <https://github.com/phuongddx/scip-swift> (macOS/Xcode)     |
+| `kotlin`   | `scip-kotlin`     | <https://github.com/sourcegraph/scip-kotlin>                |
+| `typescript` | `scip-typescript` | <https://github.com/sourcegraph/scip-typescript>          |
+
+A committed or CI-produced index always wins — generation only fills gaps.
 
 ## 2. Declare it in `cairn.json`
 
@@ -132,6 +186,11 @@ scanner so SCIP rows land under the correct `(repo_id, repo-relative path)` —
 the same file identity the scanner and incremental path use. Indexes that omit
 `Metadata.project_root` fall back to treating paths as workspace-relative,
 which is correct only when paths happen to be workspace-relative.
+
+The `project_root` value is normalized before use, so different indexers'
+conventions all resolve correctly: plain absolute paths (scip-kotlin,
+scip-typescript), workspace-relative paths, and `file://`-prefixed URLs
+(scip-swift, which writes `URL(fileURLWithPath:).absoluteString`).
 
 ## Regenerating the vendored stub
 

--- a/docs/scip.md
+++ b/docs/scip.md
@@ -1,4 +1,4 @@
-# Hybrid SCIP / Tree-sitter Indexing
+# SCIP / Tree-sitter Coexistence Indexing
 
 cairn can consume pre-built **SCIP** (Sourcegraph Code Intelligence Protocol)
 indexes for languages where compiler-grade symbol bindings beat tree-sitter's
@@ -7,11 +7,21 @@ stays a **consumer** of SCIP indexes; it never generates them (with one bounded
 exception for a missing index — see [Automatic generation](#automatic-generation-opt-in)
 below).
 
-When an index is configured **and present**, `cairn build` skips tree-sitter
-parsing for that language and imports the SCIP data instead (exact resolution —
-every reference names the definition it points to). When the index is absent
-or undeclared, cairn falls back to tree-sitter for that language. Both can
-coexist in the same workspace.
+When an index is configured **and present**, `cairn build` runs **both**
+sources and merges them: tree-sitter parses every file (providing modifiers,
+body, inheritance edges, parent_scope that SCIP can't emit), then SCIP's
+exact-resolution call/reference edges and richer qualified_name are folded onto
+the tree-sitter symbol rows. The result is one row per symbol (`source='merged'`)
+carrying the strengths of both. When the index is absent or undeclared, cairn
+uses tree-sitter alone for that language.
+
+> **scip-swift limitation:** scip-swift uses opaque USRs (`` `s:...` ``) as
+> symbol names, which don't match tree-sitter's human-readable names. The merge
+> therefore can't fold scip-swift definitions into tree-sitter rows — Swift
+> SCIP data lands as standalone `source='scip'` rows alongside tree-sitter.
+> This is inherent to scip-swift's design (see its README "Known limitations").
+> Indexers with human-readable descriptors (scip-java, scip-typescript,
+> scip-python, scip-go) merge correctly.
 
 ## 1. Generate an index (out-of-band)
 

--- a/docs/scip.md
+++ b/docs/scip.md
@@ -18,18 +18,27 @@ coexist in the same workspace.
 Install the relevant compiler-backed indexer and point it at your repo:
 
 ```bash
-# Kotlin (scip-kotlin)
-scip-kotlin index --output build/scip/kotlin.scip .
+# Kotlin (scip-java — the canonical Java+Kotlin indexer; scip-kotlin is merged in)
+scip-java index --output build/scip/kotlin.scip
 
 # TypeScript (scip-typescript)
-scip-typescript index --output build/scip/typescript.scip .
+scip-typescript index --output build/scip/typescript.scip
 
 # Swift (scip-swift)
 scip-swift index /path/to/repo --output build/scip/swift.scip
+
+# Python (scip-python — npm package, not pip)
+scip-python index . --output=build/scip/python.scip
+
+# Go (scip-go)
+scip-go --output=build/scip/go.scip
+
+# Rust (rust-analyzer scip subcommand)
+rust-analyzer scip . --output build/scip/rust.scip
 ```
 
 See the [SCIP indexer list](https://github.com/sourcegraph/scip#indexers) for
-Java, Scala, Python, Go, Rust, etc. The output is a protobuf `.scip` file.
+Scala (via scip-java), and others. The output is a protobuf `.scip` file.
 
 > Commit the `.scip` file (or produce it in CI) — cairn reads it at build time
 > and never triggers regeneration.
@@ -75,11 +84,30 @@ exception to "cairn never generates indexes".
 
 Known indexers cairn can drive:
 
-| Language   | Tool              | Install / source                                            |
-|------------|-------------------|-------------------------------------------------------------|
-| `swift`    | `scip-swift`      | <https://github.com/phuongddx/scip-swift> (macOS/Xcode)     |
-| `kotlin`   | `scip-kotlin`     | <https://github.com/sourcegraph/scip-kotlin>                |
-| `typescript` | `scip-typescript` | <https://github.com/sourcegraph/scip-typescript>          |
+| Language     | Tool              | Install / source                                            |
+|--------------|-------------------|-------------------------------------------------------------|
+| `swift`      | `scip-swift`      | <https://github.com/phuongddx/scip-swift> (macOS/Xcode)     |
+| `java`       | `scip-java`       | <https://github.com/sourcegraph/scip-java> (Gradle/Maven)   |
+| `kotlin`     | `scip-java`       | same as Java — scip-kotlin is merged into scip-java         |
+| `typescript` | `scip-typescript` | <https://github.com/sourcegraph/scip-typescript>            |
+| `python`     | `scip-python`     | npm `@sourcegraph/scip-python`; <https://github.com/sourcegraph/scip-python> |
+| `go`         | `scip-go`         | `go install ...@latest`; <https://github.com/scip-code/scip-go> |
+| `rust`       | `rust-analyzer`   | `rust-analyzer scip` subcommand; <https://github.com/rust-lang/rust-analyzer> |
+
+> **Mixed Java + Kotlin projects.** `scip-java` is the canonical indexer for
+> *both* Java and Kotlin — one `scip-java index` run indexes mixed `.java` +
+> `.kt` sources into a single `.scip`, with each `Document.language` tagged per
+> source file. Declare both keys pointing at the same file:
+> `{"scip": {"java": "build/scip/jvm.scip", "kotlin": "build/scip/jvm.scip"}}`.
+> The orchestrator's idempotency check ensures the shared file is generated
+> once (whichever key runs first creates it; the second sees it exists and
+> skips).
+
+Languages without a usable single-binary SCIP indexer (Ruby, C/C++,
+Objective-C, C#, Haskell, OCaml) are not auto-generated; a committed index for
+them is still consumed unchanged. Dart and PHP indexers exist but lack an
+`--output` flag (they write `index.scip` in the CWD), so they aren't in the
+auto-generation registry — generate those out-of-band and commit the result.
 
 A committed or CI-produced index always wins — generation only fills gaps.
 

--- a/docs/scip.md
+++ b/docs/scip.md
@@ -17,11 +17,12 @@ uses tree-sitter alone for that language.
 
 > **scip-swift limitation:** scip-swift uses opaque USRs (`` `s:...` ``) as
 > symbol names, which don't match tree-sitter's human-readable names. The merge
-> therefore can't fold scip-swift definitions into tree-sitter rows — Swift
-> SCIP data lands as standalone `source='scip'` rows alongside tree-sitter.
-> This is inherent to scip-swift's design (see its README "Known limitations").
-> Indexers with human-readable descriptors (scip-java, scip-typescript,
-> scip-python, scip-go) merge correctly.
+> can't fold scip-swift definitions into tree-sitter rows, so the build
+> **detects the zero merge rate and reverts Swift to pure-SCIP** (removes the
+> tree-sitter rows, keeps only SCIP) — avoiding the duplicate-row problem that
+> would otherwise break `get_callers` for both name forms. Indexers with
+> human-readable descriptors (scip-java, scip-typescript, scip-python, scip-go)
+> merge correctly and keep the coexistence benefit (source='merged').
 
 ## 1. Generate an index (out-of-band)
 

--- a/src/cairn/graph/builder.py
+++ b/src/cairn/graph/builder.py
@@ -361,6 +361,17 @@ def _build_graph_impl(
             ws_root_cfg = Path(workspace).resolve()
             for lang, rel_path in cfg.scip.items():
                 idx_path = (ws_root_cfg / rel_path)
+                if not idx_path.exists():
+                    # Auto-generation (bounded): if a known indexer is on PATH,
+                    # produce the missing index once before the existence gate.
+                    # Never raises -- a missing/failing tool falls back to
+                    # tree-sitter for this language. An existing index is never
+                    # rebuilt (the user/CI owns the regeneration cadence).
+                    try:
+                        from ..parsers.scip_indexers import try_generate_index
+                        try_generate_index(lang, idx_path, workspace, log)
+                    except Exception as e:
+                        log(f"  scip[{lang}]: index generation skipped ({e})")
                 if idx_path.exists():
                     scip_languages[lang] = str(idx_path)
     except Exception:

--- a/src/cairn/graph/builder.py
+++ b/src/cairn/graph/builder.py
@@ -95,6 +95,23 @@ def _new_id() -> str:
     return uuid.uuid4().hex
 
 
+# File extensions per scanner language, used by the per-language SCIP fallback
+# to identify tree-sitter rows that should be removed when an indexer's names
+# don't match (e.g. scip-swift USRs). Inverse of scanner.EXTENSION_MAP.
+_LANGUAGE_EXTENSIONS_CACHE: Dict[str, list] = {}
+
+
+def _language_extensions(language: str) -> list:
+    """Return the file extensions (with leading dot) for a scanner language."""
+    if not _LANGUAGE_EXTENSIONS_CACHE:
+        try:
+            for ext, lang in scanner_mod.EXTENSION_MAP.items():
+                _LANGUAGE_EXTENSIONS_CACHE.setdefault(lang, []).append(ext)
+        except Exception:
+            pass
+    return _LANGUAGE_EXTENSIONS_CACHE.get(language, [])
+
+
 def _scan_workspace_with_skips(
     workspace: str, repo_filter: Optional[str] = None
 ) -> tuple[list, list]:
@@ -504,13 +521,68 @@ def _build_graph_impl(
                         )
                         scip_import_stats[lang] = s
                         log(f"  SCIP[{lang}]: {s.get('symbols_added',0)} symbols, "
-                            f"{s.get('edges_added',0)} edges")
+                            f"{s.get('edges_added',0)} edges, "
+                            f"{s.get('symbols_merged',0)} merged")
                     except Exception as e:
                         log(f"  SCIP[{lang}] import failed: {e}; skipping")
                         # Don't fail the build over a bad SCIP index.
         except ImportError:
             log("  SCIP indexes configured but [scip] extra not installed; "
                 "using tree-sitter fallback")
+
+    # Per-language fallback: if an indexer's symbol names don't match
+    # tree-sitter's (merge rate ~0, e.g. scip-swift's opaque USRs), the
+    # coexistence duplicates are harmful -- two disconnected graphs for the
+    # same logical symbol, and get_callers breaks for both name forms. Revert
+    # that language to pure-SCIP: delete the tree-sitter rows for its files so
+    # only the SCIP data remains (clean, no dupes). Languages whose indexers
+    # have human-readable descriptors (scip-java, scip-typescript) keep the
+    # coexistence merge (source='merged').
+    for lang, s in scip_import_stats.items():
+        added = s.get("symbols_added", 0)
+        merged = s.get("symbols_merged", 0)
+        if added > 0 and merged == 0:
+            # Nothing merged -- the two sources don't share a name space.
+            # Delete tree-sitter symbols/edges for this language's files so
+            # only SCIP remains (reverts to the pre-coexistence skip model).
+            exts = _language_extensions(lang)
+            if exts:
+                like_clause = " OR ".join("path LIKE ?" for _ in exts)
+                cur = conn.cursor()
+                ts_file_ids = [
+                    r[0] for r in cur.execute(
+                        f"SELECT id FROM files WHERE ({like_clause}) "
+                        f"AND hash != 'scip_imported'",
+                        tuple(f"%{e}" for e in exts),
+                    ).fetchall()
+                ]
+                if ts_file_ids:
+                    fid_placeholders = ",".join("?" for _ in ts_file_ids)
+                    fids = tuple(ts_file_ids)
+                    # Delete only TREE-SITTER symbols (source != 'scip'), NOT
+                    # SCIP's -- after file_id reconciliation they share the
+                    # same file row, so a blanket delete would nuke SCIP too.
+                    ts_sym_ids = [
+                        r[0] for r in cur.execute(
+                            f"SELECT id FROM symbols WHERE file_id IN ({fid_placeholders}) "
+                            f"AND source != 'scip'",
+                            fids,
+                        ).fetchall()
+                    ]
+                    if ts_sym_ids:
+                        sid_placeholders = ",".join("?" for _ in ts_sym_ids)
+                        cur.execute(
+                            f"DELETE FROM edges WHERE source_id IN ({sid_placeholders})",
+                            tuple(ts_sym_ids),
+                        )
+                        cur.execute(
+                            f"DELETE FROM symbols WHERE id IN ({sid_placeholders})",
+                            tuple(ts_sym_ids),
+                        )
+                    log(f"  SCIP[{lang}]: 0/{added} symbols merged (indexer names "
+                        f"don't match tree-sitter); reverted to pure-SCIP "
+                        f"(removed {len(ts_sym_ids)} tree-sitter symbols)")
+                    s["reverted_to_pure_scip"] = True
 
     if in_memory:
         # Close out the single implicit transaction that's been open across

--- a/src/cairn/graph/builder.py
+++ b/src/cairn/graph/builder.py
@@ -350,9 +350,11 @@ def _build_graph_impl(
     # reflects what was found, not the post-skip tree-sitter subset.
     scan_total = len(files)
 
-    # SCIP hybrid: if cairn.json declares a pre-built SCIP index for a language
-    # and that index file exists, skip tree-sitter parsing for that language's
-    # files. The importer runs post-resolve (below) to contribute exact edges.
+    # SCIP coexistence: if cairn.json declares a pre-built SCIP index for a
+    # language and that index file exists, tree-sitter STILL parses those files
+    # (providing modifiers, body, inheritance edges, parent_scope that SCIP
+    # can't emit). The importer then merges SCIP's exact-resolution edges onto
+    # the tree-sitter rows post-resolve (below). One row per symbol after merge.
     scip_languages: Dict[str, str] = {}
     try:
         from .config import load_config
@@ -380,8 +382,8 @@ def _build_graph_impl(
         scip_languages = {}
     if scip_languages:
         # Warn when a 'scip' key doesn't correspond to any known scanner
-        # language: such files won't be skipped, so the importer would double
-        # them up. Known = scanner extension map + languages actually scanned.
+        # language -- the importer won't find matching tree-sitter rows to
+        # merge into, so the index contributes standalone rows only.
         known_langs = set()
         try:
             known_langs.update(scanner_mod.EXTENSION_MAP.values())
@@ -391,10 +393,7 @@ def _build_graph_impl(
         unmatched = [k for k in scip_languages if k not in known_langs]
         if unmatched:
             log(f"  warning: cairn.json 'scip' keys not recognized as languages: {unmatched} "
-                f"(known: {sorted(known_langs)}). Tree-sitter will NOT be skipped for them.")
-        files = [f for f in files if f.language not in scip_languages]
-        if not files:
-            log("All scanned languages have SCIP indexes; skipping tree-sitter entirely.")
+                f"(known: {sorted(known_langs)}). SCIP data for them won't merge with tree-sitter.")
 
     emit("scan", files=scan_total, skips=len(skips))
 

--- a/src/cairn/parsers/scip_importer.py
+++ b/src/cairn/parsers/scip_importer.py
@@ -296,6 +296,19 @@ _TS_ONLY_EDGE_KINDS = ("implements", "extends")
 _REPLACEABLE_EDGE_KINDS = ("calls", "call", "reference", "import")
 
 
+def _normalize_name_for_match(name: str) -> str:
+    """Normalize a symbol name for cross-source matching.
+
+    SCIP descriptors for callables often carry a trailing ``()`` (e.g.
+    ``greet()`` from scip-java's semanticdb format), while tree-sitter extracts
+    the bare identifier (``greet``). Strip trailing parens so the two match.
+    scip-swift's opaque USRs (``\\`s:...\\``` ) won't match tree-sitter names
+    regardless -- that's an inherent scip-swift limitation (opaque symbol
+    identity), documented in the README.
+    """
+    return name.rstrip("()").rstrip(".") or name
+
+
 def _merge_scip_defs_into_tree_sitter(conn, scip_def_rows: list) -> int:
     """Fold each SCIP definition symbol into its matching tree-sitter row.
 
@@ -327,19 +340,21 @@ def _merge_scip_defs_into_tree_sitter(conn, scip_def_rows: list) -> int:
     cur = conn.cursor()
     merged = 0
     for scip_sym_id, file_id, name, sl in scip_def_rows:
+        # Normalize for matching: scip-java emits "greet()", tree-sitter "greet".
+        match_name = _normalize_name_for_match(name)
         # Match by (file_id, name, line_start); fall back to name-only if the
         # exact line disagrees (tree-sitter and SCIP can differ on where a
         # definition's anchor lands).
         ts_row = cur.execute(
             "SELECT id FROM symbols WHERE file_id = ? AND name = ? AND line_start = ? "
             "AND id != ? AND source != 'scip' LIMIT 1",
-            (file_id, name, sl, scip_sym_id),
+            (file_id, match_name, sl, scip_sym_id),
         ).fetchone()
         if ts_row is None:
             ts_row = cur.execute(
                 "SELECT id FROM symbols WHERE file_id = ? AND name = ? "
                 "AND id != ? AND source != 'scip' LIMIT 1",
-                (file_id, name, scip_sym_id),
+                (file_id, match_name, scip_sym_id),
             ).fetchone()
         if ts_row is None:
             continue  # no tree-sitter match -- leave the standalone SCIP row

--- a/src/cairn/parsers/scip_importer.py
+++ b/src/cairn/parsers/scip_importer.py
@@ -124,6 +124,37 @@ def _enclosing_range(occ) -> Optional[Tuple[int, int, int, int]]:
     return (sl, sc, sl, er[2] if len(er) > 2 else sc)
 
 
+# --- language inference from path -------------------------------------------
+# Some indexers emit an empty Document.language (scip-java 0.10.4 leaves it
+# blank for both Java and Kotlin docs). The hybrid skip logic and downstream
+# tooling key off files.language, so fall back to the file extension when the
+# document doesn't declare one. Covers the languages cairn's scanner knows.
+_EXT_LANGUAGE: Dict[str, str] = {
+    ".swift": "swift", ".kt": "kotlin", ".kts": "kotlin",
+    ".java": "java", ".py": "python", ".ts": "typescript", ".tsx": "typescript",
+    ".mts": "typescript", ".cts": "typescript", ".js": "javascript",
+    ".jsx": "javascript", ".mjs": "javascript", ".cjs": "javascript",
+    ".dart": "dart", ".go": "go", ".rs": "rust",
+    ".c": "c", ".h": "c", ".cpp": "cpp", ".hpp": "cpp", ".cc": "cpp",
+    ".cxx": "cpp", ".m": "objc", ".mm": "objc",
+}
+
+
+def _language_for(rel_path: str, declared: str) -> str:
+    """Resolve a document's language, falling back to the file extension.
+
+    Real indexers don't all populate ``Document.language``: scip-java 0.10.4
+    leaves it empty for both Java and Kotlin, so the importer would store
+    ``'scip'`` and the hybrid skip logic couldn't tell those files apart.
+    Derive from the extension when the declared value is empty, and normalize
+    case (scip-swift emits ``"Swift"``; scanner keys are lowercase).
+    """
+    if declared:
+        return declared.lower()
+    suffix = Path(rel_path).suffix.lower()
+    return _EXT_LANGUAGE.get(suffix, "scip")
+
+
 # --- kind mapping -----------------------------------------------------------
 
 # Coarse SyntaxKind -> cairn kind. Graph traversal keys on edges, not kinds;
@@ -303,7 +334,7 @@ def _import_protobuf(conn, index, repo_id: str, ws_root: Optional[Path] = None) 
     # Pass 2: emit symbols + edges.
     for i, doc in enumerate(index.documents):
         doc_repo, rel = doc_paths[i]
-        lang = getattr(doc, "language", "") or ""
+        lang = _language_for(rel, getattr(doc, "language", "") or "")
         file_id = f"{doc_repo}:{rel}"
 
         # repos + files: INSERT OR IGNORE so we never overwrite tree-sitter
@@ -372,6 +403,16 @@ def _import_protobuf(conn, index, repo_id: str, ws_root: Optional[Path] = None) 
                     if dline <= el_start:
                         source_id = did
                         break
+
+            # A file-level occurrence with no enclosing definition (top-level
+            # code in a Swift main.swift, a reference before any definition,
+            # etc.) has no owning symbol to attribute the edge to. Skip it --
+            # the tree-sitter path does the same (builder: "file-level call
+            # with no owning symbol; cannot attach"). edges.source_id is NOT
+            # NULL, so a NULL here would crash the import (found against real
+            # scip-swift output).
+            if source_id is None:
+                continue
 
             # Classify edge kind from roles.
             if occ.symbol_roles & _SCIP_ROLE_IMPORT:
@@ -464,7 +505,7 @@ def import_scip_data(conn: sqlite3.Connection, scip_dict: Dict[str, Any], repo_i
         rel = doc.get("relative_path") or doc.get("path")
         if not rel:
             continue
-        lang = doc.get("language") or "scip"
+        lang = _language_for(rel, doc.get("language") or "")
         file_id = f"{repo_id}:{rel}"
 
         cur.execute(
@@ -519,6 +560,9 @@ def import_scip_data(conn: sqlite3.Connection, scip_dict: Dict[str, Any], repo_i
                 if dline <= sl:
                     source_id = did
                     break
+            # No enclosing definition -> no owning symbol (see proto path).
+            if source_id is None:
+                continue
             if roles & _SCIP_ROLE_IMPORT:
                 edge_kind = "import"
             elif roles & _SCIP_ROLE_ACCESS_MASK:

--- a/src/cairn/parsers/scip_importer.py
+++ b/src/cairn/parsers/scip_importer.py
@@ -140,6 +140,27 @@ _EXT_LANGUAGE: Dict[str, str] = {
 }
 
 
+def _resolve_real_file_id(conn, repo: str, rel: str, fallback: str) -> str:
+    """Return the file row id SCIP symbols/edges should reference.
+
+    In a coexistence build, tree-sitter parses every file first and creates a
+    ``files`` row with a uuid ``id`` and a real hash (``hash != 'scip_imported'``).
+    SCIP must link its symbols/edges to THAT row so JOINs work and the two
+    sources share one file identity. If no tree-sitter row exists (the
+    standalone ``import-scip`` escape hatch against a fresh DB), fall back to
+    the deterministic ``{repo}:{rel}`` shadow id and let the caller insert it.
+    """
+    try:
+        row = conn.execute(
+            "SELECT id FROM files WHERE repo_id = ? AND path = ? AND hash != 'scip_imported' "
+            "ORDER BY id LIMIT 1",
+            (repo, rel),
+        ).fetchone()
+    except Exception:
+        row = None
+    return row[0] if row else fallback
+
+
 def _language_for(rel_path: str, declared: str) -> str:
     """Resolve a document's language, falling back to the file extension.
 
@@ -309,13 +330,18 @@ def _import_protobuf(conn, index, repo_id: str, ws_root: Optional[Path] = None) 
     # same descriptor; a forward decl only fills in the map when no real def is
     # seen, so references still resolve without spurious symbol rows.
     doc_paths: Dict[int, Tuple[str, str]] = {}
+    doc_file_ids: Dict[int, str] = {}
     defs: Dict[str, Tuple[str, str, int, int]] = {}
     real_defs: set = set()
     for i, doc in enumerate(index.documents):
         rel = doc.relative_path
         doc_repo, rel_to_repo = _resolve_doc_path(rel, ws_root, repo_id, project_root=project_root)
         doc_paths[i] = (doc_repo, rel_to_repo)
-        file_id = f"{doc_repo}:{rel_to_repo}"
+        # Coexistence: link to the tree-sitter file row if it exists so both
+        # sources share one file identity (JOINs work, incremental clears both).
+        doc_file_ids[i] = _resolve_real_file_id(
+            conn, doc_repo, rel_to_repo, f"{doc_repo}:{rel_to_repo}")
+        file_id = doc_file_ids[i]
         for occ in doc.occurrences:
             roles = occ.symbol_roles
             if not (roles & (_SCIP_ROLE_DEFINITION | _SCIP_ROLE_FORWARD_DEFINITION)):
@@ -335,10 +361,12 @@ def _import_protobuf(conn, index, repo_id: str, ws_root: Optional[Path] = None) 
     for i, doc in enumerate(index.documents):
         doc_repo, rel = doc_paths[i]
         lang = _language_for(rel, getattr(doc, "language", "") or "")
-        file_id = f"{doc_repo}:{rel}"
+        file_id = doc_file_ids[i]
 
         # repos + files: INSERT OR IGNORE so we never overwrite tree-sitter
-        # metadata (hash/line_count/size/mtime).
+        # metadata (hash/line_count/size/mtime). When coexisting with
+        # tree-sitter, file_id already points at the real row and this is a
+        # no-op; in standalone mode it inserts the shadow row.
         cur.execute(
             "INSERT OR IGNORE INTO repos (id, name, path) VALUES (?, ?, ?)",
             (doc_repo, doc_repo, "."),

--- a/src/cairn/parsers/scip_importer.py
+++ b/src/cairn/parsers/scip_importer.py
@@ -192,6 +192,46 @@ def _resolve_doc_path(
     return repo, rel_to_repo
 
 
+def _normalize_project_root(raw_root: str, ws_root: Path) -> Path:
+    """Normalize ``Metadata.project_root`` into an absolute ``Path``.
+
+    Real indexers use different conventions here:
+
+    - scip-swift writes a ``file://`` URL (it does
+      ``URL(fileURLWithPath: repoPath).absoluteString``), e.g.
+      ``file:///Users/me/repo``.
+    - scip-kotlin / scip-typescript emit a plain absolute path.
+    - Some emit a path relative to the workspace.
+
+    ``Path("file:///abs").is_absolute()`` is ``False`` (the ``file://`` prefix
+    isn't a POSIX path marker), so without scheme handling the old inline
+    expression joined the URL verbatim onto ``ws_root`` and produced garbage,
+    silently mis-attributing every document. Strip any ``file://`` scheme first,
+    then resolve absolute vs. relative exactly as before.
+    """
+    from urllib.parse import urlparse
+    from urllib.request import url2pathname
+
+    root = raw_root.strip()
+    if root.startswith("file:"):
+        parsed = urlparse(root)
+        # urlparse("file:///a/b") -> scheme="file", netloc="", path="/a/b"
+        # urlparse("file://localhost/a/b") -> netloc="localhost", path="/a/b"
+        host = parsed.netloc or parsed.hostname or ""
+        path = url2pathname(parsed.path)
+        if host and host not in ("localhost", ""):
+            # A non-empty non-localhost host is a network URL we can't map to a
+            # local path; fall back to resolving the raw value below.
+            local = None
+        else:
+            local = path
+        if local:
+            return Path(local).resolve()
+    if Path(root).is_absolute():
+        return Path(root).resolve()
+    return (ws_root / root).resolve()
+
+
 # --- protobuf import --------------------------------------------------------
 
 def _import_protobuf(conn, index, repo_id: str, ws_root: Optional[Path] = None) -> dict:
@@ -217,7 +257,7 @@ def _import_protobuf(conn, index, repo_id: str, ws_root: Optional[Path] = None) 
         meta = getattr(index, "metadata", None)
         raw_root = getattr(meta, "project_root", None) if meta is not None else None
         if raw_root:
-            project_root = (ws_root / raw_root).resolve() if not Path(raw_root).is_absolute() else Path(raw_root)
+            project_root = _normalize_project_root(raw_root, ws_root)
 
     # Pre-index SymbolInformation.documentation by descriptor for docstring
     # attachment on definition symbols.

--- a/src/cairn/parsers/scip_importer.py
+++ b/src/cairn/parsers/scip_importer.py
@@ -284,6 +284,111 @@ def _normalize_project_root(raw_root: str, ws_root: Path) -> Path:
     return (ws_root / root).resolve()
 
 
+# --- coexistence merge ------------------------------------------------------
+
+# Edge kinds tree-sitter emits that SCIP has no equivalent for. These survive
+# the merge (SCIP replaces only call/reference/import edges; inheritance edges
+# from tree-sitter are kept since SCIP's role bitmask has no inheritance bit).
+_TS_ONLY_EDGE_KINDS = ("implements", "extends")
+
+# Edge kinds the merge replaces: tree-sitter's calls (fuzzy resolution) are
+# dropped in favor of SCIP's call/reference/import edges (exact resolution).
+_REPLACEABLE_EDGE_KINDS = ("calls", "call", "reference", "import")
+
+
+def _merge_scip_defs_into_tree_sitter(conn, scip_def_rows: list) -> int:
+    """Fold each SCIP definition symbol into its matching tree-sitter row.
+
+    Coexistence model: tree-sitter parses every file (rich metadata), then SCIP
+    imports exact-resolution edges. To get one row per symbol carrying both,
+    each SCIP definition is matched to a tree-sitter symbol by
+    ``(file_id, name, line_start)`` (falling back to name-only if the line
+    disagrees). On a match:
+
+    1. UPDATE the tree-sitter symbol: adopt SCIP's richer ``qualified_name``,
+       ``docstring`` (when SCIP has one), and mark ``source='merged'``.
+       Tree-sitter's ``modifiers``, ``body``, ``parent_scope``,
+       ``imports_summary``, ``parameters``, ``return_type``, ``metadata`` are
+       preserved (SCIP doesn't populate them).
+    2. DELETE tree-sitter's calls/reference/import edges for that symbol
+       (fuzzy resolution) -- SCIP's exact edges (already INSERT OR REPLACE'd)
+       take over. ``implements``/``extends`` edges survive (SCIP can't emit
+       inheritance).
+    3. DELETE the SCIP shadow symbol row -- its data now lives on the merged
+       tree-sitter row.
+
+    Unmatched SCIP definitions (no tree-sitter row, e.g. a symbol tree-sitter's
+    grammar missed) are left as standalone ``source='scip'`` rows.
+
+    Returns the number of definitions merged.
+    """
+    if not scip_def_rows:
+        return 0
+    cur = conn.cursor()
+    merged = 0
+    for scip_sym_id, file_id, name, sl in scip_def_rows:
+        # Match by (file_id, name, line_start); fall back to name-only if the
+        # exact line disagrees (tree-sitter and SCIP can differ on where a
+        # definition's anchor lands).
+        ts_row = cur.execute(
+            "SELECT id FROM symbols WHERE file_id = ? AND name = ? AND line_start = ? "
+            "AND id != ? AND source != 'scip' LIMIT 1",
+            (file_id, name, sl, scip_sym_id),
+        ).fetchone()
+        if ts_row is None:
+            ts_row = cur.execute(
+                "SELECT id FROM symbols WHERE file_id = ? AND name = ? "
+                "AND id != ? AND source != 'scip' LIMIT 1",
+                (file_id, name, scip_sym_id),
+            ).fetchone()
+        if ts_row is None:
+            continue  # no tree-sitter match -- leave the standalone SCIP row
+
+        ts_sym_id = ts_row[0]
+
+        # 1. Enrich the tree-sitter symbol with SCIP's higher-fidelity fields.
+        cur.execute(
+            "SELECT qualified_name, docstring FROM symbols WHERE id = ?",
+            (scip_sym_id,),
+        )
+        scip_data = cur.fetchone()
+        if scip_data:
+            scip_qn, scip_doc = scip_data
+            # COALESCE: keep tree-sitter's docstring if SCIP didn't carry one.
+            cur.execute(
+                """UPDATE symbols SET
+                     qualified_name = COALESCE(?, qualified_name),
+                     docstring = COALESCE(?, docstring),
+                     source = 'merged'
+                   WHERE id = ?""",
+                (scip_qn, scip_doc, ts_sym_id),
+            )
+
+        # 2. Drop tree-sitter's fuzzy call/reference edges for this symbol
+        #    FIRST, then re-point SCIP's exact edges from the shadow symbol to
+        #    the merged row. Order matters: the DELETE must run before the
+        #    re-point, otherwise the re-pointed SCIP edge (kind='call') gets
+        #    caught by the kind-IN-(calls,call,...) delete.
+        placeholders = ",".join("?" for _ in _REPLACEABLE_EDGE_KINDS)
+        cur.execute(
+            f"DELETE FROM edges WHERE source_id = ? AND kind IN ({placeholders})",
+            (ts_sym_id, *_REPLACEABLE_EDGE_KINDS),
+        )
+        cur.execute(
+            "UPDATE edges SET source_id = ? WHERE source_id = ?",
+            (ts_sym_id, scip_sym_id),
+        )
+        cur.execute(
+            "UPDATE edges SET target_id = ? WHERE target_id = ?",
+            (ts_sym_id, scip_sym_id),
+        )
+
+        # 3. Remove the now-merged SCIP shadow row.
+        cur.execute("DELETE FROM symbols WHERE id = ?", (scip_sym_id,))
+        merged += 1
+    return merged
+
+
 # --- protobuf import --------------------------------------------------------
 
 def _import_protobuf(conn, index, repo_id: str, ws_root: Optional[Path] = None) -> dict:
@@ -298,6 +403,10 @@ def _import_protobuf(conn, index, repo_id: str, ws_root: Optional[Path] = None) 
     """
     cur = conn.cursor()
     files_added = symbols_added = edges_added = 0
+
+    # Track SCIP definition rows inserted during Pass 2 so the merge pass can
+    # fold each into its matching tree-sitter symbol (coexistence model).
+    scip_def_rows: list[tuple] = []  # (scip_sym_id, file_id, name, line_start)
 
     # Real indexers emit Document.relative_path relative to their OWN
     # Metadata.project_root (the repo dir), not the workspace root. Read it once
@@ -408,6 +517,7 @@ def _import_protobuf(conn, index, repo_id: str, ws_root: Optional[Path] = None) 
                     )
                     if cur.rowcount > 0:
                         symbols_added += 1
+                        scip_def_rows.append((sym_id, file_id, name, sl))
                 file_defs_by_line.append((sl, sym_id))
                 continue
 
@@ -460,8 +570,18 @@ def _import_protobuf(conn, index, repo_id: str, ws_root: Optional[Path] = None) 
             if cur.rowcount > 0:
                 edges_added += 1
 
+    # Coexistence merge: fold each SCIP definition into its matching tree-sitter
+    # symbol so one row carries both sources' strengths (tree-sitter's
+    # modifiers/body/parent_scope + SCIP's exact edges/richer qualified_name).
+    merged = _merge_scip_defs_into_tree_sitter(conn, scip_def_rows)
+
     conn.commit()
-    return {"files_added": files_added, "symbols_added": symbols_added, "edges_added": edges_added}
+    return {
+        "files_added": files_added,
+        "symbols_added": symbols_added,
+        "edges_added": edges_added,
+        "symbols_merged": merged,
+    }
 
 
 # --- public API -------------------------------------------------------------

--- a/src/cairn/parsers/scip_indexers.py
+++ b/src/cairn/parsers/scip_indexers.py
@@ -1,0 +1,178 @@
+"""Generic SCIP indexer orchestrator.
+
+cairn is a *consumer* of SCIP indexes, never a producer -- indexes are generated
+out-of-band (CI, a make target) by compiler-grade indexers and pointed at via
+``cairn.json``. This module is the one bounded exception: during ``cairn build``,
+if a language declares a SCIP index in ``cairn.json`` but the index file is
+*missing* and a known indexer binary is on PATH, the orchestrator runs the
+indexer once to produce the file. It then hands off to the existing importer.
+
+Design rules (matching cairn's "never break the build over an external tool"
+discipline -- see ``utils/git.py`` and the SCIP import hook in ``builder.py``):
+
+- **Auto but bounded**: generation triggers only when the index is configured
+  *and absent*. An existing index is never rebuilt -- the user (or CI) owns the
+  regeneration cadence. Re-running a full compiler build on every ``cairn
+  build`` would be unreasonable.
+- **Never raises**: a missing binary, a nonzero exit, an OS error, or a timeout
+  is logged (visible under ``-v``) and falls back to tree-sitter. The caller's
+  ``if idx_path.exists()`` gate then naturally skips the language.
+- **No language-specific code**: each known indexer is an :class:`IndexerSpec`
+  row in a registry keyed by language. Swift is one entry alongside Kotlin and
+  TypeScript; adding another (Java, Python, Go, Rust) is one line.
+"""
+from __future__ import annotations
+
+import shutil
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, Dict, List, Optional
+
+# A build is the heavyweight step (full Swift/Xcode compile, ts-server crawl).
+# Give it generous headroom without blocking a build indefinitely.
+_INDEX_TIMEOUT_S = 30 * 60
+
+
+@dataclass(frozen=True)
+class IndexerSpec:
+    """How to invoke one known SCIP indexer for a language.
+
+    Attributes:
+        language: scanner language name (must match a ``cairn.json`` scip key),
+            e.g. ``"swift"``.
+        tool: the binary name looked up on PATH, e.g. ``"scip-swift"``.
+        build_command: ``(repo_path, output_path) -> argv list``. Each indexer
+            has a slightly different argument order, so the command is built
+            per-spec rather than templated.
+        install_hint: surfaced in verbose logs when the tool is missing, so the
+            user knows where to get it.
+    """
+
+    language: str
+    tool: str
+    build_command: Callable[[str, str], List[str]]
+    install_hint: str
+
+
+def _swift_cmd(repo: str, out: str) -> List[str]:
+    # scip-swift: `scip-swift index <repo> --output <out>` (defaultSubcommand).
+    return ["scip-swift", "index", repo, "--output", out]
+
+
+def _kotlin_cmd(repo: str, out: str) -> List[str]:
+    # scip-kotlin: `scip-kotlin index --output <out> <repo>`.
+    return ["scip-kotlin", "index", "--output", out, repo]
+
+
+def _typescript_cmd(repo: str, out: str) -> List[str]:
+    # scip-typescript: `scip-typescript index --output <out> <repo>`.
+    return ["scip-typescript", "index", "--output", out, repo]
+
+
+# Registry of indexers cairn knows how to drive. Keyed by the scanner language
+# name (the same string used as a ``cairn.json`` ``scip`` key), so a config like
+# ``{"scip": {"swift": "build/scip/swift.scip"}}`` looks up the swift spec.
+# Languages not in this map simply aren't auto-generated; a committed index for
+# them is still consumed unchanged.
+_KNOWN_INDEXERS: Dict[str, IndexerSpec] = {
+    "swift": IndexerSpec(
+        language="swift",
+        tool="scip-swift",
+        build_command=_swift_cmd,
+        install_hint=(
+            "scip-swift is the SCIP indexer for Swift. Build it from source on a "
+            "Mac (macOS/Xcode only): https://github.com/phuongddx/scip-swift"
+        ),
+    ),
+    "kotlin": IndexerSpec(
+        language="kotlin",
+        tool="scip-kotlin",
+        build_command=_kotlin_cmd,
+        install_hint=(
+            "scip-kotlin is the SCIP indexer for Kotlin. "
+            "See https://github.com/sourcegraph/scip-kotlin"
+        ),
+    ),
+    "typescript": IndexerSpec(
+        language="typescript",
+        tool="scip-typescript",
+        build_command=_typescript_cmd,
+        install_hint=(
+            "scip-typescript is the SCIP indexer for TypeScript/JavaScript. "
+            "See https://github.com/sourcegraph/scip-typescript"
+        ),
+    ),
+}
+
+
+def known_languages() -> List[str]:
+    """Languages for which cairn can auto-generate a missing index."""
+    return sorted(_KNOWN_INDEXERS)
+
+
+def spec_for(language: str) -> Optional[IndexerSpec]:
+    """Return the registered indexer spec for a language, or ``None``."""
+    return _KNOWN_INDEXERS.get(language)
+
+
+def try_generate_index(
+    language: str,
+    output_path: Path,
+    repo_path: str,
+    log: Callable[..., None] = lambda *a, **k: None,
+) -> bool:
+    """Generate a missing SCIP index if a known indexer is installed.
+
+    Returns ``True`` iff the index file now exists at ``output_path``. **Never
+    raises** -- a missing/failing/timeout indexer logs (visible under ``-v``)
+    and returns ``False``, so the caller's existence gate falls back to
+    tree-sitter for that language. Mirrors the discipline of
+    :func:`utils.git._run_git` and the SCIP import hook.
+
+    ``output_path``'s parent directory is created if needed; the indexer is
+    responsible for writing the file there.
+    """
+    spec = spec_for(language)
+    if spec is None:
+        # Not a known language -- nothing to auto-generate. A committed index
+        # for it is still consumed; this path just isn't one cairn can produce.
+        return False
+
+    if output_path.exists():
+        # Already present (caller normally checks this first, but be idempotent
+        # in case of a race or a direct call): never rebuild an existing index.
+        return True
+
+    if not shutil.which(spec.tool):
+        log(f"  scip[{language}]: index missing and '{spec.tool}' not on PATH; "
+            f"{spec.install_hint}")
+        return False
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    cmd = spec.build_command(repo_path, str(output_path))
+    log(f"  scip[{language}]: generating index with {spec.tool} -> {output_path}")
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=_INDEX_TIMEOUT_S,
+        )
+    except (subprocess.SubprocessError, OSError) as e:
+        # FileNotFoundError (subclass of OSError) covers a binary that vanished
+        # between the shutil.which probe and exec; TimeoutExpired is a
+        # SubprocessError subclass. All degrade identically: log + fallback.
+        log(f"  scip[{language}]: {spec.tool} invocation failed ({e}); "
+            f"falling back to tree-sitter")
+        return False
+
+    if result.returncode != 0 or not output_path.exists():
+        tail = (result.stderr or "").strip().splitlines()[-5:]
+        log(f"  scip[{language}]: {spec.tool} exited {result.returncode} "
+            f"without producing an index; falling back to tree-sitter")
+        if tail:
+            log("    " + "\n    ".join(tail))
+        return False
+
+    return True

--- a/src/cairn/parsers/scip_indexers.py
+++ b/src/cairn/parsers/scip_indexers.py
@@ -60,14 +60,38 @@ def _swift_cmd(repo: str, out: str) -> List[str]:
     return ["scip-swift", "index", repo, "--output", out]
 
 
-def _kotlin_cmd(repo: str, out: str) -> List[str]:
-    # scip-kotlin: `scip-kotlin index --output <out> <repo>`.
-    return ["scip-kotlin", "index", "--output", out, repo]
+def _scip_java_cmd(repo: str, out: str) -> List[str]:
+    # scip-java: `scip-java index --output <out>` run from the project root.
+    # scip-java is the canonical indexer for BOTH Java and Kotlin (the old
+    # scip-kotlin has been merged in and is no longer maintained); one run
+    # indexes mixed .java + .kt sources into a single index, with per-document
+    # language tagged per source file. A cairn.json that declares both
+    # {"java": X, "kotlin": X} pointing at the same file indexes both.
+    return ["scip-java", "index", "--output", out]
 
 
-def _typescript_cmd(repo: str, out: str) -> List[str]:
-    # scip-typescript: `scip-typescript index --output <out> <repo>`.
-    return ["scip-typescript", "index", "--output", out, repo]
+def _scip_typescript_cmd(repo: str, out: str) -> List[str]:
+    # scip-typescript: `scip-typescript index --output <out>` (run from project
+    # root; auto-discovers tsconfig / infers one for JS).
+    return ["scip-typescript", "index", "--output", out]
+
+
+def _scip_python_cmd(repo: str, out: str) -> List[str]:
+    # scip-python: `scip-python index . --output=<out>`. Distributed via npm
+    # (@sourcegraph/scip-python), not pip -- it's a Node program (pyright fork).
+    return ["scip-python", "index", repo, f"--output={out}"]
+
+
+def _scip_go_cmd(repo: str, out: str) -> List[str]:
+    # scip-go: `scip-go --output=<out>` (no `index` subcommand; lsif-go is the
+    # deprecated LSIF emitter). Run from the dir containing go.mod.
+    return ["scip-go", f"--output={out}"]
+
+
+def _scip_rust_cmd(repo: str, out: str) -> List[str]:
+    # rust-analyzer's `scip` subcommand: `rust-analyzer scip <path> --output <out>`.
+    # (scip-code/scip-rust is a thin wrapper around this.)
+    return ["rust-analyzer", "scip", repo, "--output", out]
 
 
 # Registry of indexers cairn knows how to drive. Keyed by the scanner language
@@ -75,6 +99,17 @@ def _typescript_cmd(repo: str, out: str) -> List[str]:
 # ``{"scip": {"swift": "build/scip/swift.scip"}}`` looks up the swift spec.
 # Languages not in this map simply aren't auto-generated; a committed index for
 # them is still consumed unchanged.
+#
+# CLI shapes verified against each indexer's README / --help (see docs/scip.md
+# "Automatic generation" for the full table). Two entries can point at the same
+# binary: `java` and `kotlin` both use scip-java, which indexes mixed
+# Java+Kotlin projects in one run and tags each Document's language per file.
+_SCIP_JAVA_HINT = (
+    "scip-java is the canonical SCIP indexer for Java AND Kotlin (the old "
+    "scip-kotlin has been merged in). It requires a Gradle or Maven build. "
+    "See https://github.com/sourcegraph/scip-java"
+)
+
 _KNOWN_INDEXERS: Dict[str, IndexerSpec] = {
     "swift": IndexerSpec(
         language="swift",
@@ -85,22 +120,57 @@ _KNOWN_INDEXERS: Dict[str, IndexerSpec] = {
             "Mac (macOS/Xcode only): https://github.com/phuongddx/scip-swift"
         ),
     ),
+    "java": IndexerSpec(
+        language="java",
+        tool="scip-java",
+        build_command=_scip_java_cmd,
+        install_hint=_SCIP_JAVA_HINT,
+    ),
     "kotlin": IndexerSpec(
         language="kotlin",
-        tool="scip-kotlin",
-        build_command=_kotlin_cmd,
-        install_hint=(
-            "scip-kotlin is the SCIP indexer for Kotlin. "
-            "See https://github.com/sourcegraph/scip-kotlin"
-        ),
+        tool="scip-java",  # scip-kotlin is superseded; scip-java indexes Kotlin.
+        build_command=_scip_java_cmd,
+        install_hint=_SCIP_JAVA_HINT,
     ),
     "typescript": IndexerSpec(
         language="typescript",
         tool="scip-typescript",
-        build_command=_typescript_cmd,
+        build_command=_scip_typescript_cmd,
         install_hint=(
             "scip-typescript is the SCIP indexer for TypeScript/JavaScript. "
             "See https://github.com/sourcegraph/scip-typescript"
+        ),
+    ),
+    "python": IndexerSpec(
+        language="python",
+        tool="scip-python",
+        build_command=_scip_python_cmd,
+        install_hint=(
+            "scip-python is the SCIP indexer for Python. It's an npm package "
+            "(@sourcegraph/scip-python), not pip: "
+            "`npm install -g @sourcegraph/scip-python`. "
+            "See https://github.com/sourcegraph/scip-python"
+        ),
+    ),
+    "go": IndexerSpec(
+        language="go",
+        tool="scip-go",
+        build_command=_scip_go_cmd,
+        install_hint=(
+            "scip-go is the SCIP indexer for Go (lsif-go is the deprecated LSIF "
+            "emitter). Install: "
+            "`go install github.com/scip-code/scip-go/cmd/scip-go@latest`. "
+            "See https://github.com/scip-code/scip-go"
+        ),
+    ),
+    "rust": IndexerSpec(
+        language="rust",
+        tool="rust-analyzer",
+        build_command=_scip_rust_cmd,
+        install_hint=(
+            "rust-analyzer's `scip` subcommand indexes Rust. Install "
+            "rust-analyzer via your toolchain or rustup. "
+            "See https://github.com/rust-lang/rust-analyzer"
         ),
     ),
 }

--- a/tests/test_build_scip_hybrid.py
+++ b/tests/test_build_scip_hybrid.py
@@ -129,3 +129,75 @@ def test_no_config_is_pure_tree_sitter(tmp_path):
     assert "scip" not in sources
     assert "scip" not in summary
     conn.close()
+
+
+def test_build_auto_generates_missing_index(tmp_path, monkeypatch):
+    """A declared-but-absent index is auto-generated before the skip gate.
+
+    Verifies the orchestrator hook fires inside _build_graph_impl: when
+    cairn.json declares a language whose index file does NOT exist, cairn
+    invokes the registered indexer to produce it, and the freshly-generated
+    index is then imported (source='scip') instead of falling back to
+    tree-sitter. Monkeypatches the orchestrator so no real binary is needed.
+    """
+    ws = _make_workspace(tmp_path, "scip_autogen")
+    (ws / "cairn.json").write_text(
+        json.dumps({"scip": {"kotlin": "build/scip/kotlin.scip"}})
+    )
+    # The index is deliberately NOT created -- the orchestrator should make it.
+
+    from cairn.parsers import scip_indexers
+
+    def fake_generate(language, output_path, repo_path, log=lambda *a, **k: None):
+        # Simulate scip-kotlin writing the index file.
+        Path(output_path).parent.mkdir(parents=True, exist_ok=True)
+        Path(output_path).write_bytes(_kotlin_index())
+        return True
+
+    monkeypatch.setattr(scip_indexers, "try_generate_index", fake_generate)
+
+    db = str(tmp_path / "scip_autogen.db")
+    summary = build_graph(workspace=str(ws), db_path=db)
+
+    import sqlite3
+    conn = sqlite3.connect(db)
+    conn.row_factory = sqlite3.Row
+    # The auto-generated index was imported: the symbol carries source='scip'.
+    scip_sym = conn.execute(
+        "SELECT source FROM symbols WHERE name = 'Foo'"
+    ).fetchone()
+    assert scip_sym is not None
+    assert scip_sym["source"] == "scip", "auto-generated index was not imported"
+    assert "scip" in summary and "kotlin" in summary["scip"]
+    conn.close()
+
+
+def test_build_generation_failure_falls_back_to_tree_sitter(tmp_path, monkeypatch):
+    """If the orchestrator fails to produce the index, tree-sitter is used.
+
+    The hook never raises, so a failed generation must degrade to the existing
+    "missing index" path rather than breaking the build.
+    """
+    ws = _make_workspace(tmp_path, "scip_autogen_fail")
+    (ws / "cairn.json").write_text(
+        json.dumps({"scip": {"kotlin": "build/scip/kotlin.scip"}})
+    )
+
+    from cairn.parsers import scip_indexers
+
+    def failing_generate(language, output_path, repo_path, log=lambda *a, **k: None):
+        return False  # simulate a missing/failing indexer
+
+    monkeypatch.setattr(scip_indexers, "try_generate_index", failing_generate)
+
+    db = str(tmp_path / "scip_autogen_fail.db")
+    summary = build_graph(workspace=str(ws), db_path=db)
+
+    import sqlite3
+    conn = sqlite3.connect(db)
+    conn.row_factory = sqlite3.Row
+    # No index produced -> Foo came from tree-sitter, no SCIP data.
+    foo = conn.execute("SELECT source FROM symbols WHERE name = 'Foo'").fetchone()
+    assert foo["source"] == "tree_sitter"
+    assert "scip" not in summary
+    conn.close()

--- a/tests/test_build_scip_hybrid.py
+++ b/tests/test_build_scip_hybrid.py
@@ -1,10 +1,12 @@
-"""Tests for the hybrid SCIP / tree-sitter build path.
+"""Tests for the SCIP / tree-sitter coexistence build path.
 
 Verifies that when ``cairn.json`` declares a SCIP index for a language and the
 index file exists:
-  - tree-sitter parsing is SKIPPED for that language's files,
-  - the SCIP importer runs post-resolve and contributes source='scip' symbols,
-  - a missing index file falls back to tree-sitter for that language.
+  - tree-sitter STILL parses those files (providing modifiers, body, inheritance),
+  - the SCIP importer runs post-resolve and merges exact-resolution edges onto
+    the tree-sitter symbol rows (source='merged'),
+  - a missing index file falls back to pure tree-sitter for that language,
+  - the auto-generation orchestrator fires before the existence gate.
 
 Skipped when the optional ``[scip]`` extra isn't installed.
 """
@@ -29,15 +31,15 @@ def _make_workspace(tmp_path: Path, name: str) -> Path:
     ws = tmp_path / name
     repo = ws / "demo"
     (repo / ".git").mkdir(parents=True)
-    # A Kotlin file (would be tree-sitter-parsed without SCIP) + a Python file
-    # (always tree-sitter; no SCIP index declared for python).
+    # A Kotlin file (tree-sitter-parsed AND SCIP-merged) + a Python file
+    # (always tree-sitter only; no SCIP index declared for python).
     (repo / "Foo.kt").write_text("class Foo { fun go() {} }\n")
     (repo / "bar.py").write_text("def bar():\n    pass\n")
     return ws
 
 
 def _kotlin_index() -> bytes:
-    """A minimal real SCIP protobuf index with one Kotlin symbol."""
+    """A minimal real SCIP protobuf index with one Kotlin symbol (Foo)."""
     from cairn.parsers import _scip_pb2  # deferred: see module-level note
 
     idx = _scip_pb2.Index()
@@ -48,56 +50,56 @@ def _kotlin_index() -> bytes:
     occ.symbol = "scip-kotlin com example Foo#"
     occ.symbol_roles = 1  # Definition
     occ.syntax_kind = 19  # IdentifierType -> class
-    occ.single_line_range.line = 0
+    occ.single_line_range.line = 0  # 0-based -> 1-based line 1 (matches TS)
     occ.single_line_range.start_character = 6
     occ.single_line_range.end_character = 9
     return idx.SerializeToString()
 
 
-def test_scip_language_skips_tree_sitter(tmp_path):
-    """Files whose language has a present SCIP index are NOT tree-sitter-parsed."""
-    ws = _make_workspace(tmp_path, "scip_skip")
+def test_scip_coexists_with_tree_sitter(tmp_path):
+    """Both sources run: tree-sitter provides structure, SCIP merges exact edges.
+
+    The Foo symbol ends up source='merged' -- one row carrying tree-sitter's
+    kind ('class') AND SCIP's richer qualified_name. Python (no SCIP index)
+    stays pure tree-sitter.
+    """
+    ws = _make_workspace(tmp_path, "scip_coexist")
     (ws / "build" / "scip").mkdir(parents=True)
     (ws / "build" / "scip" / "kotlin.scip").write_bytes(_kotlin_index())
     (ws / "cairn.json").write_text(json.dumps({"scip": {"kotlin": "build/scip/kotlin.scip"}}))
 
-    db = str(tmp_path / "scip_skip.db")
+    db = str(tmp_path / "scip_coexist.db")
     summary = build_graph(workspace=str(ws), db_path=db)
 
-    # The SCIP symbol is present with source='scip'.
     import sqlite3
     conn = sqlite3.connect(db)
     conn.row_factory = sqlite3.Row
-    scip_syms = conn.execute(
-        "SELECT name, source FROM symbols WHERE source = 'scip'"
-    ).fetchall()
-    assert len(scip_syms) == 1
-    assert scip_syms[0]["name"] == "Foo"
 
-    # No tree-sitter symbol named 'Foo' (the .kt file was skipped). The Kotlin
-    # class would otherwise produce a tree_sitter 'Foo' symbol too.
-    ts_foo = conn.execute(
-        "SELECT source FROM symbols WHERE name = 'Foo' AND source != 'scip'"
+    # Foo is merged: one row, source='merged', tree-sitter kind preserved.
+    foo_rows = conn.execute(
+        "SELECT name, source, kind FROM symbols WHERE name = 'Foo'"
     ).fetchall()
-    assert ts_foo == [], "Kotlin file was tree-sitter-parsed despite SCIP index"
+    assert len(foo_rows) == 1, f"expected 1 merged Foo, got {len(foo_rows)}"
+    assert foo_rows[0]["source"] == "merged"
+    assert foo_rows[0]["kind"] == "class"  # tree-sitter kind preserved
 
     # Python still went through tree-sitter (no SCIP index for it).
-    ts_bar = conn.execute(
+    bar = conn.execute(
         "SELECT source FROM symbols WHERE name = 'bar'"
-    ).fetchall()
-    assert len(ts_bar) == 1
-    assert ts_bar[0]["source"] == "tree_sitter"
+    ).fetchone()
+    assert bar is not None
+    assert bar["source"] == "tree_sitter"
 
-    # Summary carries the SCIP import stats.
+    # Summary carries the SCIP import + merge stats.
     assert "scip" in summary
     assert "kotlin" in summary["scip"]
+    assert summary["scip"]["kotlin"]["symbols_merged"] >= 1
     conn.close()
 
 
-def test_missing_index_falls_back_to_tree_sitter(tmp_path):
-    """An absent index file (declared but not present) falls back to tree-sitter."""
+def test_missing_index_falls_back_to_pure_tree_sitter(tmp_path):
+    """An absent index file (declared but not present) -> pure tree-sitter."""
     ws = _make_workspace(tmp_path, "scip_missing")
-    # Declare kotlin but DON'T create the file.
     (ws / "cairn.json").write_text(json.dumps({"scip": {"kotlin": "build/scip/absent.scip"}}))
 
     db = str(tmp_path / "scip_missing.db")
@@ -106,11 +108,8 @@ def test_missing_index_falls_back_to_tree_sitter(tmp_path):
     import sqlite3
     conn = sqlite3.connect(db)
     conn.row_factory = sqlite3.Row
-    # No SCIP data (file was absent) -> Foo came from tree-sitter.
-    foo = conn.execute("SELECT source FROM symbols WHERE name = 'Foo'").fetchall()
-    assert len(foo) == 1
-    assert foo[0]["source"] == "tree_sitter"
-    # No SCIP stats in summary (nothing imported).
+    foo = conn.execute("SELECT source FROM symbols WHERE name = 'Foo'").fetchone()
+    assert foo["source"] == "tree_sitter"
     assert "scip" not in summary
     conn.close()
 
@@ -125,31 +124,26 @@ def test_no_config_is_pure_tree_sitter(tmp_path):
     conn = sqlite3.connect(db)
     conn.row_factory = sqlite3.Row
     sources = {r["source"] for r in conn.execute("SELECT DISTINCT source FROM symbols").fetchall()}
-    # No 'scip'; legacy NULLs treated as tree_sitter but new builds tag it.
     assert "scip" not in sources
+    assert "merged" not in sources
     assert "scip" not in summary
     conn.close()
 
 
 def test_build_auto_generates_missing_index(tmp_path, monkeypatch):
-    """A declared-but-absent index is auto-generated before the skip gate.
+    """A declared-but-absent index is auto-generated, then merged with tree-sitter.
 
-    Verifies the orchestrator hook fires inside _build_graph_impl: when
-    cairn.json declares a language whose index file does NOT exist, cairn
-    invokes the registered indexer to produce it, and the freshly-generated
-    index is then imported (source='scip') instead of falling back to
-    tree-sitter. Monkeypatches the orchestrator so no real binary is needed.
+    The orchestrator fires before the existence gate, produces the index, and
+    the coexistence merge folds it into the tree-sitter row (source='merged').
     """
     ws = _make_workspace(tmp_path, "scip_autogen")
     (ws / "cairn.json").write_text(
         json.dumps({"scip": {"kotlin": "build/scip/kotlin.scip"}})
     )
-    # The index is deliberately NOT created -- the orchestrator should make it.
 
     from cairn.parsers import scip_indexers
 
     def fake_generate(language, output_path, repo_path, log=lambda *a, **k: None):
-        # Simulate scip-kotlin writing the index file.
         Path(output_path).parent.mkdir(parents=True, exist_ok=True)
         Path(output_path).write_bytes(_kotlin_index())
         return True
@@ -162,22 +156,15 @@ def test_build_auto_generates_missing_index(tmp_path, monkeypatch):
     import sqlite3
     conn = sqlite3.connect(db)
     conn.row_factory = sqlite3.Row
-    # The auto-generated index was imported: the symbol carries source='scip'.
-    scip_sym = conn.execute(
-        "SELECT source FROM symbols WHERE name = 'Foo'"
-    ).fetchone()
-    assert scip_sym is not None
-    assert scip_sym["source"] == "scip", "auto-generated index was not imported"
+    foo = conn.execute("SELECT source FROM symbols WHERE name = 'Foo'").fetchone()
+    assert foo is not None
+    assert foo["source"] == "merged", "auto-generated index should merge with tree-sitter"
     assert "scip" in summary and "kotlin" in summary["scip"]
     conn.close()
 
 
 def test_build_generation_failure_falls_back_to_tree_sitter(tmp_path, monkeypatch):
-    """If the orchestrator fails to produce the index, tree-sitter is used.
-
-    The hook never raises, so a failed generation must degrade to the existing
-    "missing index" path rather than breaking the build.
-    """
+    """If the orchestrator fails to produce the index, pure tree-sitter is used."""
     ws = _make_workspace(tmp_path, "scip_autogen_fail")
     (ws / "cairn.json").write_text(
         json.dumps({"scip": {"kotlin": "build/scip/kotlin.scip"}})
@@ -186,7 +173,7 @@ def test_build_generation_failure_falls_back_to_tree_sitter(tmp_path, monkeypatc
     from cairn.parsers import scip_indexers
 
     def failing_generate(language, output_path, repo_path, log=lambda *a, **k: None):
-        return False  # simulate a missing/failing indexer
+        return False
 
     monkeypatch.setattr(scip_indexers, "try_generate_index", failing_generate)
 
@@ -196,7 +183,6 @@ def test_build_generation_failure_falls_back_to_tree_sitter(tmp_path, monkeypatc
     import sqlite3
     conn = sqlite3.connect(db)
     conn.row_factory = sqlite3.Row
-    # No index produced -> Foo came from tree-sitter, no SCIP data.
     foo = conn.execute("SELECT source FROM symbols WHERE name = 'Foo'").fetchone()
     assert foo["source"] == "tree_sitter"
     assert "scip" not in summary

--- a/tests/test_build_scip_hybrid.py
+++ b/tests/test_build_scip_hybrid.py
@@ -187,3 +187,58 @@ def test_build_generation_failure_falls_back_to_tree_sitter(tmp_path, monkeypatc
     assert foo["source"] == "tree_sitter"
     assert "scip" not in summary
     conn.close()
+
+
+def test_unmatched_indexer_names_revert_to_pure_scip(tmp_path):
+    """When an indexer's names don't match tree-sitter (e.g. scip-swift USRs),
+    coexistence duplicates are harmful -- the two sources form disconnected
+    graphs and get_callers breaks for both. The build detects the zero-merge
+    rate and reverts that language to pure-SCIP (removes tree-sitter symbols,
+    keeps SCIP intact).
+
+    This simulates scip-swift's opaque USRs by using a descriptor whose
+    _short_name doesn't match tree-sitter's bare 'Foo'.
+    """
+    from cairn.parsers import _scip_pb2
+
+    ws = _make_workspace(tmp_path, "scip_unmatched")
+    (ws / "build" / "scip").mkdir(parents=True)
+
+    # A Kotlin index where the symbol name is an opaque ID (like a USR),
+    # NOT matching tree-sitter's bare 'Foo'.
+    idx = _scip_pb2.Index()
+    doc = idx.documents.add()
+    doc.relative_path = "demo/Foo.kt"
+    doc.language = "kotlin"
+    occ = doc.occurrences.add()
+    occ.symbol = "scip-kotlin com example `opaque_id_xyz`."  # short name = opaque_id_xyz
+    occ.symbol_roles = 1
+    occ.syntax_kind = 19
+    occ.single_line_range.line = 0
+    occ.single_line_range.start_character = 6
+    occ.single_line_range.end_character = 9
+    (ws / "build" / "scip" / "kotlin.scip").write_bytes(idx.SerializeToString())
+    (ws / "cairn.json").write_text(json.dumps({"scip": {"kotlin": "build/scip/kotlin.scip"}}))
+
+    db = str(tmp_path / "scip_unmatched.db")
+    summary = build_graph(workspace=str(ws), db_path=db)
+
+    import sqlite3
+    conn = sqlite3.connect(db)
+    conn.row_factory = sqlite3.Row
+
+    # The fallback fired: reverted_to_pure_scip is set.
+    assert summary["scip"]["kotlin"].get("reverted_to_pure_scip") is True
+
+    # No tree-sitter symbols remain for Kotlin (the 'Foo' that tree-sitter
+    # would have produced is gone). Only the standalone SCIP symbol survives.
+    ts_foo = conn.execute(
+        "SELECT COUNT(*) AS n FROM symbols WHERE name = 'Foo'"
+    ).fetchone()
+    assert ts_foo["n"] == 0, "tree-sitter Foo should be removed (pure-SCIP)"
+
+    scip_sym = conn.execute(
+        "SELECT source FROM symbols WHERE source = 'scip'"
+    ).fetchall()
+    assert len(scip_sym) >= 1, "SCIP symbol should survive the revert"
+    conn.close()

--- a/tests/test_scip_importer.py
+++ b/tests/test_scip_importer.py
@@ -257,3 +257,112 @@ def test_json_exact_when_definition_present():
     import_scip_data(conn, payload, repo_id="default")
     edge = conn.execute("SELECT resolution FROM edges WHERE target_name = 'helper'").fetchone()
     assert edge["resolution"] == "exact"
+
+
+# ---------------------------------------------------------------------------
+# project_root resolution (multi-repo path normalization)
+# ---------------------------------------------------------------------------
+# These are the only tests that pass ws_root to import_scip_bytes, so they
+# exercise the Metadata.project_root -> (repo_id, repo-relative) mapping that
+# the build-integrated path relies on. scip-swift writes project_root as a
+# file:// URL; without scheme handling the path joined garbage onto ws_root and
+# every document was silently mis-attributed.
+
+def _index_with_project_root(raw_root: str):
+    """Minimal index with one definition, metadata.project_root set to raw_root.
+
+    Document.relative_path is repo-relative ("demo/Foo.swift"); project_root
+    names the repo root so the importer should resolve the document under the
+    correct (repo_id, repo-relative path).
+    """
+    idx = _scip_pb2.Index()
+    idx.metadata.project_root = raw_root
+    doc = idx.documents.add()
+    doc.relative_path = "demo/Foo.swift"
+    doc.language = "swift"
+    occ = doc.occurrences.add()
+    occ.symbol = "scip-swift swift demo Greeter#"
+    occ.symbol_roles = 1  # Definition
+    occ.syntax_kind = 19  # IdentifierType -> class
+    occ.single_line_range.line = 0
+    occ.single_line_range.start_character = 6
+    occ.single_line_range.end_character = 13
+    return idx
+
+
+def test_project_root_file_url_resolves(tmp_path):
+    """scip-swift's file://-prefixed project_root must resolve to the real repo.
+
+    Regression: Path("file:///abs").is_absolute() is False, so the old inline
+    expression joined the URL onto ws_root and the document landed under the
+    fallback repo id with a broken path.
+    """
+    ws = tmp_path / "ws"
+    repo = ws / "demo"
+    (repo / ".git").mkdir(parents=True)
+
+    idx = _index_with_project_root(f"file://{repo}/")
+    conn = _conn()
+    import_scip_bytes(
+        conn, idx.SerializeToString(),
+        repo_id="default", ws_root=ws.resolve(),
+    )
+
+    # The file row's repo_id is the inferred repo ("demo"), NOT "default",
+    # and its path is repo-relative ("demo/Foo.swift"), proving the file://
+    # URL was stripped and resolved against the workspace.
+    row = conn.execute("SELECT repo_id, path FROM files").fetchone()
+    assert row["repo_id"] == "demo"
+    assert row["path"] == "demo/Foo.swift"
+
+
+def test_project_root_file_url_localhost_resolves(tmp_path):
+    """The file://localhost/ host form resolves the same way."""
+    ws = tmp_path / "ws"
+    repo = ws / "demo"
+    (repo / ".git").mkdir(parents=True)
+
+    idx = _index_with_project_root(f"file://localhost{repo}/")
+    conn = _conn()
+    import_scip_bytes(
+        conn, idx.SerializeToString(),
+        repo_id="default", ws_root=ws.resolve(),
+    )
+    row = conn.execute("SELECT repo_id, path FROM files").fetchone()
+    assert row["repo_id"] == "demo"
+    assert row["path"] == "demo/Foo.swift"
+
+
+def test_project_root_plain_absolute_resolves(tmp_path):
+    """A plain absolute path (scip-kotlin/scip-typescript convention) resolves."""
+    ws = tmp_path / "ws"
+    repo = ws / "demo"
+    (repo / ".git").mkdir(parents=True)
+
+    idx = _index_with_project_root(str(repo))
+    conn = _conn()
+    import_scip_bytes(
+        conn, idx.SerializeToString(),
+        repo_id="default", ws_root=ws.resolve(),
+    )
+    row = conn.execute("SELECT repo_id, path FROM files").fetchone()
+    assert row["repo_id"] == "demo"
+    assert row["path"] == "demo/Foo.swift"
+
+
+def test_project_root_relative_to_ws_resolves(tmp_path):
+    """A project_root relative to ws_root joins onto ws_root (single-repo case)."""
+    ws = tmp_path / "ws"
+    # Single-repo workspace: the repo IS the workspace root.
+    (ws / ".git").mkdir(parents=True)
+
+    idx = _index_with_project_root(".")  # relative -> ws_root
+    idx.documents[0].relative_path = "TopLevel.swift"
+    conn = _conn()
+    import_scip_bytes(
+        conn, idx.SerializeToString(),
+        repo_id="default", ws_root=ws.resolve(),
+    )
+    row = conn.execute("SELECT path FROM files").fetchone()
+    assert row["path"] == "TopLevel.swift"
+

--- a/tests/test_scip_importer.py
+++ b/tests/test_scip_importer.py
@@ -366,3 +366,123 @@ def test_project_root_relative_to_ws_resolves(tmp_path):
     row = conn.execute("SELECT path FROM files").fetchone()
     assert row["path"] == "TopLevel.swift"
 
+
+# ---------------------------------------------------------------------------
+# source_id NOT NULL: file-level occurrences with no enclosing definition
+# ---------------------------------------------------------------------------
+# Found against REAL scip-swift output: a Swift main.swift has top-level code
+# (let g = Greeter(...); print(g.greet())) where references to stdlib symbols
+# (print, String interpolation) appear before any enclosing definition. The
+# importer used to insert these with source_id=NULL, crashing on the NOT NULL
+# FK on edges.source_id. Now they're skipped (matching tree-sitter's behavior).
+
+def test_protobuf_file_level_occurrence_without_enclosing_def_is_skipped():
+    """An occurrence with no enclosing definition must not crash (NOT NULL FK).
+
+    Regression: a reference at the top of a file (before any definition, or in
+    a file with only top-level code) has no source symbol. edges.source_id is
+    NOT NULL, so inserting it crashed the whole import. Now skipped, matching
+    the tree-sitter path's "file-level call with no owning symbol" handling.
+    """
+    idx = _scip_pb2.Index()
+    doc = idx.documents.add()
+    doc.relative_path = "main.swift"
+    doc.language = "swift"
+    # A definition on line 5...
+    _occ(doc, "scip-swift swift main Greeter#", roles=1, syntax_kind=19,
+         line=4, start=7, end=14)
+    # ...and a reference on line 0 (BEFORE the definition, so no preceding def).
+    # No enclosing_range is set, so source_id stays None.
+    _occ(doc, "scip-swift swift . print()", roles=0, line=0, start=0, end=5)
+    # (deliberately leave enclosing_range unset)
+
+    conn = _conn()
+    # Must not raise IntegrityError (NOT NULL constraint).
+    stats = import_scip_bytes(conn, idx.SerializeToString(), repo_id="demo")
+    # The definition symbol is imported; the orphan reference is skipped.
+    assert stats["symbols_added"] == 1
+    # The print() reference had no enclosing def -> skipped, not stored.
+    orphan = conn.execute(
+        "SELECT COUNT(*) AS n FROM edges WHERE target_name = 'print()'"
+    ).fetchone()
+    assert orphan["n"] == 0
+
+
+def test_json_file_level_occurrence_without_enclosing_def_is_skipped():
+    """Same regression guard for the JSON path."""
+    payload = {
+        "documents": [{
+            "relative_path": "main.swift", "language": "swift",
+            "occurrences": [
+                # Definition on line 3 (0-based 2).
+                {"symbol": "scip-swift swift main Foo#", "symbol_roles": 1,
+                 "range": [2, 0, 3]},
+                # Reference on line 1 (0-based 0) -- before any definition.
+                {"symbol": "scip-swift swift . bar()", "symbol_roles": 0,
+                 "range": [0, 0, 3]},
+            ],
+        }]
+    }
+    conn = _conn()
+    # Must not raise.
+    import_scip_data(conn, payload, repo_id="demo")
+    orphan = conn.execute(
+        "SELECT COUNT(*) AS n FROM edges WHERE target_name = 'bar()'"
+    ).fetchone()
+    assert orphan["n"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Language inference: empty Document.language falls back to file extension
+# ---------------------------------------------------------------------------
+# Found against REAL scip-java 0.10.4 output: it emits language='' for both
+# Java and Kotlin documents. Without extension-based fallback the importer
+# stored 'scip', breaking the hybrid skip logic (which keys off files.language).
+
+def test_language_inferred_from_extension_when_document_omits_it():
+    """An empty Document.language is derived from the file extension.
+
+    scip-java 0.10.4 leaves language blank; the importer must still tag Java
+    files 'java' and Kotlin files 'kotlin' so the hybrid skip + downstream
+    tooling work.
+    """
+    idx = _scip_pb2.Index()
+    for rel, lang in [("src/Main.java", ""), ("src/Foo.kt", "")]:
+        doc = idx.documents.add()
+        doc.relative_path = rel
+        doc.language = lang  # empty -- the bug case
+        _occ(doc, f"semanticdb maven . . {rel}#Bar", roles=1, syntax_kind=19,
+             line=0)
+    conn = _conn()
+    import_scip_bytes(conn, idx.SerializeToString(), repo_id="demo")
+    langs = {r["path"]: r["language"] for r in conn.execute(
+        "SELECT path, language FROM files").fetchall()}
+    assert langs["src/Main.java"] == "java"
+    assert langs["src/Foo.kt"] == "kotlin"
+
+
+def test_language_normalized_to_lowercase():
+    """scip-swift emits 'Swift' (capitalized); scanner keys are lowercase."""
+    idx = _scip_pb2.Index()
+    doc = idx.documents.add()
+    doc.relative_path = "Sources/App/main.swift"
+    doc.language = "Swift"  # capitalized, as scip-swift actually emits
+    _occ(doc, "scip-swift swift main App#", roles=1, syntax_kind=19, line=0)
+    conn = _conn()
+    import_scip_bytes(conn, idx.SerializeToString(), repo_id="demo")
+    row = conn.execute("SELECT language FROM files").fetchone()
+    assert row["language"] == "swift"
+
+
+def test_language_falls_back_to_scip_for_unknown_extension():
+    """An unrecognized extension with no declared language stays 'scip'."""
+    idx = _scip_pb2.Index()
+    doc = idx.documents.add()
+    doc.relative_path = "weird.xyz"
+    doc.language = ""
+    _occ(doc, "scip-unknown unknown main Foo#", roles=1, syntax_kind=19, line=0)
+    conn = _conn()
+    import_scip_bytes(conn, idx.SerializeToString(), repo_id="demo")
+    row = conn.execute("SELECT language FROM files").fetchone()
+    assert row["language"] == "scip"
+

--- a/tests/test_scip_importer.py
+++ b/tests/test_scip_importer.py
@@ -184,6 +184,47 @@ def test_protobuf_does_not_clobber_existing_tree_sitter_rows():
     assert row["line_count"] == 42
 
 
+def test_protobuf_reuses_tree_sitter_file_id_when_coexisting():
+    """In coexistence mode, SCIP symbols link to the existing tree-sitter file row.
+
+    Tree-sitter creates file rows with uuid ids and a real hash; SCIP's id
+    format is ``{repo}:{rel}``. Without reconciliation, SCIP's INSERT OR IGNORE
+    no-ops on UNIQUE(repo_id, path) and SCIP symbols dangle off a non-existent
+    file_id, silently vanishing from every JOIN. The importer must look up the
+    real tree-sitter row and use ITS id.
+    """
+    conn = _conn()
+    conn.execute("INSERT INTO repos (id, name, path) VALUES ('demo','demo','.')")
+    # Tree-sitter creates this with a uuid id (not the {repo}:{rel} format).
+    ts_file_id = "a1b2c3d4e5f6"  # uuid-like, NOT "demo:src/Foo.swift"
+    conn.execute(
+        "INSERT INTO files (id, path, repo_id, hash, line_count, language) "
+        "VALUES (?, 'src/Foo.swift', 'demo', 'ts_hash_123', 10, 'swift')",
+        (ts_file_id,),
+    )
+    conn.commit()
+
+    idx = _scip_pb2.Index()
+    doc = idx.documents.add()
+    doc.relative_path = "src/Foo.swift"
+    doc.language = "swift"
+    _occ(doc, "scip-swift swift demo Foo#", roles=1, syntax_kind=19,
+         line=0, start=6, end=9)
+
+    import_scip_bytes(conn, idx.SerializeToString(), repo_id="demo")
+
+    # The SCIP symbol must reference the TREE-SITTER file id, not a shadow.
+    sym = conn.execute("SELECT file_id FROM symbols").fetchone()
+    assert sym["file_id"] == ts_file_id, (
+        "SCIP symbol should link to the tree-sitter file row, not a shadow"
+    )
+    # Only ONE file row exists (no duplicate shadow).
+    files = conn.execute(
+        "SELECT id FROM files WHERE path = 'src/Foo.swift'"
+    ).fetchall()
+    assert len(files) == 1
+
+
 def test_import_scip_file_proto_and_json(tmp_path):
     """import_scip_file reads both formats via the fmt flag."""
     # Proto

--- a/tests/test_scip_importer.py
+++ b/tests/test_scip_importer.py
@@ -225,6 +225,127 @@ def test_protobuf_reuses_tree_sitter_file_id_when_coexisting():
     assert len(files) == 1
 
 
+# ---------------------------------------------------------------------------
+# Coexistence merge: tree-sitter metadata + SCIP exact edges in one row
+# ---------------------------------------------------------------------------
+# The core feature: when both sources cover a file, the SCIP definition is
+# folded into the tree-sitter symbol. One row carries tree-sitter's modifiers/
+# body/parent_scope + SCIP's richer qualified_name and exact-resolution edges.
+
+def test_merge_folds_scip_definition_into_tree_sitter_symbol():
+    """A SCIP definition matching a tree-sitter symbol enriches it, not duplicates.
+
+    After merge: one symbol row (source='merged') with tree-sitter's modifiers
+    preserved and SCIP's qualified_name adopted. Tree-sitter call edges for the
+    symbol are replaced by SCIP's exact edges; inheritance edges survive.
+    """
+    conn = _conn()
+    conn.execute("INSERT INTO repos (id, name, path) VALUES ('demo','demo','.')")
+    conn.execute(
+        "INSERT INTO files (id, path, repo_id, hash, line_count, language) "
+        "VALUES ('ts-file-1', 'Foo.swift', 'demo', 'ts_hash', 10, 'swift')"
+    )
+    # Tree-sitter symbol with metadata SCIP can't provide.
+    conn.execute(
+        "INSERT INTO symbols (id, file_id, name, qualified_name, kind, "
+        "line_start, line_end, column_start, column_end, modifiers, source) "
+        "VALUES ('ts-sym-1', 'ts-file-1', 'Greeter', 'Greeter', 'class', "
+        "1, 5, 6, 13, '[\"public\",\"final\"]', 'tree_sitter')"
+    )
+    # Tree-sitter call edge (fuzzy resolution) + inheritance edge (SCIP can't emit).
+    conn.execute(
+        "INSERT INTO edges (id, source_id, target_name, kind, line, resolution) "
+        "VALUES ('ts-edge-1', 'ts-sym-1', 'helper', 'calls', 3, 'ambiguous')"
+    )
+    conn.execute(
+        "INSERT INTO edges (id, source_id, target_name, kind, line) "
+        "VALUES ('ts-edge-2', 'ts-sym-1', 'Base', 'implements', 1)"
+    )
+    conn.commit()
+
+    # SCIP index: same definition + an exact-resolution call edge.
+    idx = _scip_pb2.Index()
+    doc = idx.documents.add()
+    doc.relative_path = "Foo.swift"
+    doc.language = "swift"
+    # Definition at line 1 (matches tree-sitter's line_start=1).
+    _occ(doc, "scip-swift swift demo Greeter#", roles=1, syntax_kind=19,
+         line=0, start=6, end=13)  # 0-based line 0 = 1-based line 1
+    # Exact call edge inside Greeter.
+    ref = _occ(doc, "scip-swift swift demo helper#", roles=0, line=2, start=4, end=10)
+    ref.multi_line_enclosing_range.start_line = 0
+    ref.multi_line_enclosing_range.start_character = 0
+    ref.multi_line_enclosing_range.end_line = 5
+    ref.multi_line_enclosing_range.end_character = 0
+
+    stats = import_scip_bytes(conn, idx.SerializeToString(), repo_id="demo")
+    assert stats["symbols_merged"] == 1
+
+    # One symbol row, source='merged', carrying tree-sitter's modifiers.
+    syms = conn.execute(
+        "SELECT source, modifiers, qualified_name FROM symbols WHERE name = 'Greeter'"
+    ).fetchall()
+    assert len(syms) == 1, f"expected 1 merged row, got {len(syms)}"
+    assert syms[0]["source"] == "merged"
+    assert syms[0]["modifiers"] == '["public","final"]'  # tree-sitter preserved
+    assert "scip-swift" in syms[0]["qualified_name"]  # SCIP adopted
+
+    # Tree-sitter call edge replaced; inheritance edge survived.
+    edges = conn.execute(
+        "SELECT kind, resolution FROM edges WHERE source_id = 'ts-sym-1'"
+    ).fetchall()
+    kinds = {e["kind"] for e in edges}
+    assert "implements" in kinds, "inheritance edge must survive merge"
+    # The fuzzy 'calls' edge is gone; SCIP's exact 'call' edge took over.
+    assert "calls" not in kinds, "tree-sitter calls edge should be replaced"
+    assert "call" in kinds, "SCIP exact call edge should be present"
+
+
+def test_merge_preserves_tree_sitter_docstring_when_scip_has_none():
+    """If SCIP doesn't carry a docstring, tree-sitter's survives (COALESCE)."""
+    conn = _conn()
+    conn.execute("INSERT INTO repos (id, name, path) VALUES ('demo','demo','.')")
+    conn.execute(
+        "INSERT INTO files (id, path, repo_id, hash, line_count, language) "
+        "VALUES ('ts-f', 'Bar.kt', 'demo', 'h', 5, 'kotlin')"
+    )
+    conn.execute(
+        "INSERT INTO symbols (id, file_id, name, qualified_name, kind, "
+        "line_start, modifiers, docstring, source) "
+        "VALUES ('ts-b', 'ts-f', 'Bar', 'Bar', 'class', 1, '[]', 'TS doc', 'tree_sitter')"
+    )
+    conn.commit()
+
+    idx = _scip_pb2.Index()
+    doc = idx.documents.add()
+    doc.relative_path = "Bar.kt"
+    doc.language = "kotlin"
+    _occ(doc, "scip-kotlin com example Bar#", roles=1, syntax_kind=19, line=0)
+
+    import_scip_bytes(conn, idx.SerializeToString(), repo_id="demo")
+    row = conn.execute("SELECT docstring FROM symbols WHERE name = 'Bar'").fetchone()
+    assert row["docstring"] == "TS doc"  # tree-sitter's docstring preserved
+
+
+def test_unmatched_scip_definition_left_as_standalone():
+    """A SCIP def with no tree-sitter match stays source='scip' (not lost)."""
+    conn = _conn()
+    conn.execute("INSERT INTO repos (id, name, path) VALUES ('demo','demo','.')")
+    conn.execute(
+        "INSERT INTO files (id, path, repo_id, hash, line_count, language) "
+        "VALUES ('ts-f', 'Baz.swift', 'demo', 'h', 5, 'swift')"
+    )
+    conn.commit()
+    # No tree-sitter symbol for "Baz" -- SCIP's row should stand alone.
+    idx = _scip_pb2.Index()
+    doc = idx.documents.add()
+    doc.relative_path = "Baz.swift"
+    _occ(doc, "scip-swift swift demo Baz#", roles=1, syntax_kind=19, line=0)
+    import_scip_bytes(conn, idx.SerializeToString(), repo_id="demo")
+    row = conn.execute("SELECT source FROM symbols WHERE name = 'Baz'").fetchone()
+    assert row["source"] == "scip"  # standalone, not merged
+
+
 def test_import_scip_file_proto_and_json(tmp_path):
     """import_scip_file reads both formats via the fmt flag."""
     # Proto

--- a/tests/test_scip_incremental.py
+++ b/tests/test_scip_incremental.py
@@ -1,11 +1,12 @@
-"""Tests for SCIP-aware incremental reindexing.
+"""Tests for SCIP-aware incremental reindexing under the coexistence model.
 
-Per docs/scip-hybrid-plan.md §Incremental updates: when a file that was
-originally SCIP-sourced is edited, ``reindex_paths`` falls back to tree-sitter
-for that single file (same as the "missing index" fallback), tagging it
-``source='tree_sitter'``. The next full ``cairn build`` restores
-``source='scip'`` once the out-of-band index is regenerated -- a bounded,
-self-healing staleness window rather than a silent permanent downgrade.
+In coexistence, tree-sitter always runs (providing modifiers/body/inheritance),
+and SCIP merges exact-resolution edges onto the tree-sitter rows at build time
+(source='merged'). When a file is edited, ``reindex_paths`` re-parses just that
+file with tree-sitter (source='tree_sitter') -- the SCIP merge doesn't run for
+a single-file incremental update, so the symbol temporarily loses its merged
+status. The next full ``cairn build`` re-imports SCIP and re-merges, restoring
+source='merged' -- a bounded, self-healing staleness window.
 
 Skipped when the optional ``[scip]`` extra isn't installed.
 """
@@ -43,8 +44,14 @@ def _kotlin_index() -> bytes:
     return idx.SerializeToString()
 
 
-def test_reindex_of_scip_file_falls_back_to_tree_sitter(tmp_path):
-    """Editing a SCIP-covered file re-parses it as source='tree_sitter'."""
+def test_reindex_of_merged_file_falls_back_to_tree_sitter(tmp_path):
+    """Editing a coexistence file re-parses it as source='tree_sitter'.
+
+    The incremental path re-parses only with tree-sitter (the SCIP merge runs
+    at full-build time, not per-file). So after reindex the symbol is
+    temporarily tree_sitter-only -- the merged status is restored on the next
+    full build.
+    """
     ws = tmp_path / "ws"
     repo = ws / "demo"
     (repo / ".git").mkdir(parents=True)
@@ -60,31 +67,30 @@ def test_reindex_of_scip_file_falls_back_to_tree_sitter(tmp_path):
     from cairn.graph.schema import get_db
     conn = get_db(db)
     try:
-        # Initially Foo is SCIP-sourced.
+        # Initially Foo is merged (tree-sitter + SCIP).
         before = conn.execute(
             "SELECT source FROM symbols WHERE name = 'Foo'"
         ).fetchone()
-        assert before["source"] == "scip"
+        assert before["source"] == "merged"
 
         # Edit the file and reindex just it.
         foo.write_text("class Foo { fun go() {} }\n")
         reindex_paths(conn, str(ws), [str(foo)])
 
-        # After reindex: Foo is now tree_sitter (SCIP importer didn't run for
-        # one file; the incremental path is language-blind by design).
+        # After reindex: Foo is tree_sitter (incremental doesn't re-run SCIP merge).
         after = conn.execute(
             "SELECT source FROM symbols WHERE name = 'Foo'"
         ).fetchone()
         assert after is not None
         assert after["source"] == "tree_sitter", (
-            f"expected tree_sitter after reindex of a SCIP file, got {after['source']!r}"
+            f"expected tree_sitter after reindex, got {after['source']!r}"
         )
     finally:
         conn.close()
 
 
-def test_full_build_restores_scip_after_incremental(tmp_path):
-    """A full rebuild re-imports SCIP, restoring source='scip' (self-healing)."""
+def test_full_build_restores_merged_after_incremental(tmp_path):
+    """A full rebuild re-imports SCIP and re-merges, restoring source='merged'."""
     ws = tmp_path / "ws"
     repo = ws / "demo"
     (repo / ".git").mkdir(parents=True)
@@ -107,13 +113,13 @@ def test_full_build_restores_scip_after_incremental(tmp_path):
     finally:
         conn.close()
 
-    # Full rebuild re-imports the SCIP index (unchanged) -> source flips back.
+    # Full rebuild re-imports SCIP and re-merges -> source flips back to 'merged'.
     build_graph(workspace=str(ws), db_path=db)
     conn = get_db(db)
     try:
         final = conn.execute("SELECT source FROM symbols WHERE name = 'Foo'").fetchone()
-        assert final["source"] == "scip", (
-            f"full build should restore source='scip', got {final['source']!r}"
+        assert final["source"] == "merged", (
+            f"full build should restore source='merged', got {final['source']!r}"
         )
     finally:
         conn.close()

--- a/tests/test_scip_indexers.py
+++ b/tests/test_scip_indexers.py
@@ -1,0 +1,190 @@
+"""Tests for the generic SCIP indexer orchestrator.
+
+Covers the registry, the happy path (indexer runs and writes the file), and the
+three graceful-degrade paths (tool not on PATH, nonzero exit, OS error). The
+orchestrator must never raise -- a missing/failing indexer logs and returns
+False so the build falls back to tree-sitter.
+
+Does NOT require the optional ``[scip]`` extra: the orchestrator only spawns
+external binaries and writes files; it never touches the protobuf stub.
+"""
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+from cairn.parsers import scip_indexers
+from cairn.parsers.scip_indexers import (
+    known_languages,
+    spec_for,
+    try_generate_index,
+)
+
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+def test_registry_has_swift_kotlin_typescript():
+    """The three documented indexers are registered; Swift is one of them."""
+    langs = known_languages()
+    assert "swift" in langs
+    assert "kotlin" in langs
+    assert "typescript" in langs
+
+
+def test_spec_for_unknown_language_is_none():
+    """An unregistered language (e.g. a lang with no known indexer) is None."""
+    assert spec_for("rust") is None
+    assert spec_for("not-a-language") is None
+
+
+def test_swift_spec_command_shape():
+    """scip-swift's documented CLI is `scip-swift index <repo> --output <out>`."""
+    spec = spec_for("swift")
+    assert spec is not None
+    assert spec.tool == "scip-swift"
+    cmd = spec.build_command("/repo", "/out/x.scip")
+    assert cmd[0] == "scip-swift"
+    assert "index" in cmd
+    assert "/repo" in cmd
+    assert "/out/x.scip" in cmd
+
+
+def test_kotlin_spec_command_shape():
+    """scip-kotlin's documented CLI is `scip-kotlin index --output <out> <repo>`."""
+    spec = spec_for("kotlin")
+    assert spec is not None
+    cmd = spec.build_command("/repo", "/out/k.scip")
+    # --output <out> precedes the repo path (matches docs/scip.md §1).
+    assert cmd.index("--output") < cmd.index("/repo")
+
+
+def test_typescript_spec_command_shape():
+    """scip-typescript mirrors scip-kotlin's argument order."""
+    spec = spec_for("typescript")
+    assert spec is not None
+    cmd = spec.build_command("/repo", "/out/t.scip")
+    assert cmd.index("--output") < cmd.index("/repo")
+
+
+# ---------------------------------------------------------------------------
+# try_generate_index: happy path + degrade paths (never raises)
+# ---------------------------------------------------------------------------
+
+def test_generate_returns_false_for_unknown_language(tmp_path, monkeypatch):
+    """An unregistered language short-circuits without spawning anything."""
+    out = tmp_path / "x.scip"
+    # Even if a tool were "installed", an unknown language must not spawn it.
+    monkeypatch.setattr(scip_indexers.shutil, "which", lambda tool: "/bin/" + tool)
+    spawned = []
+    monkeypatch.setattr(scip_indexers.subprocess, "run",
+                        lambda cmd, **kw: spawned.append(cmd) or (_ for _ in ()).throw(AssertionError("must not spawn")))
+
+    ok = try_generate_index("rust", out, str(tmp_path), log=lambda *a, **k: None)
+    assert ok is False
+    assert spawned == []  # no subprocess spawned
+    assert not out.exists()
+
+
+def test_generate_runs_indexer_when_missing(tmp_path, monkeypatch):
+    """When the tool is on PATH and exits 0 writing the file, generation succeeds."""
+    out = tmp_path / "build" / "swift.scip"
+
+    def fake_run(cmd, **kw):
+        # The real indexer would write the .scip file; simulate it.
+        Path(cmd[cmd.index("--output") + 1]).write_bytes(b"\x12\x01x")  # minimal proto
+        return subprocess.CompletedProcess(cmd, 0)
+
+    monkeypatch.setattr(scip_indexers.shutil, "which", lambda tool: "/usr/local/bin/" + tool)
+    monkeypatch.setattr(scip_indexers.subprocess, "run", fake_run)
+
+    logs = []
+    ok = try_generate_index("swift", out, str(tmp_path), log=logs.append)
+    assert ok is True
+    assert out.exists()
+    # The command targeted the repo path and the configured output path.
+    assert any(str(out) in str(m) for m in logs) or out.exists()
+
+
+def test_generate_skips_when_tool_not_on_path(tmp_path, monkeypatch):
+    """A missing binary is logged (install hint) and returns False -- no spawn."""
+    out = tmp_path / "swift.scip"
+    monkeypatch.setattr(scip_indexers.shutil, "which", lambda tool: None)
+
+    spawned = []
+    monkeypatch.setattr(scip_indexers.subprocess, "run",
+                        lambda cmd, **kw: spawned.append(cmd) or (_ for _ in ()).throw(AssertionError("must not spawn")))
+
+    logs = []
+    ok = try_generate_index("swift", out, str(tmp_path), log=logs.append)
+    assert ok is False
+    assert spawned == []
+    assert not out.exists()
+    # The install hint is surfaced.
+    assert any("scip-swift" in str(m) for m in logs)
+
+
+def test_generate_swallows_nonzero_exit(tmp_path, monkeypatch):
+    """A nonzero exit that produces no file logs + returns False, never raises."""
+    out = tmp_path / "swift.scip"
+    monkeypatch.setattr(scip_indexers.shutil, "which", lambda tool: "/bin/" + tool)
+    monkeypatch.setattr(
+        scip_indexers.subprocess, "run",
+        lambda cmd, **kw: subprocess.CompletedProcess(cmd, 2, stdout="", stderr="boom\nbuild failed"),
+    )
+
+    logs = []
+    ok = try_generate_index("swift", out, str(tmp_path), log=logs.append)
+    assert ok is False
+    assert not out.exists()
+    # Nonzero exit is reported.
+    assert any("exited" in str(m) for m in logs)
+
+
+def test_generate_swallows_oserror(tmp_path, monkeypatch):
+    """A missing binary at exec time (FileNotFoundError) is absorbed, not raised."""
+    out = tmp_path / "swift.scip"
+    monkeypatch.setattr(scip_indexers.shutil, "which", lambda tool: "/bin/" + tool)
+
+    def raise_fnf(cmd, **kw):
+        raise FileNotFoundError("[Errno 2] No such file")
+
+    monkeypatch.setattr(scip_indexers.subprocess, "run", raise_fnf)
+
+    logs = []
+    ok = try_generate_index("swift", out, str(tmp_path), log=logs.append)
+    assert ok is False
+    assert not out.exists()
+    assert any("invocation failed" in str(m) for m in logs)
+
+
+def test_generate_swallows_timeout(tmp_path, monkeypatch):
+    """A timed-out indexer is absorbed, not raised."""
+    out = tmp_path / "swift.scip"
+    monkeypatch.setattr(scip_indexers.shutil, "which", lambda tool: "/bin/" + tool)
+
+    def raise_timeout(cmd, **kw):
+        raise subprocess.TimeoutExpired(cmd=cmd, timeout=1)
+
+    monkeypatch.setattr(scip_indexers.subprocess, "run", raise_timeout)
+
+    logs = []
+    ok = try_generate_index("swift", out, str(tmp_path), log=logs.append)
+    assert ok is False
+    assert not out.exists()
+
+
+def test_generate_is_idempotent_when_index_exists(tmp_path, monkeypatch):
+    """An already-present index is never rebuilt -- returns True without spawning."""
+    out = tmp_path / "swift.scip"
+    out.write_bytes(b"\x12\x01x")
+    monkeypatch.setattr(scip_indexers.shutil, "which", lambda tool: "/bin/" + tool)
+
+    spawned = []
+    monkeypatch.setattr(scip_indexers.subprocess, "run",
+                        lambda cmd, **kw: spawned.append(cmd) or (_ for _ in ()).throw(AssertionError("must not rebuild")))
+
+    ok = try_generate_index("swift", out, str(tmp_path), log=lambda *a, **k: None)
+    assert ok is True
+    assert spawned == []

--- a/tests/test_scip_indexers.py
+++ b/tests/test_scip_indexers.py
@@ -25,18 +25,33 @@ from cairn.parsers.scip_indexers import (
 # Registry
 # ---------------------------------------------------------------------------
 
-def test_registry_has_swift_kotlin_typescript():
-    """The three documented indexers are registered; Swift is one of them."""
-    langs = known_languages()
-    assert "swift" in langs
-    assert "kotlin" in langs
-    assert "typescript" in langs
+def test_registry_covers_supported_languages():
+    """Every language with a known single-binary SCIP indexer is registered."""
+    langs = set(known_languages())
+    assert {"swift", "java", "kotlin", "typescript", "python", "go", "rust"} <= langs
 
 
 def test_spec_for_unknown_language_is_none():
-    """An unregistered language (e.g. a lang with no known indexer) is None."""
-    assert spec_for("rust") is None
+    """An unregistered language (no known indexer / not a scanner language) is None."""
+    assert spec_for("ruby") is None  # scip-ruby is dead
+    assert spec_for("csharp") is None  # no indexer exists
     assert spec_for("not-a-language") is None
+
+
+def test_kotlin_uses_scip_java_not_deprecated_scip_kotlin():
+    """scip-kotlin is superseded; the kotlin key must invoke scip-java.
+
+    scip-java indexes mixed Java+Kotlin projects in one run and tags each
+    Document's language per source file, so both 'java' and 'kotlin' keys
+    pointing at scip-java is correct. Regression guard: don't let a future
+    edit reintroduce the deprecated scip-kotlin binary.
+    """
+    kotlin = spec_for("kotlin")
+    java = spec_for("java")
+    assert kotlin is not None and java is not None
+    assert kotlin.tool == "scip-java"
+    assert java.tool == "scip-java"
+    assert kotlin.build_command == java.build_command
 
 
 def test_swift_spec_command_shape():
@@ -45,27 +60,47 @@ def test_swift_spec_command_shape():
     assert spec is not None
     assert spec.tool == "scip-swift"
     cmd = spec.build_command("/repo", "/out/x.scip")
-    assert cmd[0] == "scip-swift"
-    assert "index" in cmd
-    assert "/repo" in cmd
-    assert "/out/x.scip" in cmd
+    assert cmd == ["scip-swift", "index", "/repo", "--output", "/out/x.scip"]
 
 
-def test_kotlin_spec_command_shape():
-    """scip-kotlin's documented CLI is `scip-kotlin index --output <out> <repo>`."""
-    spec = spec_for("kotlin")
+def test_java_spec_command_shape():
+    """scip-java: `scip-java index --output <out>` (no repo arg; run from root)."""
+    spec = spec_for("java")
     assert spec is not None
-    cmd = spec.build_command("/repo", "/out/k.scip")
-    # --output <out> precedes the repo path (matches docs/scip.md §1).
-    assert cmd.index("--output") < cmd.index("/repo")
+    cmd = spec.build_command("/repo", "/out/j.scip")
+    assert cmd == ["scip-java", "index", "--output", "/out/j.scip"]
 
 
 def test_typescript_spec_command_shape():
-    """scip-typescript mirrors scip-kotlin's argument order."""
+    """scip-typescript: `scip-typescript index --output <out>`."""
     spec = spec_for("typescript")
     assert spec is not None
     cmd = spec.build_command("/repo", "/out/t.scip")
-    assert cmd.index("--output") < cmd.index("/repo")
+    assert cmd == ["scip-typescript", "index", "--output", "/out/t.scip"]
+
+
+def test_python_spec_command_shape():
+    """scip-python: `scip-python index <repo> --output=<out>` (= form, npm pkg)."""
+    spec = spec_for("python")
+    assert spec is not None
+    cmd = spec.build_command("/repo", "/out/p.scip")
+    assert cmd == ["scip-python", "index", "/repo", "--output=/out/p.scip"]
+
+
+def test_go_spec_command_shape():
+    """scip-go: `scip-go --output=<out>` (no `index` subcommand)."""
+    spec = spec_for("go")
+    assert spec is not None
+    cmd = spec.build_command("/repo", "/out/g.scip")
+    assert cmd == ["scip-go", "--output=/out/g.scip"]
+
+
+def test_rust_spec_command_shape():
+    """rust-analyzer scip subcommand: `rust-analyzer scip <repo> --output <out>`."""
+    spec = spec_for("rust")
+    assert spec is not None
+    cmd = spec.build_command("/repo", "/out/r.scip")
+    assert cmd == ["rust-analyzer", "scip", "/repo", "--output", "/out/r.scip"]
 
 
 # ---------------------------------------------------------------------------
@@ -76,12 +111,13 @@ def test_generate_returns_false_for_unknown_language(tmp_path, monkeypatch):
     """An unregistered language short-circuits without spawning anything."""
     out = tmp_path / "x.scip"
     # Even if a tool were "installed", an unknown language must not spawn it.
+    # ruby is unregistered (scip-ruby is dead); cairn can't auto-generate it.
     monkeypatch.setattr(scip_indexers.shutil, "which", lambda tool: "/bin/" + tool)
     spawned = []
     monkeypatch.setattr(scip_indexers.subprocess, "run",
                         lambda cmd, **kw: spawned.append(cmd) or (_ for _ in ()).throw(AssertionError("must not spawn")))
 
-    ok = try_generate_index("rust", out, str(tmp_path), log=lambda *a, **k: None)
+    ok = try_generate_index("ruby", out, str(tmp_path), log=lambda *a, **k: None)
     assert ok is False
     assert spawned == []  # no subprocess spawned
     assert not out.exists()


### PR DESCRIPTION
## Summary

End-to-end SCIP indexing for Swift (via scip-swift) and 6 other languages, with a tree-sitter/SCIP coexistence merge model. Validated against real indexer output — scip-swift 0.1.2 and scip-java 0.10.4.

## What's included (9 commits + 1 merge)

### 1. `project_root` file:// fix
scip-swift writes `Metadata.project_root` as a `file://` URL; the importer treated it as a relative path and silently mis-attributed every Swift document. Now scheme-stripped before resolution. Found by validating against real output.

### 2. Auto-generation orchestrator (bounded, opt-in)
When `cairn.json` declares a SCIP index but the file is missing and a known indexer is on PATH, `cairn build` generates it once. Never raises — falls back to tree-sitter on failure. Registry of 7 indexers: scip-swift, scip-java (Java+Kotlin), scip-typescript, scip-python, scip-go, rust-analyzer.

### 3. Registry correctness
Kotlin now uses scip-java (scip-kotlin is deprecated/merged). CLI shapes verified against each indexer's README.

### 4. Real-data bug fixes (found via validation)
- `source_id` NOT NULL crash on file-level occurrences (top-level Swift code)
- Empty `Document.language` (scip-java 0.10.4) → derive from extension
- Symlink divergence in `project_root` (macOS `/tmp` → `/private/tmp`)

### 5. Coexistence merge model
Both sources run: tree-sitter provides modifiers/body/inheritance, SCIP provides exact-resolution edges. Merged into one row per symbol (`source='merged'`). **Per-language fallback**: when an indexer's names don't match tree-sitter (scip-swift's opaque USRs), the build auto-detects the zero merge rate and reverts that language to pure-SCIP to avoid duplicate disconnection.

## Validation

| Indexer | Result |
|---|---|
| scip-java 0.10.4 (mixed Java+Kotlin Gradle) | 4/7 symbols merged, modifiers preserved, exact edges |
| scip-swift 0.1.2 (SwiftPM package) | Pure-SCIP fallback (opaque USRs don't match tree-sitter) |

## Test status
590 passed, 1 pre-existing skip, no regressions.