### PR TITLE
release: 0.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- _Nothing yet._
+
+### Changed
+- _Nothing yet._
+
+### Fixed
+- _Nothing yet._
+
+### Removed
+- _Nothing yet._
+
+## [0.6.1] - 2026-08-07
+
+> **Focus:** post-audit hardening — incremental reindex correctness repairs
+> and a full code↔docs reconciliation. No user-facing API changes.
+
+### Added
 - **Vertical-rail flow UI for `cairn init` and `cairn build`.** Both commands
   now render a clack-style vertical rail — `┌` open, `│` spacers between
   groups, green `◆` step markers, animated sub-steps (`Scanning files`,
@@ -138,6 +155,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 - _Nothing yet._
+
+### Audit findings fixed (code↔docs reconciliation)
+- **README/quickstart recommended `cairn update` as the first command**, but it
+  parses nothing on a fresh clone (`git diff HEAD` is empty). Switched to
+  `cairn build` for the first run.
+- **README's `--client claude,cursor` install example failed** under Click
+  `multiple=True`; fixed to repeated `--client`.
+- **`opencode` was installable but not removable via `--client`** — added to
+  both uninstall `click.Choice` lists.
+- **Skill `cli-fallback.md` documented a non-existent `compass flow-gaps
+  --as-workflow` flag** — removed.
+- **Stale `_INSTRUCTIONS_BODY` install template** regenerated three wrong
+  claims into every fresh AGENTS.md/CLAUDE.md (ANN backend "opt-in" vs the
+  on-by-default code, `recall_memory` "substring-only" vs multi-token + semantic
+  fallback, non-canonical layer breakdown). Synced with the committed AGENTS.md.
+- **"wiki generate is critic-gated" was false** — it runs the critic but still
+  writes. Scoped the safety guarantee to `compass generate` / `compass flow`.
+- **MCP `get_callers`/`get_callees` documented with `kind=` filter the wrappers
+  don't expose** — scoped to library/CLI layer.
+- **"cairn update does not rebuild derived indexes" was false** (already fixed
+  in code above) — docs updated.
+- **`configuration.md` SCIP row claimed tree-sitter is "skipped"** — rewritten
+  to the actual coexistence-then-merge model; stale `scip-kotlin` reference
+  corrected to `scip-java`.
+- **`architecture.md` mislabeled the 9th graph tool as "a blast-radius helper"**
+  — it is `visualize_graph`. Also documented the C/C++ scanner gap.
+- **Version drift**: README Status `v0.5.3` and SECURITY supported-versions
+  `0.5.x` refreshed to `0.6.x`; `architecture.html` "26 tools" → "27 tools".
 
 ## [0.6.0] - 2026-08-05
 

--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ end user at install time.
 
 ## Status
 
-**Beta — pre-1.0 (v0.6.0).** Public surfaces (CLI flags, MCP tool shapes,
+**Beta — pre-1.0 (v0.6.1).** Public surfaces (CLI flags, MCP tool shapes,
 knowledge-file layout) may still shift before 1.0. Feedback welcome via
 [GitHub issues](https://github.com/tanlnm512/cairn/issues).
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "cairn-intel"
-version = "0.6.0"
+version = "0.6.1"
 description = "Local codebase intelligence system: structural graph + compass + wiki + agent memory"
 readme = "README.md"
 license = "MIT"

--- a/src/cairn/__init__.py
+++ b/src/cairn/__init__.py
@@ -1,3 +1,3 @@
 """Cairn: local codebase intelligence system."""
-__version__ = "0.6.0"
+__version__ = "0.6.1"
 __package_name__ = "cairn-intel"


### PR DESCRIPTION
## Summary

Release cut for **0.6.1** — post-audit hardening. No API changes.

This PR contains only the release bookkeeping: version bump in `pyproject.toml` +
`src/cairn/__init__.py`, README Status line, and CHANGELOG `[Unreleased]` →
`[0.6.1] - 2026-08-07`. The actual code changes shipped in #12 (already merged).

## What 0.6.1 ships

Already merged into `main` via #12:
- **Incremental reindex correctness repairs** (`6acc430`): `cairn update` now
  rebuilds derived indexes, repairs incoming edges to re-created symbols,
  wraps each file reinsert in one transaction, and takes the advisory
  `build_lock` for `--repo` builds.
- **Code↔docs reconciliation** (`f8544a0`): 12 high + 5 medium audit findings
  fixed — broken CLI examples, stale install template, critic-gate scope,
  SCIP coexistence model, version drift, tool-count drift.

Folded from `[Unreleased]` into this version header:
- Vertical-rail flow UI for `cairn init` / `cairn build`
- Hybrid SCIP / tree-sitter indexing (`source='merged'`)
- Portable `.kg` database (repo-relative paths)

## After merge

Tag `v0.6.1` is created locally and will be pushed immediately after this PR
lands, triggering the PyPI publish workflow (`.github/workflows/release.yml`,
Trusted Publishing).

## Test plan
- [x] Full suite on `main` post-merge of #12: **597 passed, 1 skipped**
- [x] Version smoke: `python -c "import cairn; print(cairn.__version__)"` → `0.6.1`
- [x] Pre-commit hook (ruff + reinstall) passes
