### PR TITLE
release: sync main with 0.7.0 (CHANGELOG + version bump)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- _Nothing yet._
+
+### Changed
+- _Nothing yet._
+
+### Fixed
+- _Nothing yet._
+
+### Removed
+- _Nothing yet._
+
+## [0.7.0] - 2026-08-10
+
 > **Focus:** the verification contract becomes the product — a machine-checked
 > promise that every `exact` edge is resolved, every doc symbol is
 > graph-verified, and the LLM is never in the query path. Plus a memory moat

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "cairn-intel"
-version = "0.6.1"
+version = "0.7.0"
 description = "Local codebase intelligence system: structural graph + compass + wiki + agent memory"
 readme = "README.md"
 license = "MIT"
@@ -153,7 +153,7 @@ select = ["F"]
 # The custom template (.cz_templates/keepachangelog.j2) renders that draft in
 # the existing `## [X.Y.Z] - YYYY-MM-DD` format rather than commitizen's
 # default `## X.Y.Z (YYYY-MM-DD)`.
-version = "0.6.1"
+version = "0.7.0"
 version_scheme = "pep440"
 tag_format = "v$version"
 update_changelog_on_bump = false

--- a/src/cairn/__init__.py
+++ b/src/cairn/__init__.py
@@ -1,3 +1,3 @@
 """Cairn: local codebase intelligence system."""
-__version__ = "0.6.1"
+__version__ = "0.7.0"
 __package_name__ = "cairn-intel"


### PR DESCRIPTION
## Why

The `v0.7.0` tag was pushed and 0.7.0 is published on PyPI + GitHub Releases, but these two commits could not be pushed directly to `main` (repo rules require a PR). This PR syncs `main` to match what was released.

## What

- `docs(changelog): move [Unreleased] -> [0.7.0] - 2026-08-10`
- `bump: version 0.6.1 → 0.7.0` (pyproject.toml ×2, src/cairn/__init__.py)

The tag `v0.7.0` already points at the bump commit; merging this PR brings `main` to the same SHA the release was built from.

## Verify

- `cairn version` → `0.7.0`
- `pypi.org/project/cairn-intel` → 0.7.0 (live)
- GitHub Release `v0.7.0` → published