### PR TITLE
fix(ci+test): unblock release pipeline after v0.6.1 (GH release checkout, network leak in upgrade tests)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,6 +85,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: publish-pypi
     steps:
+      # CHANGELOG.md lives in the repo; the changelog-extraction step below
+      # needs the source tree (download-artifact only restores dist/).
+      - uses: actions/checkout@v5
+
       - uses: actions/download-artifact@v6
         with:
           name: dist

--- a/tests/test_upgrade.py
+++ b/tests/test_upgrade.py
@@ -18,11 +18,20 @@ from cairn.cli import upgrade as upgrade_mod
 # --- Fixtures --------------------------------------------------------------
 
 def _set_versions(monkeypatch, installed=None, latest=None, reinstall=None):
-    """Stub the upgrade helpers. `reinstall` records calls instead of shelling."""
+    """Stub the upgrade helpers. `reinstall` records calls instead of shelling.
+
+    `installed`/`latest` are always patched when the helper is invoked -- using
+    a sentinel instead of `if x is not None` so that `latest=None` (the very
+    value the "PyPI unreachable" tests exercise) still replaces the real
+    ``_pypi_latest`` rather than letting it hit the network. Without this,
+    those tests leaked a real call to pypi.org and only stayed green while the
+    project was unpublished.
+    """
+    _UNSET = object()
     calls = []
-    if installed is not None:
+    if installed is not _UNSET:
         monkeypatch.setattr(upgrade_mod, "_installed_version", lambda: installed)
-    if latest is not None:
+    if latest is not _UNSET:
         monkeypatch.setattr(upgrade_mod, "_pypi_latest", lambda: latest)
     if reinstall is None:
         reinstall = lambda method, version: calls.append((method, version))


### PR DESCRIPTION
## Context

The v0.6.1 release (the project's first PyPI publish) surfaced two latent bugs. PyPI itself is fine — `cairn-intel` 0.6.1 is published and the GitHub Release is cut. This PR fixes both so the next release works end-to-end and CI stays green.

## 1. `github-release` job: missing `actions/checkout`

The `github-release` job in `release.yml` reads `CHANGELOG.md` to build release notes, but it only ran `actions/download-artifact` — which restores `dist/`, not the source tree. It failed on the v0.6.1 run with:

```
awk: fatal: cannot open file `CHANGELOG.md` for reading: No such file or directory
```

**Fix:** add `actions/checkout@v5` as the first step. `softprops/action-gh-release@v2` still works via the API; only the changelog reading needed the source tree.

## 2. `test_upgrade.py`: network leak in the "PyPI unreachable" tests

Two tests (`test_upgrade_check_pypi_unreachable`, `test_upgrade_when_pypi_unreachable`) call `_set_versions(latest=None)`, expecting `_pypi_latest` to be stubbed to return `None`. But the helper's `if latest is not None` guard skipped the patch, so `_pypi_latest` made a **real network call** to `pypi.org`. That call returned `None` only because `cairn-intel` was unpublished — masking the leak.

Publishing v0.6.1 made the live call return `0.6.1`, so the "unreachable" branches were no longer taken:

```
AssertionError: assert 'PyPI' in '⠿ cairn-intel 0.6.0 (latest: 0.6.1)\n'
```

**Fix:** use a sentinel instead of `is not None` so `latest=None` still replaces the real `_pypi_latest`.

## Verification
- Local: `597 passed, 1 skipped` (matches the green main build pre-release)
- The `awk` changelog extraction is correct (verified: 160-line `[0.6.1]` section) — only the missing checkout was wrong