### PR TITLE
build: add 'make release' target as a release walkthrough + bump preview

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: dist evals verify-no-code-change help
+.PHONY: dist evals verify-no-code-change release help
 
 # Build the wheel + sdist into dist/. Produces:
 #   dist/cairn_intel-<version>-py3-none-any.whl
@@ -24,10 +24,40 @@ evals:
 verify-no-code-change:
 	uv run python scripts/verify_no_code_change.py $(REF)
 
+# Release walkthrough -- prints the steps AND previews the next bump.
+# Does NOT modify anything; the dry-run just shows what cz would do.
+# Full details: docs/release-checklist.md "Cutting a release".
+release:
+	@echo "┌─ Release checklist ───────────────────────────────────────────"
+	@echo "│"
+	@echo "│  0. You are on main, pulled, working tree clean, CI green."
+	@echo "│     Run the pre-release checks (tests, build, etc.) in"
+	@echo "│     docs/release-checklist.md first."
+	@echo "│"
+	@echo "│  1. Finalize CHANGELOG.md: move [Unreleased] -> [X.Y.Z] - YYYY-MM-DD"
+	@echo "│     (use the draft printed below as a starting point)."
+	@echo "│"
+	@echo "│  2. cz bump --yes"
+	@echo "│     Bumps version in pyproject.toml + __init__.py, commits,"
+	@echo "│     tags vX.Y.Z. CHANGELOG stays hand-maintained."
+	@echo "│"
+	@echo "│  3. git push origin main && git push origin vX.Y.Z"
+	@echo "│     The tag push triggers .github/workflows/release.yml:"
+	@echo "│     build -> publish to PyPI -> cut GitHub Release."
+	@echo "│"
+	@echo "│  Watch: gh run watch \$$(gh run list --workflow=release.yml -L1 -q '.[0].databaseId')"
+	@echo "└──────────────────────────────────────────────────────────────"
+	@echo ""
+	@echo "Preview of the next bump (dry-run, nothing is written):"
+	@echo ""
+	@uv run cz bump --dry-run --changelog-to-stdout || \
+		echo "(cz not available -- run 'uv sync --extra dev' first)"
+
 help:
-	@echo "Targets: dist evals verify-no-code-change"
+	@echo "Targets: dist evals verify-no-code-change release help"
 	@echo ""
 	@echo "  dist                   build wheel + sdist into dist/ (for distribution)"
 	@echo "  evals                  validate skill eval specs"
 	@echo "  verify-no-code-change  AST-check that changed .py files are comment-only"
 	@echo "                         (REF=HEAD~1 to verify a commit; default: uncommitted)"
+	@echo "  release                print the release walkthrough + preview the next bump"


### PR DESCRIPTION
## What

Adds a `make release` target that surfaces the release flow at the point of use (the terminal, at release time) instead of only in `docs/release-checklist.md`.

## Why

Right now the release steps live in a doc you have to remember to open. `make release` is the natural muscle-memory entry point — running it prints the full walkthrough **and** previews the next bump live:

```
$ make release
┌─ Release checklist ───────────────────────────────────────────
│  0. On main, pulled, clean, CI green. Run pre-release checks first.
│  1. Finalize CHANGELOG.md: [Unreleased] -> [X.Y.Z] - YYYY-MM-DD
│  2. cz bump --yes  (bumps version_files, commits, tags vX.Y.Z)
│  3. git push origin main && git push origin vX.Y.Z  (triggers release.yml)
└──────────────────────────────────────────────────────────────

bump: version 0.6.1 → 0.6.2
increment detected: PATCH
## [0.6.2] - 2026-08-08
### Fix
- **ci**: checkout repo in github-release job for CHANGELOG extraction
```

It modifies **nothing** — the dry-run is read-only. It just reminds you of the steps and shows what the next release would be.

## Test
```sh
make release      # prints checklist + dry-run preview
make help         # now lists 'release' in the targets
```

Makefile-only change; no code or workflow logic touched.