### PR TITLE
feat(memory): semantic recall pipeline + MCP lock-contention fixes

### DIFF
--- a/docs/audit-checklist.md
+++ b/docs/audit-checklist.md
@@ -1,0 +1,278 @@
+# Scope Audit Checklist
+
+> Periodic, scope-based audits of whole areas of the codebase — **not** per-PR
+> review. Run these on a cadence (quarterly) or after heavy churn in an area.
+> For the per-change review gate, see [`review-checklist.md`](review-checklist.md).
+
+**How the two differ:**
+- `review-checklist.md` — *change-driven*: "this PR is safe to merge." Blast
+  radius of a diff. Run every PR.
+- `audit-checklist.md` (this file) — *area-driven*: "this subsystem is sound."
+  Deep correctness/integrity of a whole scope. Run periodically or on trigger.
+
+**TL;DR — every scope audit answers four questions:**
+1. **Correctness** — does the scope do what it claims, including failure modes?
+2. **Integrity** — are writes atomic, migrations ordered, no silent corruption?
+3. **Precedent** — have bugs recurred here? Check `docs/BUGS.md` for the pattern.
+4. **Coverage** — do tests actually exercise the failure modes that bit us before?
+
+---
+
+## Index
+
+| # | Scope | Area | Key files (LOC) | Recurrence signal in BUGS.md | Default cadence |
+|---|-------|------|-----------------|------------------------------|-----------------|
+| 1 | Data integrity & transactions | graph / memory stores | `schema.py`, `builder.py`, `incremental.py`, `memory/store.py`, `memory/promotion.py` | 4 entries (partial-write, schema-order, stale-resolution, tier-collision) | Quarterly |
+| 2 | Secret redaction & privacy | memory / knowledge layer | `memory/privacy.py`, `tools_memory.py`, `knowledge/store.py`, `knowledge/workflow.py` | 2 entries (unredacted secrets, missing scope-guard) | Quarterly |
+| 3 | Concurrency & locking | MCP server / embeddings | `mcp_server/lifecycle.py`, `_server_core.py`, `embeddings.py`, `embed_buffering.py` | live branch (`feat/...-mcp-locking-fixes`); stdio-leak memory | After churn in area |
+| 4 | Resolver / fusion / retrieval | graph intelligence | `resolver.py`, `fusion.py`, `semantic.py`, `lexical.py`, `ann_index.py`, `retrieval/` | 2 entries (fusion silently skipped, dead dict key) | Quarterly |
+| 5 | Parser correctness | parsers/ | `scip_importer.py`, `kotlin.py`, `typescript.py`, `php.py`, `routes.py` | 3 entries (fake-resolution, attribute-pollution, var-drop) | After adding a parser |
+| 6 | Agent-install file-write safety | agent_install/ | `merge.py`, `_common.py`, `detect.py`, `clients/*` | 1 entry (comments-only code drift) | After client changes |
+| 7 | Supply chain & CI gates | tooling | `pyproject.toml`, `uv.lock`, `.github/workflows/`, `.pre-commit-config.yaml` | — | Quarterly |
+| 8 | Doc / test consistency | docs / tests | `README.md`, `CHANGELOG.md`, `docs/`, `tests/` | docs-version-drift memory | Per release |
+
+> **Tier 1 = scopes 1–3.** `BUGS.md` recurrence + the live locking branch put the
+> trust/integrity cluster at the highest blast radius. Run those together.
+
+---
+
+## How to run an audit (meta-procedure)
+
+1. **Branch off:** `git switch -c audit/<scope>-<YYYY-MM-DD>`.
+2. **Load context the cairn way** (per AGENTS.md):
+   - `explore("<scope entry symbol>")` — get the source + call paths in one call.
+   - `ask_compass(file_path="<key file>")` — module guide + memory for each file.
+   - `recall_memory("<symbol>")` — past decisions/mistakes in the area.
+   - `search_knowledge("<topic>", type_filter="Wiki")` — architecture docs.
+3. **Walk the scope's checklist** below. For each failed box, file a finding
+   (format in §"Recording findings").
+4. **Regression-test:** if a finding is a correctness/integrity bug, add a test
+   that fails before the fix.
+5. **Record:** `record_memory` for any new pattern/mistake; update the BUGS.md
+   index + entry if it's a new bug class.
+6. **Ship:** follow [`contribution-workflow.md`](contribution-workflow.md)
+   (pre-commit → conventional commit → PR with audit checklist).
+
+### Recording findings
+
+One line per finding in the audit's summary, then a section:
+`[P1/P2/P3] <scope> — <file:line> — <symptom> → <root cause> → <fix or ticket>`.
+P1 = corrupts data / security / data loss. P2 = wrong answers / silent
+misbehavior. P3 = hygiene / drift.
+
+---
+
+## Scope 1 — Data integrity & transaction safety
+
+**What:** every persistent write to the SQLite graph + memory stores. This is
+where `BUGS.md` shows the densest recurrence: silent corruption that agents then
+build on.
+
+**Load context:** `explore("clear_repo")`, `explore("_apply_migration")`,
+`recall_memory("schema-init")`, `recall_memory("scip-import-partial-write")`.
+
+For each DB-writing module (`schema.py`, `builder.py`, `incremental.py`,
+`memory/store.py`, `memory/promotion.py`, `cross_repo.py`):
+
+- [ ] **Transactions** — every multi-statement write is wrapped in a single
+      transaction (`BEGIN…COMMIT` or a context manager). No partial persists on
+      exception mid-sequence.
+- [ ] **Rollback on failure** — a failed import/build leaves the DB in its prior
+      state. No partial-write-then-commit pattern
+      (precedent: `scip-import-partial-write-no-rollback`).
+- [ ] **Migration ordering** — the "schema initialized" flag is set *after*
+      migrations succeed, never before
+      (precedent: `schema-init-flag-before-migration`).
+- [ ] **No orphaned edges** — bulk deletes (`_clear_repo`, repo re-index) null
+      `target_id` *and* clear/downgrade `resolution`, not just one
+      (precedent: `clear-repo-stale-exact-resolution`).
+- [ ] **Idempotency** — re-running a build/import on the same input produces the
+      same graph, no duplicate rows or overwritten captures
+      (precedent: `raw-memory-tier-id-collision`).
+- [ ] **Connection lifecycle** — connections/cursors are closed on all paths
+      (incl. exceptions); no handle leak across `build_graph` runs.
+- [ ] **Parameterized queries** — no f-string/`%` SQL interpolation. (bandit
+      `B608` is suppressed repo-wide with rationale; verify it still holds.)
+
+---
+
+## Scope 2 — Secret redaction & privacy
+
+**What:** every path that persists untrusted input (memory captures, knowledge
+docs). The recurring failure mode is *two codepaths diverging* — hook path
+redacts, MCP path doesn't.
+
+**Load context:** `explore("record_memory")`, `recall_memory("unredacted-secrets")`,
+`recall_memory("knowledge-status-scope-guard")`.
+
+- [ ] **Single redaction source** — CLI, MCP, and hook entry points all route
+      through one redactor (`memory/privacy.py`). No copy of the logic elsewhere
+      (precedent: `record-memory-unredacted-secrets`).
+- [ ] **Redaction before persistence** — redaction happens *before* the write,
+      not just before display. Check the store layer, not just the tool layer.
+- [ ] **Namespace / scope guards** — `knowledge_status`, archive, and delete
+      operations namespace-guard so they can't act on docs outside their scope
+      (precedent: `knowledge-status-missing-scope-guard`).
+- [ ] **PII patterns** — redactor covers the patterns that matter for this repo
+      (keys, tokens, connection strings). Add a test per pattern.
+- [ ] **No raw capture in logs** — logging/telemetry paths don't echo unredacted
+      captures (`metric_buffering.py`, `structured.py`).
+- [ ] **Regression tests** — one test per redaction entry point (CLI + MCP + hook).
+
+---
+
+## Scope 3 — Concurrency & locking
+
+**What:** file/process locking between the MCP server and the graph builder, and
+process lifecycle (the live `feat/...-mcp-locking-fixes` branch; stdio-leak
+memory note).
+
+**Load context:** `explore("flock")`, `explore("serve start")`,
+`recall_memory("mcp-stdio-leak")`.
+
+- [ ] **Lock release on exception** — every `flock`/lock acquire is paired with
+      release in a `try/finally`. No lock held across a raised exception.
+- [ ] **Lock scope** — locks protect the *minimum* critical section, not whole
+      tool handlers (deadlock/contention risk).
+- [ ] **No deadlock cycle** — graph builder and MCP server can't both hold locks
+      the other needs. Map the lock acquisition order.
+- [ ] **Process lifecycle** — server start/stop (stdio *and* SSE daemon) reaps
+      children; no orphaned/hung processes after stop
+      (precedent: `mcp-stdio-leak-issue` memory).
+- [ ] **Concurrent build + query** — a graph rebuild mid-query doesn't return
+      torn/inconsistent results.
+- [ ] **Buffer flush on shutdown** — `embed_buffering.py` / `metric_buffering.py`
+      flush buffered writes before process exit; no lost embeddings on crash.
+- [ ] **Lock tests exist and pass** — `tests/test_*lock*` cover contention and
+      release-on-exception.
+
+---
+
+## Scope 4 — Resolver / fusion / retrieval correctness
+
+**What:** the engine that makes the product work. Subtle and failure-prone — a
+swallowed `.get()` once disabled fusion entirely.
+
+**Load context:** `explore("resolve")`, `explore("semantic_search")`,
+`recall_memory("rrf-fusion-silently-skipped")`, `recall_memory("fusion")`,
+`search_knowledge("precise vs fuzzy", type_filter="Wiki")`.
+
+- [ ] **Fusion actually runs** — under default config (`CAIRN_FUSION=1`), RRF
+      fusion combines BM25 + vector. Verify it isn't silently skipped by a
+      swallowed `.get()` / wrong default
+      (precedent: `rrf-fusion-silently-skipped`).
+- [ ] **Score semantics** — documented: returned `score` is a rank-fusion number
+      under fusion, cosine similarity only with `CAIRN_FUSION=0`
+      (see AGENTS.md §"Tool Quirks"). No code treats it as the other.
+- [ ] **Precise vs fuzzy** — precise follows only resolved edges; empty precise
+      ≠ unused. Fuzzy is a candidate list, verified before trust.
+- [ ] **Resolution labels honest** — `exact`/`ambiguous`/`unresolved` reflect
+      resolver truth; no `exact` with NULL target
+      (precedent: `scip-importer-fake-resolution`).
+- [ ] **ANN fallback** — sqlite-vec fails load → silent degrade to brute-force is
+      logged/observable, not silent-and-invisible.
+- [ ] **Dead dict keys / unreachable branches** — no cross-repo bridge line that
+      never prints (precedent: `dead-depends-on-key-in-knowledge-search`).
+- [ ] **Determinism** — same query → same ranking (modulo legitimate tie-breaks).
+
+---
+
+## Scope 5 — Parser correctness
+
+**What:** the 13 tree-sitter parsers + SCIP importer. Steady drip of edge cases;
+run after adding/touching a parser.
+
+**Load context:** `explore("parse")`, `explore("language inference")`,
+`recall_memory("swift-modifier-attribute-pollution")`,
+`recall_memory("ts-parser-var-declarator-edge-drop")`.
+
+For each parser (esp. `scip_importer.py`, `kotlin.py`, `typescript.py`, `php.py`):
+
+- [ ] **Resolution labels** — edges labeled `exact` have a non-NULL, correct
+      `target_id`. Importer doesn't overclaim resolution.
+- [ ] **Idiomatic constructs** — common idioms for the language produce edges, not
+      drops: Kotlin `operator fun invoke`, TS `const x = fn()`, JSX refs, Swift
+      modifiers (precedents: kotlin-operator-invoke, var-declarator-drop,
+      jsx-references, swift-attribute-pollution).
+- [ ] **Attribute vs modifier** — modifiers/attributes aren't concatenated into
+      symbol names (precedent: `swift-modifier-attribute-pollution`).
+- [ ] **Language detection** — `routes.py` / `inference/` detect the right parser
+      for ambiguous extensions; inference doesn't misroute.
+- [ ] **Golden fixtures** — `tests/fixtures` + `test_golden_parsers.py` cover the
+      idioms above, plus a real-world corpus probe (fixtures alone are insufficient).
+- [ ] **Error isolation** — a parse error in one file doesn't abort the whole build.
+
+---
+
+## Scope 6 — Agent-install file-write safety
+
+**What:** writes into the *user's* config files across 7 agent clients. Even
+"safe" edit tasks have mutated executable code before.
+
+**Load context:** `explore("merge")`, `explore("detect")`,
+`recall_memory("comments-only-code-drift")`.
+
+For `merge.py`, `_common.py`, `detect.py`, `clients/*`:
+
+- [ ] **Atomic writes** — config writes go to a temp file + rename, not in-place
+      mutation. No torn config on crash.
+- [ ] **Backup before edit** — original config backed up before merge; documented
+      recovery path.
+- [ ] **Merge idempotency** — running install twice doesn't duplicate blocks or
+      stack guidance.
+- [ ] **Dry-run fidelity** — `--dry-run` reports exactly what the real run writes.
+- [ ] **No executable mutation** — comment/guidance edits never touch executable
+      code. (`make verify-no-code-change` is the guard; precedent:
+      `comments-only-code-drift`.)
+- [ ] **Subprocess in clients** — client launchers (`subprocess` sites in
+      `clients/*`) don't pass untrusted input to a shell.
+- [ ] **Per-client tests** — `test_clients.py` + `test_agent_install_dry.py` cover
+      each client's merge path.
+
+---
+
+## Scope 7 — Supply chain & CI gates
+
+**What:** the Layer 0-1 automated defense. If these drift, the whole pipeline weakens.
+
+- [ ] **Dependency pinning** — `mypy` is pinned (rationale documented); check
+      whether the others that *should* be pinned are, and that floating pins are
+      intentional.
+- [ ] **`uv.lock` fresh** — lockfile matches `pyproject.toml`; no stale entries.
+- [ ] **pip-audit (hard gate)** — clean; every advisory has a tracked decision.
+- [ ] **bandit / mypy (advisory)** — *new* findings since last audit are reviewed,
+      not just accumulated. Suppressed `B608` still justified.
+- [ ] **CI matrix** — `.github/workflows/ci.yml` runs all gates; the gate list
+      matches what AGENTS.md claims (pip-audit, bandit, mypy, PR-title).
+- [ ] **pre-commit hooks** — `.pre-commit-config.yaml` revs current; ruff +
+      gitleaks + yaml/toml/large-file checks active.
+- [ ] **Release pipeline** — tag push triggers release; `release.yml` consistent
+      with `release-checklist.md`.
+
+---
+
+## Scope 8 — Doc / test consistency
+
+**What:** the surfaces that drift on every release (~10, per the docs-version-drift
+memory). Run per release.
+
+- [ ] **Version refs** — version string consistent across README, CHANGELOG,
+      cli-reference, architecture docs, pyproject.
+- [ ] **Tool counts / language counts** — "27 tools", "13 parsers" etc. match
+      reality (recount, don't trust the doc).
+- [ ] **BUGS.md structure** — index table present, one TL;DR per entry, each entry
+      maps to a regression test (per the structure convention).
+- [ ] **Test markers** — `-m core` actually has tagged tests; markers aren't stale.
+- [ ] **Tool-quirks table** — AGENTS.md §"Tool Quirks" matches current tool behavior.
+- [ ] **Dead links** — every doc cross-link resolves.
+
+---
+
+## Triggers (run an audit outside cadence)
+
+- **A bug fix in the scope** — audit the scope after the 3rd fix in the same area
+  (recurrence signal).
+- **Heavy churn** — >20% of a scope's LOC changed in a window.
+- **Before a release** — run Tier 1 (scopes 1–3) before tagging.
+- **New dependency / parser / client** — run the matching scope (5, 6, or 7).
+- **Onboarding** — running a scope audit is the fastest way to learn an area.

--- a/src/cairn/agent_install/_common.py
+++ b/src/cairn/agent_install/_common.py
@@ -291,23 +291,40 @@ You can read these files directly when MCP is unavailable.
 """
 
 
-def _claude_instructions() -> str:
+def _transport_note(transport: str = "stdio", sse_url: str | None = None) -> str:
+    """One-line transport description; must match what mcp_config_json() writes."""
+    if transport == "sse":
+        from ..mcp_server import lifecycle as lc
+
+        url = sse_url or f"http://127.0.0.1:{lc.DEFAULT_PORT}/sse"
+        return (
+            f"- Transport: SSE, shared daemon at {url} (one process serves every "
+            "MCP client; managed via `cairn serve start` / `stop` / `status`).\n"
+            "- Do NOT run `cairn serve` yourself in this workspace -- a stray stdio "
+            "server would hold SQLite's writer lock and bring back \"database is "
+            "locked\" for every other client."
+        )
+    return "- Transport: stdio (one `cairn serve` process per client, spawned automatically by the MCP client)."
+
+
+def _claude_instructions(transport: str = "stdio", sse_url: str | None = None) -> str:
     return (
         "# Codebase Intelligence (Cairn)\n\n"
         "This workspace is connected to the cairn knowledge system. Use these tools\n"
         "to understand the codebase before making changes. Start with the router, drill\n"
         "down with layer-specific tools.\n\n"
+        f"{_transport_note(transport, sse_url)}\n\n"
     ) + _INSTRUCTIONS_BODY
 
 
-def _agents_instructions() -> str:
+def _agents_instructions(transport: str = "stdio", sse_url: str | None = None) -> str:
     return (
         "# Codebase Intelligence System\n\n"
         "This workspace uses a local knowledge graph (cairn) for codebase intelligence.\n"
         "All AI coding agents working in this workspace should use these tools.\n\n"
         "## MCP Server\n"
         "- Name: `cairn` (auto-connected at session start)\n"
-        "- Transport: stdio\n"
+        f"{_transport_note(transport, sse_url)}\n"
         "- 27 tools across 5 layers: graph (9), knowledge base + compass (5), memory (8), knowledge (5)\n"
         "  (`explore` is the recommended first call -- it aggregates the graph layer)\n"
         "\n"

--- a/src/cairn/agent_install/clients/claude.py
+++ b/src/cairn/agent_install/clients/claude.py
@@ -130,7 +130,7 @@ def install_claude(workspace: str, force: bool, dry_run: bool,
     if scope == "workspace":
         claude_md = ws / "CLAUDE.md"
         if not claude_md.exists():
-            _write_file(claude_md, _claude_instructions(), force=False, result=res, dry_run=dry_run)
+            _write_file(claude_md, _claude_instructions(transport, sse_url), force=False, result=res, dry_run=dry_run)
         else:
             res.skipped.append(str(claude_md) + " (exists; not overwritten)")
 

--- a/src/cairn/agent_install/clients/zcode.py
+++ b/src/cairn/agent_install/clients/zcode.py
@@ -84,7 +84,7 @@ def install_zcode(workspace: str, force: bool, dry_run: bool,
     # ZCode uses AGENTS.md as its instruction file.
     agents_md = ws / "AGENTS.md"
     if not agents_md.exists():
-        _write_file(agents_md, _agents_instructions(), force=False, result=res, dry_run=dry_run)
+        _write_file(agents_md, _agents_instructions(transport, sse_url), force=False, result=res, dry_run=dry_run)
     else:
         res.skipped.append(str(agents_md) + " (exists; not overwritten)")
 

--- a/src/cairn/cli/memory.py
+++ b/src/cairn/cli/memory.py
@@ -322,14 +322,21 @@ def memory_promote(path, db, knowledge):
 
 
 @memory.command("decay")
+@click.option("--db", default=str(DEFAULT_DB_PATH))
 @click.option("--knowledge", default=str(DEFAULT_DB_PATH.parent / ".knowledge"))
-def memory_decay(knowledge):
+def memory_decay(db, knowledge):
     """Expire raw memories >7d, archive tribal >90d stale."""
     from ..memory.promotion import decay
     from ..okf.bundle import OKFBundle
 
     bundle = OKFBundle(knowledge)
-    result = decay(bundle)
+    # Pass a writable conn so decay also reaps embedding rows orphaned by the
+    # tier moves (dead vectors otherwise accumulate in memory_embeddings).
+    conn = get_db(db)
+    try:
+        result = decay(bundle, conn=conn)
+    finally:
+        conn.close()
     click.echo(f"Expired raw: {result['expired_raw']}, archived tribal: {result['archived_tribal']}")
 
 

--- a/src/cairn/cli/memory.py
+++ b/src/cairn/cli/memory.py
@@ -111,6 +111,10 @@ def memory_search(query, tier, db, knowledge):
         except Exception:
             refs = "?"
         click.echo(f"  [{t} {score}, refs-verified={refs}] {c.title}  ({c.concept_id})")
+    from ..graph.embeddings import unembedded_memory_hint
+    hint = unembedded_memory_hint(conn, bundle)
+    if hint:
+        click.echo(hint)
     conn.close()
 
 
@@ -280,6 +284,11 @@ def memory_digest(limit, db, knowledge):
                 except Exception:
                     pass
             click.echo(f"  [{score}, refs-verified={refs}] {c.title}")
+        if conn is not None:
+            from ..graph.embeddings import unembedded_memory_hint
+            hint = unembedded_memory_hint(conn, bundle)
+            if hint:
+                click.echo(hint)
     finally:
         if conn is not None:
             conn.close()
@@ -287,14 +296,24 @@ def memory_digest(limit, db, knowledge):
 
 @memory.command("promote")
 @click.argument("path")
+@click.option("--db", default=str(DEFAULT_DB_PATH))
 @click.option("--knowledge", default=str(DEFAULT_DB_PATH.parent / ".knowledge"))
-def memory_promote(path, knowledge):
+def memory_promote(path, db, knowledge):
     """Force-promote a memory to canonical (compass/wiki)."""
     from ..memory.promotion import promote_memory
     from ..okf.bundle import OKFBundle
 
     bundle = OKFBundle(knowledge)
-    new_id = promote_memory(bundle, path)
+    # Pass a writable conn so promote_memory renames the persisted embedding
+    # row to the new concept_id in place (content is unchanged by a promote),
+    # instead of orphaning + re-embedding identical text.
+    conn = get_db(db)
+    try:
+        new_id = promote_memory(bundle, path, conn=conn)
+        if new_id:
+            conn.commit()
+    finally:
+        conn.close()
     if new_id:
         click.echo(f"Promoted to {new_id}")
     else:

--- a/src/cairn/cli/memory.py
+++ b/src/cairn/cli/memory.py
@@ -32,6 +32,7 @@ def memory_record(mtype, title, body, resource, confidence, db, knowledge):
     Skip anything cheaper to re-derive than recall: facts the graph already
     answers, plain git history, or ephemeral session-only state.
     """
+    from ..graph.embeddings import embed_memory_concepts
     from ..memory.promotion import capture_memory
     from ..okf.bundle import OKFBundle
 
@@ -41,6 +42,8 @@ def memory_record(mtype, title, body, resource, confidence, db, knowledge):
         conn, bundle, type_=mtype, title=title, body=body or title,
         resource=resource, confidence=confidence,
     )
+    embed_memory_concepts(conn, bundle, [result["path"]])
+    conn.commit()
     conn.close()
     signals = result["signals"]
     click.echo(f"Recorded {mtype} '{title}' -> {result['path']} (score={signals['score']}, tier={result['tier']})")
@@ -59,6 +62,7 @@ def memory_evolve(memory_path, title, body, db, knowledge):
     --include-superseded) and its version chain is inherited, preserving
     the full decision history.
     """
+    from ..graph.embeddings import embed_memory_concepts
     from ..memory.promotion import evolve_memory
     from ..okf.bundle import OKFBundle
 
@@ -67,6 +71,9 @@ def memory_evolve(memory_path, title, body, db, knowledge):
     result = evolve_memory(
         conn, bundle, memory_path, new_title=title, new_body=body
     )
+    if result is not None:
+        embed_memory_concepts(conn, bundle, [result["path"]])
+        conn.commit()
     conn.close()
     if result is None:
         click.echo(f"Memory not found: '{memory_path}'.")
@@ -126,6 +133,7 @@ def memory_capture(session_transcript, session_transcript_stdin, session_id, db,
     both are given the stdin form wins.
     """
 
+    from ..graph.embeddings import embed_memory_concepts
     from ..llm.tasks import create_task
     from ..memory.promotion import capture_memory
     from ..okf.bundle import OKFBundle
@@ -152,9 +160,10 @@ def memory_capture(session_transcript, session_transcript_stdin, session_id, db,
 
     # If we got candidates, record them now.
     recorded = 0
+    captured_paths = []
     for cand in candidates:
         try:
-            capture_memory(
+            result = capture_memory(
                 conn, bundle,
                 type_=cand.get("type", "decision"),
                 title=cand.get("title", "untitled"),
@@ -162,9 +171,14 @@ def memory_capture(session_transcript, session_transcript_stdin, session_id, db,
                 confidence=float(cand.get("confidence", 0.6)),
                 session_origin=session_id,
             )
+            captured_paths.append(result["path"])
             recorded += 1
         except Exception:
             continue
+
+    if captured_paths:
+        embed_memory_concepts(conn, bundle, captured_paths)
+        conn.commit()
 
     if recorded:
         click.echo(f"Captured {recorded} memories from session {session_id}.")
@@ -273,17 +287,14 @@ def memory_digest(limit, db, knowledge):
 
 @memory.command("promote")
 @click.argument("path")
-@click.option("--db", default=str(DEFAULT_DB_PATH))
 @click.option("--knowledge", default=str(DEFAULT_DB_PATH.parent / ".knowledge"))
-def memory_promote(path, db, knowledge):
+def memory_promote(path, knowledge):
     """Force-promote a memory to canonical (compass/wiki)."""
     from ..memory.promotion import promote_memory
     from ..okf.bundle import OKFBundle
 
-    conn = get_db(db)
     bundle = OKFBundle(knowledge)
-    new_id = promote_memory(bundle, path, conn=conn)
-    conn.close()
+    new_id = promote_memory(bundle, path)
     if new_id:
         click.echo(f"Promoted to {new_id}")
     else:
@@ -301,6 +312,36 @@ def memory_decay(knowledge):
     bundle = OKFBundle(knowledge)
     result = decay(bundle)
     click.echo(f"Expired raw: {result['expired_raw']}, archived tribal: {result['archived_tribal']}")
+
+
+@memory.command("embed")
+@click.option("--db", default=str(DEFAULT_DB_PATH))
+@click.option("--knowledge", default=str(DEFAULT_DB_PATH.parent / ".knowledge"))
+@click.option("--batch-size", default=64, type=int)
+@click.option("--reap/--no-reap", default=True,
+              help="Also delete embedding rows whose memory no longer exists "
+                   "(left behind by promote/demote/decay tier moves). Default on.")
+def memory_embed(db, knowledge, batch_size, reap):
+    """Backfill semantic embeddings for memories captured before this existed,
+    or after an embedding-model swap. Ongoing capture/evolve embed on their
+    own; this is for catching up the rest."""
+    from cairn.graph import embeddings as emb
+    from ..okf.bundle import OKFBundle
+
+    bundle = OKFBundle(knowledge)
+    conn = get_db(db)
+    try:
+        if reap:
+            reaped = emb.reap_orphaned_memory_embeddings(conn, bundle)
+            if reaped:
+                click.echo(f"Reaped {reaped} orphaned embedding row(s).")
+        summary = emb.embed_memory(conn, bundle, batch_size=batch_size)
+        click.echo(
+            f"Embedded {summary['embedded']} memory concept(s) with {summary['model']} "
+            f"({summary['skipped']} already up to date, {summary['total']} total)."
+        )
+    finally:
+        conn.close()
 
 
 @memory.command("batch-critic")

--- a/src/cairn/cli/update.py
+++ b/src/cairn/cli/update.py
@@ -76,7 +76,13 @@ def update(repo, file_path, workspace, db, knowledge):
     # This ensures raw memories don't grow unbounded over time.
     try:
         bundle = OKFBundle(knowledge)
-        decay_result = decay(bundle)
+        # Pass a writable conn so decay also reaps embedding rows orphaned by
+        # the tier moves (dead vectors otherwise accumulate in memory_embeddings).
+        reap_conn = get_db(db, busy_timeout_ms=20000)
+        try:
+            decay_result = decay(bundle, conn=reap_conn)
+        finally:
+            reap_conn.close()
         if decay_result.get("expired_raw", 0) > 0 or decay_result.get("archived_tribal", 0) > 0:
             display.success(
                 f"Memory decay: archived {decay_result['expired_raw']} stale raw memories, "

--- a/src/cairn/graph/__init__.py
+++ b/src/cairn/graph/__init__.py
@@ -9,10 +9,11 @@ semantic, vector_math) hold the actual implementations; the ``queries``
 shim re-exports the same names for backward compatibility.
 
 A small set of shared text/vector primitives (``simple_tokenize``,
-``BASE_STOP_WORDS``, ``l2norm``, ``dot``) and the ``embeddings`` module are
-also exposed here as the public surface for higher layers (knowledge L5,
-memory L4) to consume without reaching into submodule internals. They load
-lazily via ``__getattr__`` so a structural-only import stays embeddings-free.
+``BASE_STOP_WORDS``, ``l2norm``, ``dot``, ``rrf_fuse``) and the ``embeddings``
+module are also exposed here as the public surface for higher layers
+(knowledge L5, memory L4) to consume without reaching into submodule
+internals. They load lazily via ``__getattr__`` so a structural-only import
+stays embeddings-free.
 """
 from .cross_repo import cross_repo_deps
 from .explore import explore
@@ -43,6 +44,11 @@ def __getattr__(name):
         globals()["l2norm"] = _l
         globals()["dot"] = _d
         return _l if name == "l2norm" else _d
+    if name == "rrf_fuse":
+        from .fusion import rrf_fuse as _r
+
+        globals()["rrf_fuse"] = _r
+        return _r
     if name == "embeddings":
         # Use import_module (not `from . import embeddings`) to avoid
         # re-triggering this __getattr__ recursively: `from . import embeddings`
@@ -73,5 +79,6 @@ __all__ = [
     "BASE_STOP_WORDS",
     "l2norm",
     "dot",
+    "rrf_fuse",
     "embeddings",
 ]

--- a/src/cairn/graph/ann_index.py
+++ b/src/cairn/graph/ann_index.py
@@ -13,6 +13,14 @@ reused by delete+reinsert).
 On by default: `CAIRN_ANN_BACKEND` unset resolves to `sqlite-vec`. Set it to
 `off` to force the brute-force cosine scan. Any load failure degrades to the
 brute-force scan.
+
+Scope: this index covers ONLY the code-corpus ``embeddings`` table (the path
+that ``graph.semantic.semantic_search`` and ``explore`` consume). The
+``knowledge_embeddings`` and ``memory_embeddings`` tables intentionally have
+no vec0 index: those corpora are small and curated (dozens to low hundreds of
+rows), so a brute-force ``cosine_scan`` is sub-millisecond and not worth the
+per-write vec0 sync cost. If either corpus ever grows large, the pattern here
+(rebuild from the source table) is the template for adding one.
 """
 from __future__ import annotations
 

--- a/src/cairn/graph/embeddings.py
+++ b/src/cairn/graph/embeddings.py
@@ -850,23 +850,43 @@ def embed_memory_concepts(conn: sqlite3.Connection, bundle, concept_ids: Sequenc
     Delete+reinsert rather than upsert: a re-embed of an edited memory may
     have a different chunk count than before, so there is no stable
     chunk_index to upsert against.
+
+    Batches the (potentially expensive) ``_embed`` call: all chunks across
+    every concept in ``concept_ids`` are embedded in a SINGLE call, then
+    sliced back out per concept for the DELETE+INSERT. Read failures are
+    still isolated per concept (a deleted/moved concept is skipped before any
+    embedding happens), so one bad concept_id can't abort the batch.
     """
     model = current_model(corpus="memory")
     now = datetime.now(timezone.utc).isoformat()
-    embedded = 0
+
+    # Phase 1: read + chunk each concept, isolating read failures per-cid.
+    plan: List[Tuple[str, List[str]]] = []  # (cid, [chunks])
     for cid in concept_ids:
         try:
             concept = bundle.read_concept(cid)
         except Exception:
             continue  # deleted/moved since being queued -- nothing to embed
         chunks = chunk_memory_body(concept)
-        if not chunks:
-            continue
-        blobs, _dim = _embed(chunks)
+        if chunks:
+            plan.append((cid, chunks))
+    if not plan:
+        return 0
+
+    # Phase 2: ONE embed call for every chunk across every concept.
+    all_chunks = [chunk for _cid, chunks in plan for chunk in chunks]
+    blobs, _dim = _embed(all_chunks)
+
+    # Phase 3: slice the flat blob list back out per concept and persist.
+    embedded = 0
+    offset = 0
+    for cid, chunks in plan:
+        cid_blobs = blobs[offset:offset + len(chunks)]
+        offset += len(chunks)
         conn.execute(
             "DELETE FROM memory_embeddings WHERE doc_id = ? AND model = ?", (cid, model)
         )
-        for idx, (chunk, blob) in enumerate(zip(chunks, blobs)):
+        for idx, (chunk, blob) in enumerate(zip(chunks, cid_blobs)):
             dim = len(blob) // 4
             conn.execute(
                 "INSERT INTO memory_embeddings "
@@ -917,6 +937,56 @@ def embed_memory_count(conn):
         (current_model(corpus="memory"),),
     ).fetchone()
     return r["c"] if r else 0
+
+
+def memory_is_embedded(conn: sqlite3.Connection, doc_id: str) -> bool:
+    """True if ``doc_id`` has at least one embedding row under the current memory model."""
+    r = conn.execute(
+        "SELECT 1 FROM memory_embeddings WHERE doc_id = ? AND model = ? LIMIT 1",
+        (doc_id, current_model(corpus="memory")),
+    ).fetchone()
+    return r is not None
+
+
+def unembedded_memory_hint(conn: sqlite3.Connection, bundle) -> str:
+    """One-line footnote for recall/digest output when some memories lack embeddings.
+
+    Returns "" when every memory is embedded (or none exist), so callers can
+    append it unconditionally. Compares the persisted embedding count against
+    the on-disk memory concept count; the ``list_concepts`` scan is cheap
+    because the curated memory corpus stays small. recall/digest use a
+    read-only conn, so this never writes -- it only tells the user to run
+    ``cairn memory embed`` on the writable side.
+    """
+    total = len(bundle.list_concepts(prefix="memory/"))
+    if total == 0:
+        return ""
+    embedded = embed_memory_count(conn)
+    if embedded < total:
+        return (
+            f"({total - embedded} of {total} memories not yet embedded -- "
+            "run `cairn memory embed` for semantic recall)"
+        )
+    return ""
+
+
+def rename_memory_embedding(conn: sqlite3.Connection, old_id: str, new_id: str) -> int:
+    """Move a memory's embedding row(s) from ``old_id`` to ``new_id`` in place.
+
+    Used by promote/demote, which move a memory to a new concept_id WITHOUT
+    changing its content: renaming the persisted embedding avoids re-running
+    the embedder on unchanged text (and the orphan+re-embed it would otherwise
+    leave behind). Rows for ALL models are moved so a stale prior-model row
+    travels too (harmless -- reads are model-scoped). Does NOT commit; the
+    caller owns the transaction boundary. Returns rows moved (0 when the
+    memory had no embedding yet, in which case the caller should embed at
+    ``new_id`` instead).
+    """
+    cur = conn.execute(
+        "UPDATE memory_embeddings SET doc_id = ? WHERE doc_id = ?",
+        (new_id, old_id),
+    )
+    return cur.rowcount if cur.rowcount is not None and cur.rowcount > 0 else 0
 
 
 def reap_orphaned_memory_embeddings(conn: sqlite3.Connection, bundle) -> int:

--- a/src/cairn/graph/embeddings.py
+++ b/src/cairn/graph/embeddings.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import hashlib
 import math
 import os
+import re
 import sqlite3
 import struct
 from datetime import datetime, timezone
@@ -26,12 +27,18 @@ HASH_MODEL = "hash-256-v1"  # deterministic fallback; tests + offline smoke
 DEFAULT_DIM = 256           # dimensionality of the hash fallback embedder
 
 
+_CORPUS_MODEL_ENV = {
+    "knowledge": "CAIRN_EMBED_KNOWLEDGE_MODEL",
+    "memory": "CAIRN_EMBED_MEMORY_MODEL",
+}
+
+
 def current_model(corpus: str = "code") -> str:
     """The model name rows are stamped with for the effective backend.
 
-    ``corpus`` selects between the code corpus (default) and the knowledge
-    corpus, which can be pinned to a different local model via
-    CAIRN_EMBED_KNOWLEDGE_MODEL (falls back to CAIRN_EMBED_LOCAL_MODEL).
+    ``corpus`` selects between the code corpus (default) and the
+    knowledge/memory corpora, each of which can be pinned to a different
+    local model via its own env var (falls back to CAIRN_EMBED_LOCAL_MODEL).
     Only applies to the local backend.
     """
     backend = _effective_backend()
@@ -39,10 +46,11 @@ def current_model(corpus: str = "code") -> str:
         return HASH_MODEL
     if backend == "openai":
         return os.environ.get("CAIRN_EMBED_OPENAI_MODEL", "text-embedding-3-small")
-    if corpus == "knowledge":
-        kn_model = os.environ.get("CAIRN_EMBED_KNOWLEDGE_MODEL")
-        if kn_model:
-            return kn_model.strip()
+    env_name = _CORPUS_MODEL_ENV.get(corpus)
+    if env_name:
+        corpus_model = os.environ.get(env_name)
+        if corpus_model:
+            return corpus_model.strip()
     return (os.environ.get("CAIRN_EMBED_LOCAL_MODEL") or DEFAULT_LOCAL_MODEL).strip()
 
 
@@ -455,6 +463,10 @@ def purge_stale_models(conn: sqlite3.Connection, active_model: Optional[str] = N
         c2 = cur.execute("DELETE FROM knowledge_embeddings WHERE model != ?", (target_model,)).rowcount
     except Exception:
         c2 = 0
+    try:
+        c3 = cur.execute("DELETE FROM memory_embeddings WHERE model != ?", (target_model,)).rowcount
+    except Exception:
+        c3 = 0
 
     tables = cur.execute("SELECT name FROM sqlite_master WHERE type='table' AND name LIKE 'vec_%'").fetchall()
     # Resolve the active ANN table name once so an ImportError surfaces loudly
@@ -465,7 +477,7 @@ def purge_stale_models(conn: sqlite3.Connection, active_model: Optional[str] = N
             cur.execute(f"DROP TABLE IF EXISTS {tname}")
 
     conn.commit()
-    return c1 + c2
+    return c1 + c2 + c3
 
 
 def _embed_local(texts: Sequence[str]) -> Tuple[List[bytes], int]:
@@ -790,3 +802,147 @@ def embed_knowledge_count(conn):
         (current_model(corpus="knowledge"),),
     ).fetchone()
     return r["c"] if r else 0
+
+
+# ---------------------------------------------------------------------------
+# Memory embeddings — chunked, keyed by concept_id (see memory_embeddings
+# table). Unlike knowledge docs, a memory's concept_id is NOT stable
+# (promote/demote/decay move it to a new path with a fresh uuid suffix), so
+# rows here can go stale on a tier move; reap_orphaned_memory_embeddings
+# cleans those up periodically rather than every write path carrying the old
+# row forward.
+# ---------------------------------------------------------------------------
+
+_CHUNK_SPLIT_RE = re.compile(r"\n(?=Why:|How to apply:)")
+MAX_MEMORY_CHUNKS = 5
+
+
+def chunk_memory_body(concept) -> List[str]:
+    """Split a memory concept into embeddable chunks.
+
+    record_memory's own guidance asks agents to structure a memory body as
+    the fact, then a `Why:` line and a `How to apply:` line -- a natural,
+    marker-based chunk boundary that needs no NLP. Falls back to blank-line
+    paragraph splits for memories that don't follow that structure. The
+    title is prepended to the first chunk for context (description is
+    skipped: create_memory always sets it equal to title, so including both
+    would just duplicate it). Capped at MAX_MEMORY_CHUNKS so a very long body
+    can't blow up embedding cost.
+    """
+    body = concept.body or ""
+    parts = [p for p in _CHUNK_SPLIT_RE.split(body) if p.strip()]
+    if len(parts) < 2:
+        parts = [p for p in body.split("\n\n") if p.strip()]
+    if not parts:
+        parts = [body]
+    header = concept.title or ""
+    chunks = []
+    for i, part in enumerate(parts[:MAX_MEMORY_CHUNKS]):
+        text = f"{header} {part}".strip() if i == 0 else part.strip()
+        if text:
+            chunks.append(text)
+    return chunks or ([header] if header else [])
+
+
+def embed_memory_concepts(conn: sqlite3.Connection, bundle, concept_ids: Sequence[str]) -> int:
+    """(Re-)embed specific memory concepts by concept_id. Returns count embedded.
+
+    Delete+reinsert rather than upsert: a re-embed of an edited memory may
+    have a different chunk count than before, so there is no stable
+    chunk_index to upsert against.
+    """
+    model = current_model(corpus="memory")
+    now = datetime.now(timezone.utc).isoformat()
+    embedded = 0
+    for cid in concept_ids:
+        try:
+            concept = bundle.read_concept(cid)
+        except Exception:
+            continue  # deleted/moved since being queued -- nothing to embed
+        chunks = chunk_memory_body(concept)
+        if not chunks:
+            continue
+        blobs, _dim = _embed(chunks)
+        conn.execute(
+            "DELETE FROM memory_embeddings WHERE doc_id = ? AND model = ?", (cid, model)
+        )
+        for idx, (chunk, blob) in enumerate(zip(chunks, blobs)):
+            dim = len(blob) // 4
+            conn.execute(
+                "INSERT INTO memory_embeddings "
+                "(doc_id, chunk_index, model, dim, vec, chunk, embedded_at) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?)",
+                (cid, idx, model, dim, blob, chunk, now),
+            )
+        embedded += 1
+    return embedded
+
+
+def embed_memory(conn, bundle, batch_size=64, progress=None):
+    """Embed all memory concepts not yet embedded under the current model.
+
+    Batch backfill for memories captured before this feature existed, or
+    after a model swap. Ongoing capture/evolve calls embed via the buffered
+    per-concept path (embed_memory_concepts) instead of waiting for this.
+    """
+    model = current_model(corpus="memory")
+    cids = bundle.list_concepts(prefix="memory/")
+    if not cids:
+        return {"model": model, "embedded": 0, "skipped": 0, "total": 0}
+
+    existing = {
+        r[0] for r in conn.execute(
+            "SELECT doc_id FROM memory_embeddings WHERE model = ? AND chunk_index = 0",
+            (model,),
+        ).fetchall()
+    }
+    to_embed = [cid for cid in cids if cid not in existing]
+
+    total = len(to_embed)
+    embedded = 0
+    for i in range(0, total, batch_size):
+        batch = to_embed[i:i + batch_size]
+        embedded += embed_memory_concepts(conn, bundle, batch)
+        conn.commit()
+        if progress:
+            progress(min(i + batch_size, total), total)
+
+    return {"model": model, "embedded": embedded, "skipped": total - embedded, "total": total}
+
+
+def embed_memory_count(conn):
+    """Count memory embeddings (distinct concepts, chunk_index=0) under current model."""
+    r = conn.execute(
+        "SELECT COUNT(*) AS c FROM memory_embeddings WHERE model = ? AND chunk_index = 0",
+        (current_model(corpus="memory"),),
+    ).fetchone()
+    return r["c"] if r else 0
+
+
+def reap_orphaned_memory_embeddings(conn: sqlite3.Connection, bundle) -> int:
+    """Delete memory_embeddings rows whose concept no longer resolves in the bundle.
+
+    Covers rows left behind by promote/demote/decay tier moves (which change
+    a memory's concept_id without carrying its embedding forward). Safe to
+    call any time; best-effort like the rest of the embedding pipeline.
+    """
+    doc_ids = {
+        r[0] for r in conn.execute("SELECT DISTINCT doc_id FROM memory_embeddings").fetchall()
+    }
+    orphaned = [cid for cid in doc_ids if not _concept_exists(bundle, cid)]
+    if not orphaned:
+        return 0
+    placeholders = ",".join("?" for _ in orphaned)
+    cur = conn.execute(
+        f"DELETE FROM memory_embeddings WHERE doc_id IN ({placeholders})", orphaned
+    )
+    conn.commit()
+    return cur.rowcount if cur.rowcount is not None and cur.rowcount > 0 else 0
+
+
+def _concept_exists(bundle, concept_id: str) -> bool:
+    try:
+        bundle.read_concept(concept_id)
+        return True
+    except Exception:
+        return False

--- a/src/cairn/graph/schema.py
+++ b/src/cairn/graph/schema.py
@@ -196,6 +196,25 @@ CREATE TABLE IF NOT EXISTS knowledge_embeddings (
 );
 CREATE INDEX IF NOT EXISTS idx_knowledge_embeddings_model ON knowledge_embeddings(model);
 
+-- semantic embeddings for memory concepts (decisions/patterns/mistakes under
+-- memory/). doc_id is a concept_id path on disk (NOT a DB row, and NOT
+-- stable -- promote/demote/decay move a memory to a new concept_id), so
+-- there is no foreign key constraint and a row can go stale on a tier move
+-- (skipped at read time when doc_id no longer resolves in the bundle).
+-- chunk_index lets a long body be split into multiple embedded pieces
+-- (see chunk_memory_body) instead of one embedding per whole concept.
+CREATE TABLE IF NOT EXISTS memory_embeddings (
+    doc_id TEXT NOT NULL,          -- concept_id path (e.g. "memory/tribal/foo-a1b2c3")
+    chunk_index INTEGER NOT NULL DEFAULT 0,
+    model TEXT NOT NULL,           -- for invalidation on model swap
+    dim INTEGER NOT NULL,
+    vec BLOB NOT NULL,             -- float32 little-endian
+    chunk TEXT NOT NULL,           -- the text that was embedded
+    embedded_at TIMESTAMP,
+    PRIMARY KEY (doc_id, chunk_index, model)
+);
+CREATE INDEX IF NOT EXISTS idx_memory_embeddings_model ON memory_embeddings(model);
+
 -- precomputed dataflow index for public/exported symbols. Within-repo
 -- impacted symbols and cross-repo consumer repos are materialised so lookups
 -- are O(1) instead of re-running impact_analysis + cross_repo_deps on each

--- a/src/cairn/knowledge/search.py
+++ b/src/cairn/knowledge/search.py
@@ -250,7 +250,10 @@ def _semantic_search(conn, bundle, query, limit, threshold, include_archived=Fal
             (model,),
         ).fetchall()
 
-        # Cosine scan — dual path (numpy or pure-Python)
+        # Cosine scan — dual path (numpy or pure-Python). Deliberately brute-force:
+        # the knowledge corpus is small and curated, so a full-table scan is
+        # sub-millisecond and not worth a vec0 index (see graph/ann_index.py for
+        # the ANN path, which covers only the code-corpus embeddings table).
         scored = _cosine_scan(rows, q_blob, q_dim, threshold)
         scored.sort(key=lambda x: -x[0])
 

--- a/src/cairn/knowledge/store.py
+++ b/src/cairn/knowledge/store.py
@@ -120,17 +120,18 @@ def update_status(bundle: OKFBundle, doc_id: str, new_status: str) -> bool:
     """
     if new_status not in DOC_STATUSES:
         return False
-    concept = get_document(bundle, doc_id)
-    if not concept:
-        return False
-    current = concept.extensions.get("doc_status", "active")
-    if current not in DOC_STATUSES:
-        current = "active"
-    if DOC_STATUSES.index(new_status) < DOC_STATUSES.index(current):
-        return False
-    concept.extensions["doc_status"] = new_status
-    bundle.write_concept(concept)
-    return True
+    with bundle.lock():
+        concept = get_document(bundle, doc_id)
+        if not concept:
+            return False
+        current = concept.extensions.get("doc_status", "active")
+        if current not in DOC_STATUSES:
+            current = "active"
+        if DOC_STATUSES.index(new_status) < DOC_STATUSES.index(current):
+            return False
+        concept.extensions["doc_status"] = new_status
+        bundle.write_concept(concept)
+        return True
 
 
 def delete_document(bundle: OKFBundle, doc_id: str, conn=None) -> bool:
@@ -139,19 +140,20 @@ def delete_document(bundle: OKFBundle, doc_id: str, conn=None) -> bool:
     Removes the .md file from the bundle and optionally cleans up
     knowledge_embeddings rows in the database.
     """
-    concept = get_document(bundle, doc_id)
-    if concept is not None:
-        doc_id = concept.concept_id
-    # Route the file path through the write-path validator so a malformed /
-    # malicious doc_id can't escape the bundle root. Raises ValueError on
-    # escape; treat that as "nothing to delete".
-    try:
-        file_path = bundle._validate_concept_path(doc_id)
-    except ValueError:
-        return False
-    if not file_path.exists():
-        return False
-    file_path.unlink()
+    with bundle.lock():
+        concept = get_document(bundle, doc_id)
+        if concept is not None:
+            doc_id = concept.concept_id
+        # Route the file path through the write-path validator so a malformed /
+        # malicious doc_id can't escape the bundle root. Raises ValueError on
+        # escape; treat that as "nothing to delete".
+        try:
+            file_path = bundle._validate_concept_path(doc_id)
+        except ValueError:
+            return False
+        if not file_path.exists():
+            return False
+        file_path.unlink()
     # Clean up embeddings in DB. Normalize doc_id to relative for DB lookup.
     try:
         rel_id = str(Path(doc_id).relative_to(bundle.root))

--- a/src/cairn/mcp_server/embed_buffering.py
+++ b/src/cairn/mcp_server/embed_buffering.py
@@ -1,0 +1,103 @@
+"""Background buffered embedding for captured/evolved memory concepts.
+
+Embedding a memory needs a genuinely writable SQL connection (an INSERT into
+memory_embeddings), which would contend with a concurrent `cairn build`/
+`update` if done synchronously inside the MCP tool call under the read-only
+SSE daemon. Buffering + a background flush thread (same pattern as
+metric_buffering.py) removes that write from the tool call's hot path:
+capture/evolve enqueue a concept_id, a flusher thread drains the queue on its
+own writable connection periodically, retrying on failure instead of raising.
+
+Unlike metric_buffering, this does NOT skip under CAIRN_READ_ONLY -- a
+captured memory should still get embedded on the read-only SSE daemon (that
+is the deployment mode this exists for); the injected conn_factory is
+responsible for returning a writable connection regardless of the server's
+read-only mode (see server.py's wiring via `_rw_conn`).
+"""
+from __future__ import annotations
+
+import atexit
+import collections
+import logging
+import threading
+import time
+from typing import Callable, Optional
+
+logger = logging.getLogger(__name__)
+
+_QUEUE: collections.deque = collections.deque(maxlen=500)
+_LOCK = threading.Lock()
+_FLUSHER_STARTED = False
+_FLUSH_INTERVAL = 15.0  # seconds
+
+_conn_factory: Optional[Callable[[], "object"]] = None
+_bundle_factory: Optional[Callable[[], "object"]] = None
+
+
+def configure(conn_factory: Callable[[], "object"], bundle_factory: Callable[[], "object"]) -> None:
+    """Inject the writable-conn and bundle factories. Called once at server boot."""
+    global _conn_factory, _bundle_factory
+    _conn_factory = conn_factory
+    _bundle_factory = bundle_factory
+
+
+def enqueue(concept_id: str) -> None:
+    """Queue a memory concept_id for (re)embedding. Non-blocking, no I/O."""
+    if not concept_id:
+        return
+    with _LOCK:
+        _QUEUE.append(concept_id)
+    _start_flusher()
+
+
+def _flush() -> None:
+    with _LOCK:
+        if not _QUEUE:
+            return
+        batch = list(_QUEUE)
+    if _conn_factory is None or _bundle_factory is None:
+        return
+    from cairn.graph import embeddings as emb
+
+    conn = None
+    try:
+        conn = _conn_factory()
+        bundle = _bundle_factory()
+        emb.embed_memory_concepts(conn, bundle, batch)
+        conn.commit()
+    except Exception:
+        # Lock contention or a transient error -- leave the batch queued for
+        # the next flush attempt rather than dropping it.
+        logger.debug("memory embed flush failed; %d concept(s) remain queued", len(batch), exc_info=True)
+        return
+    finally:
+        if conn is not None:
+            try:
+                conn.close()
+            except Exception:
+                pass
+    with _LOCK:
+        for cid in batch:
+            try:
+                _QUEUE.remove(cid)
+            except ValueError:
+                pass
+
+
+def _start_flusher() -> None:
+    global _FLUSHER_STARTED
+    if _FLUSHER_STARTED:
+        return
+    with _LOCK:
+        if _FLUSHER_STARTED:
+            return
+        _FLUSHER_STARTED = True
+
+    def _loop():
+        while True:
+            time.sleep(_FLUSH_INTERVAL)
+            _flush()
+
+    t = threading.Thread(target=_loop, name="cairn-memory-embed-flusher", daemon=True)
+    t.start()
+    atexit.register(_flush)

--- a/src/cairn/mcp_server/server.py
+++ b/src/cairn/mcp_server/server.py
@@ -217,7 +217,14 @@ def run(transport: str = "stdio", port: int | None = None):
 
             knowledge_path = str(resolve_store().knowledge)
             bundle = OKFBundle(knowledge_path)
-            decay_result = decay(bundle)
+            # Open a writable conn so decay can also reap embedding rows orphaned
+            # by the tier moves (otherwise dead vectors accumulate and tax the
+            # brute-force memory cosine scan on every recall).
+            reap_conn = get_db(db_path)
+            try:
+                decay_result = decay(bundle, conn=reap_conn)
+            finally:
+                reap_conn.close()
             if decay_result.get("expired_raw", 0) > 0 or decay_result.get("archived_tribal", 0) > 0:
                 from datetime import datetime
                 ts = datetime.now().strftime("%Y-%m-%d %H:%M:%S")

--- a/src/cairn/mcp_server/server.py
+++ b/src/cairn/mcp_server/server.py
@@ -31,9 +31,15 @@ from cairn.paths import resolve_store
 # the first @instrument-wrapped tool call would otherwise hit a None factory.
 # _conn in _server_core is exactly the connection factory metric_buffering
 # needs (open graph DB for the current workspace).
-from ._server_core import _conn, mcp
+from ._server_core import _bundle, _conn, _rw_conn, mcp
 from .metric_buffering import configure_conn
 configure_conn(_conn)
+
+# Memory-embed buffering needs a genuinely writable connection (unlike
+# metrics, it must not skip under CAIRN_READ_ONLY), so it's wired with
+# _rw_conn rather than _conn.
+from . import embed_buffering
+embed_buffering.configure(_rw_conn, _bundle)
 
 # Importing the tools_*.py modules registers every @mcp.tool() on the shared
 # `mcp` instance via decorator side effects. The names aren't used directly

--- a/src/cairn/mcp_server/tools_memory.py
+++ b/src/cairn/mcp_server/tools_memory.py
@@ -103,10 +103,11 @@ def recall_memory(query: str, tier: str = "", include_superseded: bool = False) 
             f"captured -- see the Memory Capture Workflow in the skill."
         )
     out = [f"{len(results)} memories matching '{query}':"]
-    # If any hit came via the semantic fallback, surface the backend quality:
-    # the hash fallback carries token-overlap signal, not real semantic meaning.
-    # One-time warning is enough -- provenance on each line carries it too.
-    if any(c.extensions.get("provenance", "").startswith("semantic") for c in results):
+    # If any hit involved the semantic/fused ranking, surface the backend
+    # quality: the hash fallback carries token-overlap signal, not real
+    # semantic meaning. One-time warning is enough -- provenance on each line
+    # carries it too.
+    if any(c.extensions.get("provenance") for c in results):
         from cairn.graph import embeddings as _emb
         _emb.warn_hash_fallback_once(logger, context="recall_memory")
     # Reuse the already-open conn for verification.
@@ -179,9 +180,10 @@ def record_memory(
     Every raw capture still costs review/decay cycles even if never promoted.
     """
     from cairn.memory.promotion import capture_memory
+    from . import embed_buffering
 
     bundle = _bundle()
-    conn = _rw_conn()
+    conn = _conn()
     try:
         result = capture_memory(
             conn, bundle, type_=type, title=title, body=body,
@@ -189,6 +191,7 @@ def record_memory(
         )
     finally:
         conn.close()
+    embed_buffering.enqueue(result["path"])
     signals = result["signals"]
     superseded = result.get("superseded")
     msg = f"Recorded {type} '{title}' -> {result['path']} (score={signals['score']}, tier={result['tier']})"
@@ -211,9 +214,10 @@ def memory_evolve(memory_path: str, title: str = "", body: str = "") -> str:
     At least one of title or body must be provided (and differ from the old).
     """
     from cairn.memory.promotion import evolve_memory
+    from . import embed_buffering
 
     bundle = _bundle()
-    conn = _rw_conn()
+    conn = _conn()
     try:
         result = evolve_memory(
             conn, bundle, memory_path,
@@ -224,6 +228,7 @@ def memory_evolve(memory_path: str, title: str = "", body: str = "") -> str:
         conn.close()
     if result is None:
         return f"Error: could not find memory at '{memory_path}'."
+    embed_buffering.enqueue(result["path"])
     signals = result["signals"]
     return (
         f"Evolved '{memory_path}' -> {result['path']} "
@@ -238,15 +243,16 @@ def memory_promote(memory_path: str) -> str:
     compass/ (decisions/patterns/mistakes/workarounds) or wiki/features/
     (architecture), bypassing the raw→drafts→tribal tiers entirely."""
     from cairn.memory.promotion import promote_memory
+    from . import embed_buffering
 
     bundle = _bundle()
-    conn = _rw_conn()
-    try:
-        new_id = promote_memory(bundle, memory_path, conn=conn)
-    finally:
-        conn.close()
+    new_id = promote_memory(bundle, memory_path)
     if new_id is None:
         return f"Error: could not find memory at '{memory_path}'."
+    # Re-embeds at the new address rather than carrying the old row forward --
+    # content is unchanged, so this is cheap, and it's simpler than a SQL
+    # rename since promote_memory itself has no DB connection to do one with.
+    embed_buffering.enqueue(new_id)
     return f"Promoted '{memory_path}' -> {new_id}"
 
 
@@ -257,9 +263,12 @@ def memory_demote(memory_path: str, tier: str = "raw") -> str:
     Validates downward-only; rejects promotions via this tool — use
     memory_promote instead."""
     from cairn.memory.store import demote_memory
+    from . import embed_buffering
 
     bundle = _bundle()
     new_path = demote_memory(bundle, memory_path, target_tier=tier)
+    if new_path is not None:
+        embed_buffering.enqueue(new_path)
     if new_path is None:
         return (
             f"Error: cannot demote '{memory_path}' to '{tier}'. "

--- a/src/cairn/mcp_server/tools_memory.py
+++ b/src/cairn/mcp_server/tools_memory.py
@@ -49,6 +49,10 @@ def memory_digest(limit: int = 10) -> str:
             out.append(f"  [{score}, refs-verified={refs_verified}] {c.title}")
             if c.description:
                 out.append(f"    {c.description}")
+        from cairn.graph.embeddings import unembedded_memory_hint
+        hint = unembedded_memory_hint(conn, bundle)
+        if hint:
+            out.append(hint)
     finally:
         conn.close()
     return "\n".join(out)
@@ -154,6 +158,13 @@ def recall_memory(query: str, tier: str = "", include_superseded: bool = False) 
                 out.append("    ^ a cited file/symbol no longer exists in the graph -- verify before relying on this memory")
             if c.description:
                 out.append(f"    {c.description}")
+        # Footnote: surface the gap when some memories lack embeddings (e.g.
+        # after an upgrade, before `cairn memory embed` has run) so the user
+        # knows semantic recall is partial. Read-only; never writes.
+        from cairn.graph.embeddings import unembedded_memory_hint
+        hint = unembedded_memory_hint(conn, bundle)
+        if hint:
+            out.append(hint)
     finally:
         conn.close()
     return "\n".join(out)
@@ -242,17 +253,24 @@ def memory_promote(memory_path: str) -> str:
     """Force-promote a memory to canonical (compass/wiki). Moves it into
     compass/ (decisions/patterns/mistakes/workarounds) or wiki/features/
     (architecture), bypassing the raw→drafts→tribal tiers entirely."""
+    from cairn.graph.embeddings import memory_is_embedded
     from cairn.memory.promotion import promote_memory
     from . import embed_buffering
 
     bundle = _bundle()
-    new_id = promote_memory(bundle, memory_path)
-    if new_id is None:
-        return f"Error: could not find memory at '{memory_path}'."
-    # Re-embeds at the new address rather than carrying the old row forward --
-    # content is unchanged, so this is cheap, and it's simpler than a SQL
-    # rename since promote_memory itself has no DB connection to do one with.
-    embed_buffering.enqueue(new_id)
+    conn = _rw_conn()
+    try:
+        new_id = promote_memory(bundle, memory_path, conn=conn)
+        if new_id is None:
+            return f"Error: could not find memory at '{memory_path}'."
+        conn.commit()
+        # promote_memory renamed the embedding row in place (content unchanged),
+        # so only enqueue a fresh embed when the memory had no embedding yet.
+        already_embedded = memory_is_embedded(conn, new_id)
+    finally:
+        conn.close()
+    if not already_embedded:
+        embed_buffering.enqueue(new_id)
     return f"Promoted '{memory_path}' -> {new_id}"
 
 
@@ -262,12 +280,24 @@ def memory_demote(memory_path: str, tier: str = "raw") -> str:
     """Demote a memory to a lower tier (tribal→drafts→raw→archived).
     Validates downward-only; rejects promotions via this tool — use
     memory_promote instead."""
+    from cairn.graph.embeddings import memory_is_embedded
     from cairn.memory.store import demote_memory
     from . import embed_buffering
 
     bundle = _bundle()
-    new_path = demote_memory(bundle, memory_path, target_tier=tier)
-    if new_path is not None:
+    conn = _rw_conn()
+    try:
+        new_path = demote_memory(bundle, memory_path, target_tier=tier, conn=conn)
+        already_embedded = False
+        if new_path is not None:
+            conn.commit()
+            # demote_memory renamed the embedding row in place (content
+            # unchanged), so only enqueue a fresh embed when the memory had no
+            # embedding yet.
+            already_embedded = memory_is_embedded(conn, new_path)
+    finally:
+        conn.close()
+    if new_path is not None and not already_embedded:
         embed_buffering.enqueue(new_path)
     if new_path is None:
         return (

--- a/src/cairn/memory/promotion.py
+++ b/src/cairn/memory/promotion.py
@@ -1,6 +1,7 @@
 """Memory promotion, critic, decay, and search."""
 from __future__ import annotations
 
+import logging
 import sqlite3
 from datetime import datetime, timezone
 from pathlib import Path
@@ -11,6 +12,8 @@ from ..okf.concept import OKFConcept
 from ..graph import BASE_STOP_WORDS, simple_tokenize
 from . import store as store_mod
 from .scoring import DEFAULT_CRITIC_SCORE, apply_score, score_memory
+
+logger = logging.getLogger(__name__)
 
 
 def capture_memory(
@@ -282,6 +285,10 @@ def _semantic_memory_search(
             (model,),
         ).fetchall()
         triples = [(r["vec"], r["dim"], r["doc_id"]) for r in rows]
+        # Deliberately brute-force: the memory corpus is small and curated, so a
+        # full-table cosine scan is sub-millisecond and not worth a vec0 index.
+        # (graph/ann_index.py's ANN path covers only the code-corpus embeddings
+        # table; see its module docstring for when to extend it here.)
         scored = cosine_scan(q_blob, q_dim, triples, threshold=0.1)
 
         # Stamp provenance so callers know these are semantic, not lexical;
@@ -308,14 +315,23 @@ def _semantic_memory_search(
                 break
         return out
     except Exception:
+        # Never let semantic ranking break recall_memory, but leave a debug
+        # breadcrumb (schema drift / malformed blob shouldn't vanish silently).
+        logger.debug("semantic memory search failed; returning []", exc_info=True)
         return []  # never let semantic ranking break recall_memory
 
 
-def promote_memory(bundle: OKFBundle, memory_path: str) -> Optional[str]:
+def promote_memory(bundle: OKFBundle, memory_path: str, conn=None) -> Optional[str]:
     """Force-promote a memory to canonical (compass or wiki).
 
     Moves the file from its tier dir into compass/ (for decisions/patterns) or
-    wiki/ (for architecture). Returns the new concept_id or None on failure.
+    wiki/ (for the architecture). Returns the new concept_id or None on failure.
+
+    If ``conn`` is provided, the memory's persisted embedding row is renamed
+    from the old concept_id to the new one in place (content is unchanged by a
+    promote), avoiding a re-embed of identical text. The caller is responsible
+    for committing/owning the transaction; pass ``conn=None`` to skip (in which
+    case the caller should enqueue a fresh embed at the new id).
     """
     with bundle.lock():
         concept = store_mod.get_memory(bundle, memory_path)
@@ -341,6 +357,13 @@ def promote_memory(bundle: OKFBundle, memory_path: str) -> Optional[str]:
         # an unpromoted memory.
         concept.extensions.pop("memory_tier", None)
         old_id = concept.concept_id
+        # from_file leaves concept_id as an ABSOLUTE path, but embedding doc_ids
+        # are stored relative (they originate from store_memory's return value).
+        # Normalize so the embedding rename below matches the persisted row.
+        try:
+            old_id = str(Path(old_id).relative_to(bundle.root))
+        except ValueError:
+            pass  # already relative, or escapes root -- keep as-is
         concept.concept_id = new_id
         # Append the promotion-history entry BEFORE writing so the new file is
         # written exactly once with history included (no crash window between
@@ -348,6 +371,13 @@ def promote_memory(bundle: OKFBundle, memory_path: str) -> Optional[str]:
         _append_promotion(concept, "force_promote", concept.extensions.get("memory_score", 0.0))
         # Write the new file (with history) first...
         bundle.write_concept(concept)
+        # Carry the embedding forward in place instead of orphaning it (a
+        # promote never changes content, so re-embedding would be wasted work).
+        # Import via the cairn.graph public surface (not the internal submodule)
+        # per the layering rule enforced by test_layer_direction.
+        if conn is not None:
+            from cairn.graph import embeddings as _emb
+            _emb.rename_memory_embedding(conn, old_id, new_id)  # caller commits
         # ...and only once the new file is safely on disk, remove the old one.
         old_file = Path(bundle.root) / f"{old_id}.md"
         if old_file.exists():

--- a/src/cairn/memory/promotion.py
+++ b/src/cairn/memory/promotion.py
@@ -43,38 +43,39 @@ def capture_memory(
     from .privacy import strip_private_data
 
     body = strip_private_data(body)
-    superseded_id = _find_supersession_candidate(
-        conn, bundle, type_, title, body, supersedes_threshold
-    )
+    with bundle.lock():
+        superseded_id = _find_supersession_candidate(
+            conn, bundle, type_, title, body, supersedes_threshold
+        )
 
-    supersedes_chain: list[str] = []
-    if superseded_id:
-        # Inherit the old version chain so memory_supersedes is the full history.
-        old = store_mod.get_memory(bundle, superseded_id)
-        if old is not None:
-            norm_id = _norm_cid(bundle, superseded_id)
-            old_chain = [_norm_cid(bundle, cid) for cid in (old.extensions.get("memory_supersedes") or [])]
-            supersedes_chain = [norm_id] + old_chain
+        supersedes_chain: list[str] = []
+        if superseded_id:
+            # Inherit the old version chain so memory_supersedes is the full history.
+            old = store_mod.get_memory(bundle, superseded_id)
+            if old is not None:
+                norm_id = _norm_cid(bundle, superseded_id)
+                old_chain = [_norm_cid(bundle, cid) for cid in (old.extensions.get("memory_supersedes") or [])]
+                supersedes_chain = [norm_id] + old_chain
 
-    concept = store_mod.create_memory(
-        type_=type_,
-        title=title,
-        body=body,
-        resource=resource,
-        confidence=confidence,
-        session_origin=session_origin,
-        tags=tags,
-        supersedes=supersedes_chain or None,
-    )
-    signals = score_memory(concept, conn, bundle)
-    apply_score(concept, signals)
-    tier = store_mod.tier_for_score(signals["score"])
-    path = store_mod.store_memory(concept, bundle, tier=tier)
+        concept = store_mod.create_memory(
+            type_=type_,
+            title=title,
+            body=body,
+            resource=resource,
+            confidence=confidence,
+            session_origin=session_origin,
+            tags=tags,
+            supersedes=supersedes_chain or None,
+        )
+        signals = score_memory(concept, conn, bundle)
+        apply_score(concept, signals)
+        tier = store_mod.tier_for_score(signals["score"])
+        path = store_mod.store_memory(concept, bundle, tier=tier)
 
-    # Flip the old memory to is_latest=false AFTER the new one is safely on disk.
-    if superseded_id:
-        _mark_superseded(bundle, superseded_id, path)
-        _append_promotion(concept, "supersede", signals["score"])
+        # Flip the old memory to is_latest=false AFTER the new one is safely on disk.
+        if superseded_id:
+            _mark_superseded(bundle, superseded_id, path)
+            _append_promotion(concept, "supersede", signals["score"])
 
     return {
         "path": path,
@@ -170,57 +171,74 @@ def search_memory(
     session_id: Optional[str] = None,
     include_superseded: bool = False,
 ) -> List[OKFConcept]:
-    """Search tribal + canonical memories. Records a reference for each result.
+    """Search tribal + canonical memories via fused lexical + semantic ranking.
 
-    Falls back to a semantic scan over the memory corpus when the lexical
-    substring search (bundle.search) returns nothing. Superseded memories
-    (``memory_is_latest: false``) are filtered out by default; pass
+    Runs a lexical scan (substring + multi-token broaden) and a semantic scan
+    (cosine over persisted memory_embeddings) and fuses both ranked lists with
+    RRF (same technique as the code-search hybrid), so a semantically related
+    memory with no shared keywords can surface instead of only being tried
+    once lexical comes up completely empty. Semantic degrades to a no-op
+    (pure lexical results) until at least one memory has been embedded --
+    embedding happens out-of-band at capture/evolve time, not here. Superseded
+    memories (``memory_is_latest: false``) are filtered out by default; pass
     ``include_superseded=True`` to traverse the version chain.
     """
-    results = bundle.search(query, limit=20)
-    # Filter to memory concepts only.
-    results = [
-        c
-        for c in results
-        if c.concept_id.startswith("memory/") or c.extensions.get("memory_tier")
+    def _visible(c: OKFConcept) -> bool:
+        if tier and not c.extensions.get("memory_tier", "").startswith(tier):
+            return False
+        if not include_superseded and c.extensions.get("memory_is_latest", True) is False:
+            return False
+        return True
+
+    lexical_hits = [
+        c for c in bundle.search(query, limit=20)
+        if (c.concept_id.startswith("memory/") or c.extensions.get("memory_tier")) and _visible(c)
     ]
-    if tier:
-        results = [c for c in results if c.extensions.get("memory_tier", "").startswith(tier)]
+    resolved: Dict[str, OKFConcept] = {c.concept_id: c for c in lexical_hits}
 
-    # Drop superseded versions unless explicitly requested. A memory is
-    # superseded when memory_is_latest is explicitly false; older memories
-    # without this key default to True (treated as latest).
-    if not include_superseded:
-        results = [
-            c for c in results if c.extensions.get("memory_is_latest", True) is not False
-        ]
-
-    # Lexical broaden: if initial results are thin (empty or very few), run a
-    # multi-token keyword scan over all memory concepts to recover matches
-    # where query tokens are spread across fields.
-    if len(results) <= 2:
+    # Lexical broaden: only pay the cost of reading every memory concept from
+    # disk when substring search alone came up thin.
+    if len(lexical_hits) <= 2:
         all_mem = [
-            c
-            for cid in bundle.list_concepts(prefix="memory/")
-            if (c := bundle.read_concept(cid)) is not None
+            c for cid in bundle.list_concepts(prefix="memory/")
+            if (c := bundle.read_concept(cid)) is not None and _visible(c)
         ]
-        if not include_superseded:
-            all_mem = [
-                c for c in all_mem if c.extensions.get("memory_is_latest", True) is not False
-            ]
-        lexical = _lexical_memory_match(all_mem, query)
-        seen = {c.concept_id for c in results}
-        for c in lexical:
+        for c in all_mem:
+            resolved.setdefault(c.concept_id, c)
+        seen = {c.concept_id for c in lexical_hits}
+        for c in _lexical_memory_match(all_mem, query):
             if c.concept_id not in seen:
-                results.append(c)
+                lexical_hits.append(c)
                 seen.add(c.concept_id)
 
-    # Semantic fallback when lexical search comes up empty. Embeds the query
-    # and cosine-ranks every memory concept by its title+description+body.
-    if not results:
-        results = _semantic_memory_fallback(
-            conn, bundle, query, tier=tier, include_superseded=include_superseded
-        )
+    semantic_hits = _semantic_memory_search(
+        conn, bundle, query, tier=tier, include_superseded=include_superseded
+    )
+    # Overwrite (not setdefault): the semantic object already carries the
+    # provenance stamp that needs to survive into the returned result, so it
+    # must win over the provenance-less lexical object for any id in both.
+    for c in semantic_hits:
+        resolved[c.concept_id] = c
+
+    lexical_ids = [c.concept_id for c in lexical_hits]
+    semantic_ids = [c.concept_id for c in semantic_hits]
+
+    if semantic_ids:
+        from cairn.graph import rrf_fuse
+
+        # _semantic_memory_search already stamped "semantic"/"semantic (hash
+        # backend)" on its own hits; upgrade any hit found BOTH ways to
+        # "fused"/"fused (hash backend)" -- mirrors the code-search hybrid's
+        # bm25/semantic/fused labeling. Lexical-only hits stay unstamped.
+        lexical_id_set = set(lexical_ids)
+        for c in semantic_hits:
+            if c.concept_id in lexical_id_set:
+                c.extensions["provenance"] = c.extensions["provenance"].replace("semantic", "fused")
+
+        fused = rrf_fuse([lexical_ids, semantic_ids], k=60)
+        results = [resolved[cid] for cid, _score in fused if cid in resolved]
+    else:
+        results = lexical_hits
 
     # Record references for tribal/canonical (not raw/drafts) in ONE batched
     # transaction instead of one write per result, to avoid N write-lock
@@ -235,7 +253,7 @@ def search_memory(
     return results
 
 
-def _semantic_memory_fallback(
+def _semantic_memory_search(
     conn: sqlite3.Connection,
     bundle: OKFBundle,
     query: str,
@@ -243,104 +261,98 @@ def _semantic_memory_fallback(
     limit: int = 20,
     include_superseded: bool = False,
 ) -> List[OKFConcept]:
-    """Semantic recall over memory concepts when lexical search misses.
+    """Cosine scan over persisted memory_embeddings, ranked by best-matching chunk.
 
-    Embeds the query with the configured backend and cosine-ranks every memory
-    concept (by its title + description + body text). Returns [] if embedding is
-    unavailable. Under the dep-free hash fallback the stamped provenance is
-    ``semantic (hash backend)`` so callers can flag the degraded signal.
+    Returns [] if nothing has been embedded yet (fresh install, or before a
+    backfill has run) or on any error -- never raises, mirroring
+    knowledge/search.py's _semantic_search. A memory can have multiple
+    embedded chunks (see chunk_memory_body); this dedupes to one entry per
+    concept_id, keeping its single best-scoring chunk's rank.
     """
     try:
         from cairn.graph import embeddings as emb
         from cairn.retrieval import cosine_scan
 
-        if not emb.embeddings_available():
+        if emb.embed_memory_count(conn) == 0:
             return []
-        concepts = [
-            c
-            for c in (bundle.read_concept(cid) for cid in bundle.list_concepts())
-            if c is not None
-            and (
-                c.concept_id.startswith("memory/")
-                or c.extensions.get("memory_tier")
-            )
-        ]
-        if not include_superseded:
-            concepts = [
-                c for c in concepts
-                if c.extensions.get("memory_is_latest", True) is not False
-            ]
-        if tier:
-            concepts = [
-                c for c in concepts
-                if c.extensions.get("memory_tier", "").startswith(tier)
-            ]
-        if not concepts:
-            return []
-        texts = [
-            " ".join(filter(None, [c.title, c.description, c.body]))
-            for c in concepts
-        ]
-        # Embed the query + every memory text with the SAME backend so the
-        # dimensions and embedding space line up.
-        q_blob, dim = emb.embed_query(query)
-        mem_blobs, _ = emb._embed(texts)
+        model = emb.current_model(corpus="memory")
+        q_blob, q_dim = emb.embed_query(query)
+        rows = conn.execute(
+            "SELECT doc_id, vec, dim FROM memory_embeddings WHERE model = ?",
+            (model,),
+        ).fetchall()
+        triples = [(r["vec"], r["dim"], r["doc_id"]) for r in rows]
+        scored = cosine_scan(q_blob, q_dim, triples, threshold=0.1)
 
-        # Unified cosine scan over the shared vector_math helpers.
-        rows = [
-            (blob if isinstance(blob, bytes) else bytes(blob), len(blob) // 4, concept)
-            for concept, blob in zip(concepts, mem_blobs)
-        ]
-        # Mild threshold: this is a fallback, so we surface candidates even when
-        # similarity is modest. Below 0.1 the match is essentially noise.
-        scored = cosine_scan(q_blob, dim, rows, threshold=0.1)
-        out = [c for s, c in scored[:limit]]
-        # Stamp provenance so callers know these are semantic, not lexical.
+        # Stamp provenance so callers know these are semantic, not lexical;
+        # search_memory upgrades this to "fused" for hits found both ways.
         prov = "semantic (hash backend)" if emb.is_hash_fallback() else "semantic"
-        for c in out:
-            c.extensions["provenance"] = prov
+
+        seen_ids: set = set()
+        out = []
+        for _score, doc_id in scored:
+            if doc_id in seen_ids:
+                continue  # keep only the best-scoring chunk per concept
+            seen_ids.add(doc_id)
+            try:
+                concept = bundle.read_concept(doc_id)
+            except Exception:
+                continue  # row orphaned by a since-moved/deleted memory
+            if tier and not concept.extensions.get("memory_tier", "").startswith(tier):
+                continue
+            if not include_superseded and concept.extensions.get("memory_is_latest", True) is False:
+                continue
+            concept.extensions["provenance"] = prov
+            out.append(concept)
+            if len(out) >= limit:
+                break
         return out
     except Exception:
-        return []  # never let the fallback break recall_memory
+        return []  # never let semantic ranking break recall_memory
 
 
-def promote_memory(bundle: OKFBundle, memory_path: str, conn=None) -> Optional[str]:
+def promote_memory(bundle: OKFBundle, memory_path: str) -> Optional[str]:
     """Force-promote a memory to canonical (compass or wiki).
 
     Moves the file from its tier dir into compass/ (for decisions/patterns) or
     wiki/ (for architecture). Returns the new concept_id or None on failure.
     """
-    concept = store_mod.get_memory(bundle, memory_path)
-    if concept is None:
-        return None
-    mtype = concept.extensions.get("memory_type", "decision")
-    # Decisions/patterns/mistakes -> compass; architecture-ish -> wiki.
-    if mtype in ("decision", "pattern", "mistake", "workaround"):
-        new_type = "Compass"
-        new_id = f"compass/promoted-{store_mod.slugify(concept.title)}"
-    else:
-        new_type = "Wiki-Feature"
-        new_id = f"wiki/features/promoted-{store_mod.slugify(concept.title)}"
-    concept.type = new_type
-    concept.extensions["memory_status"] = "canonical"
-    # Clear the tier label: search_memory()/router.py filter on truthy
-    # memory_tier to decide whether a result is a memory hit, so a stale
-    # label here would make a promoted, canonical concept keep showing up as
-    # an unpromoted memory.
-    concept.extensions.pop("memory_tier", None)
-    old_id = concept.concept_id
-    concept.concept_id = new_id
-    # Append the promotion-history entry BEFORE writing so the new file is
-    # written exactly once with history included (no crash window between
-    # unlinking the old file and the rewrite).
-    _append_promotion(concept, "force_promote", concept.extensions.get("memory_score", 0.0))
-    # Write the new file (with history) first...
-    bundle.write_concept(concept)
-    # ...and only once the new file is safely on disk, remove the old one.
-    old_file = Path(bundle.root) / f"{old_id}.md"
-    if old_file.exists():
-        old_file.unlink()
-    return new_id
+    with bundle.lock():
+        concept = store_mod.get_memory(bundle, memory_path)
+        if concept is None:
+            return None
+        mtype = concept.extensions.get("memory_type", "decision")
+        # UUID suffix avoids same-title collisions; safe since callers always
+        # use the returned concept_id rather than reconstructing this slug.
+        import uuid
+        unique_suffix = uuid.uuid4().hex[:6]
+        # Decisions/patterns/mistakes -> compass; architecture-ish -> wiki.
+        if mtype in ("decision", "pattern", "mistake", "workaround"):
+            new_type = "Compass"
+            new_id = f"compass/promoted-{store_mod.slugify(concept.title)}-{unique_suffix}"
+        else:
+            new_type = "Wiki-Feature"
+            new_id = f"wiki/features/promoted-{store_mod.slugify(concept.title)}-{unique_suffix}"
+        concept.type = new_type
+        concept.extensions["memory_status"] = "canonical"
+        # Clear the tier label: search_memory()/router.py filter on truthy
+        # memory_tier to decide whether a result is a memory hit, so a stale
+        # label here would make a promoted, canonical concept keep showing up as
+        # an unpromoted memory.
+        concept.extensions.pop("memory_tier", None)
+        old_id = concept.concept_id
+        concept.concept_id = new_id
+        # Append the promotion-history entry BEFORE writing so the new file is
+        # written exactly once with history included (no crash window between
+        # unlinking the old file and the rewrite).
+        _append_promotion(concept, "force_promote", concept.extensions.get("memory_score", 0.0))
+        # Write the new file (with history) first...
+        bundle.write_concept(concept)
+        # ...and only once the new file is safely on disk, remove the old one.
+        old_file = Path(bundle.root) / f"{old_id}.md"
+        if old_file.exists():
+            old_file.unlink()
+        return new_id
 
 
 def batch_critic(
@@ -389,19 +401,20 @@ def decay(bundle: OKFBundle, raw_max_days: int = 7, tribal_max_stale: int = 90) 
     """Expire raw memories older than raw_max_days; archive tribal past staleness."""
     expired = 0
     archived = 0
-    for concept in store_mod.list_memories(bundle, tier="raw"):
-        ts = concept.timestamp
-        if ts and _age_days(ts) > raw_max_days:
-            old_id = concept.concept_id
-            store_mod.store_memory(concept, bundle, tier="archived", old_id=old_id)
-            expired += 1
-    for concept in store_mod.list_memories(bundle, tier="tribal"):
-        ts = concept.timestamp
-        age = _age_days(ts) if ts else 0
-        if age > tribal_max_stale:
-            old_id = concept.concept_id
-            store_mod.store_memory(concept, bundle, tier="archived", old_id=old_id)
-            archived += 1
+    with bundle.lock():
+        for concept in store_mod.list_memories(bundle, tier="raw"):
+            ts = concept.timestamp
+            if ts and _age_days(ts) > raw_max_days:
+                old_id = concept.concept_id
+                store_mod.store_memory(concept, bundle, tier="archived", old_id=old_id)
+                expired += 1
+        for concept in store_mod.list_memories(bundle, tier="tribal"):
+            ts = concept.timestamp
+            age = _age_days(ts) if ts else 0
+            if age > tribal_max_stale:
+                old_id = concept.concept_id
+                store_mod.store_memory(concept, bundle, tier="archived", old_id=old_id)
+                archived += 1
     return {"expired_raw": expired, "archived_tribal": archived}
 
 
@@ -536,30 +549,31 @@ def evolve_memory(
     stores the new version. At least one of new_title / new_body must differ
     from the old memory.
     """
-    old = store_mod.get_memory(bundle, memory_path)
-    if old is None:
-        return None
-    mtype = old.extensions.get("memory_type", "decision")
-    norm_old = _norm_cid(bundle, old.concept_id)
-    old_chain = [_norm_cid(bundle, cid) for cid in (old.extensions.get("memory_supersedes") or [])]
-    chain = [norm_old] + old_chain
-    confidence = old.extensions.get("memory_signals", {}).get("agent_confidence", 0.7)
-    concept = store_mod.create_memory(
-        type_=mtype,
-        title=new_title or old.title or "memory",
-        body=new_body or old.body or "",
-        resource=old.resource,
-        confidence=confidence,
-        tags=old.tags,
-        supersedes=chain,
-    )
-    signals = score_memory(concept, conn, bundle)
-    apply_score(concept, signals)
-    tier = store_mod.tier_for_score(signals["score"])
-    new_path = store_mod.store_memory(concept, bundle, tier=tier)
-    _mark_superseded(bundle, old.concept_id, new_path)
-    _append_promotion(concept, "evolve", signals["score"])
-    return {"path": new_path, "tier": tier, "signals": signals, "superseded": old.concept_id}
+    with bundle.lock():
+        old = store_mod.get_memory(bundle, memory_path)
+        if old is None:
+            return None
+        mtype = old.extensions.get("memory_type", "decision")
+        norm_old = _norm_cid(bundle, old.concept_id)
+        old_chain = [_norm_cid(bundle, cid) for cid in (old.extensions.get("memory_supersedes") or [])]
+        chain = [norm_old] + old_chain
+        confidence = old.extensions.get("memory_signals", {}).get("agent_confidence", 0.7)
+        concept = store_mod.create_memory(
+            type_=mtype,
+            title=new_title or old.title or "memory",
+            body=new_body or old.body or "",
+            resource=old.resource,
+            confidence=confidence,
+            tags=old.tags,
+            supersedes=chain,
+        )
+        signals = score_memory(concept, conn, bundle)
+        apply_score(concept, signals)
+        tier = store_mod.tier_for_score(signals["score"])
+        new_path = store_mod.store_memory(concept, bundle, tier=tier)
+        _mark_superseded(bundle, old.concept_id, new_path)
+        _append_promotion(concept, "evolve", signals["score"])
+        return {"path": new_path, "tier": tier, "signals": signals, "superseded": old.concept_id}
 
 
 # --- helpers -------------------------------------------------------------

--- a/src/cairn/memory/promotion.py
+++ b/src/cairn/memory/promotion.py
@@ -427,8 +427,14 @@ def batch_critic(
     return {"processed": len(drafts), "tribal": tribal, "dropped": dropped, "remaining_drafts": promoted}
 
 
-def decay(bundle: OKFBundle, raw_max_days: int = 7, tribal_max_stale: int = 90) -> Dict:
-    """Expire raw memories older than raw_max_days; archive tribal past staleness."""
+def decay(bundle: OKFBundle, raw_max_days: int = 7, tribal_max_stale: int = 90, conn=None) -> Dict:
+    """Expire raw memories older than raw_max_days; archive tribal past staleness.
+
+    If ``conn`` is provided, also reap embedding rows orphaned by the tier moves
+    (a decay moves a memory to a new concept_id, leaving its embedding row
+    stranded at the old address). Reap is best-effort and also cleans orphans
+    left by other paths; it never fails decay.
+    """
     expired = 0
     archived = 0
     with bundle.lock():
@@ -445,7 +451,19 @@ def decay(bundle: OKFBundle, raw_max_days: int = 7, tribal_max_stale: int = 90) 
                 old_id = concept.concept_id
                 store_mod.store_memory(concept, bundle, tier="archived", old_id=old_id)
                 archived += 1
-    return {"expired_raw": expired, "archived_tribal": archived}
+    reaped = 0
+    if conn is not None and (expired or archived):
+        # The moves above orphan embedding rows at the old concept_ids; clean
+        # them now rather than letting dead vectors accumulate in the table
+        # (memory search is a brute-force cosine scan, so orphans tax every
+        # recall). Reap also catches orphans from other paths.
+        from cairn.graph import embeddings as _emb
+        try:
+            reaped = _emb.reap_orphaned_memory_embeddings(conn, bundle)
+        except Exception:
+            logger.debug("memory embed reap during decay failed", exc_info=True)
+            reaped = 0
+    return {"expired_raw": expired, "archived_tribal": archived, "reaped_embeddings": reaped}
 
 
 def tribal_digest(bundle: OKFBundle, limit: int = 10) -> List[OKFConcept]:

--- a/src/cairn/memory/store.py
+++ b/src/cairn/memory/store.py
@@ -209,10 +209,14 @@ def delete_memory(bundle: OKFBundle, memory_path: str, conn=None) -> bool:
 TIER_ORDER = ["tribal", "drafts", "raw", "archived"]
 
 
-def demote_memory(bundle: OKFBundle, memory_path: str, target_tier: str = "raw") -> Optional[str]:
+def demote_memory(bundle: OKFBundle, memory_path: str, target_tier: str = "raw", conn=None) -> Optional[str]:
     """Demote a memory to a lower tier. Returns new path or None.
 
     Rejects promotions — target_tier must be strictly lower than current.
+
+    If ``conn`` is provided, the memory's persisted embedding row is renamed
+    from the old concept_id to the new one in place (content is unchanged by a
+    demote), avoiding a re-embed of identical text. The caller owns the commit.
     """
     with bundle.lock():
         concept = get_memory(bundle, memory_path)
@@ -235,6 +239,12 @@ def demote_memory(bundle: OKFBundle, memory_path: str, target_tier: str = "raw")
             pass  # keep as-is if not under bundle root
         concept.extensions["memory_tier"] = target_tier
         new_id = store_memory(concept, bundle, tier=target_tier, old_id=old_id)
+        # Carry the embedding forward in place (a demote never changes content,
+        # so re-embedding would be wasted work). old_id is already relative here.
+        # Import via the cairn.graph public surface per the layering rule.
+        if conn is not None:
+            from ..graph import embeddings as _emb
+            _emb.rename_memory_embedding(conn, old_id, new_id)  # caller commits
         return new_id
 
 

--- a/src/cairn/memory/store.py
+++ b/src/cairn/memory/store.py
@@ -176,27 +176,28 @@ def delete_memory(bundle: OKFBundle, memory_path: str, conn=None) -> bool:
     # when the concept_id escapes the bundle root. Catch it here so a
     # traversal attempt is a controlled refusal (returns False), not an
     # unhandled exception.
-    try:
-        concept = get_memory(bundle, memory_path)
-    except ValueError:
-        return False
-    if concept is not None:
-        cid = concept.concept_id
-        # Normalize to relative for DB lookup.
+    with bundle.lock():
         try:
-            cid = str(Path(cid).relative_to(bundle.root))
+            concept = get_memory(bundle, memory_path)
         except ValueError:
-            pass
-    # Route the file path through the write-path validator so a malformed
-    # concept_id can't escape the bundle root via the delete path. Raises
-    # ValueError if cid escapes root; treat that as "nothing to delete".
-    try:
-        file_path = bundle._validate_concept_path(cid)
-    except ValueError:
-        return False
-    if not file_path.exists():
-        return False
-    file_path.unlink()
+            return False
+        if concept is not None:
+            cid = concept.concept_id
+            # Normalize to relative for DB lookup.
+            try:
+                cid = str(Path(cid).relative_to(bundle.root))
+            except ValueError:
+                pass
+        # Route the file path through the write-path validator so a malformed
+        # concept_id can't escape the bundle root via the delete path. Raises
+        # ValueError if cid escapes root; treat that as "nothing to delete".
+        try:
+            file_path = bundle._validate_concept_path(cid)
+        except ValueError:
+            return False
+        if not file_path.exists():
+            return False
+        file_path.unlink()
     # Clean up memory_refs in DB. Do NOT commit here -- the caller owns the
     # transaction boundary; committing a connection we don't own can either
     # commit an in-flight caller transaction or hit "database is locked".
@@ -213,45 +214,47 @@ def demote_memory(bundle: OKFBundle, memory_path: str, target_tier: str = "raw")
 
     Rejects promotions — target_tier must be strictly lower than current.
     """
-    concept = get_memory(bundle, memory_path)
-    if concept is None:
-        return None
-    current_tier = concept.extensions.get("memory_tier", "drafts")
-    try:
-        # TIER_ORDER is highest-first: tribal=0, drafts=1, raw=2, archived=3.
-        # Demotion means target index > current index. Reject promotions (target < current)
-        # and same-tier moves.
-        if TIER_ORDER.index(target_tier) <= TIER_ORDER.index(current_tier):
-            return None  # target is same or higher — not a demotion
-    except ValueError:
-        return None  # invalid tier name
-    # Normalize concept_id to relative (from_file sets absolute paths).
-    old_id = concept.concept_id
-    try:
-        old_id = str(Path(old_id).relative_to(bundle.root))
-    except ValueError:
-        pass  # keep as-is if not under bundle root
-    concept.extensions["memory_tier"] = target_tier
-    new_id = store_memory(concept, bundle, tier=target_tier, old_id=old_id)
-    return new_id
+    with bundle.lock():
+        concept = get_memory(bundle, memory_path)
+        if concept is None:
+            return None
+        current_tier = concept.extensions.get("memory_tier", "drafts")
+        try:
+            # TIER_ORDER is highest-first: tribal=0, drafts=1, raw=2, archived=3.
+            # Demotion means target index > current index. Reject promotions (target < current)
+            # and same-tier moves.
+            if TIER_ORDER.index(target_tier) <= TIER_ORDER.index(current_tier):
+                return None  # target is same or higher — not a demotion
+        except ValueError:
+            return None  # invalid tier name
+        # Normalize concept_id to relative (from_file sets absolute paths).
+        old_id = concept.concept_id
+        try:
+            old_id = str(Path(old_id).relative_to(bundle.root))
+        except ValueError:
+            pass  # keep as-is if not under bundle root
+        concept.extensions["memory_tier"] = target_tier
+        new_id = store_memory(concept, bundle, tier=target_tier, old_id=old_id)
+        return new_id
 
 
 def purge_archived(bundle: OKFBundle, max_days: int = 90) -> int:
     """Delete archived memories older than max_days. Returns count purged."""
     now = datetime.now(timezone.utc)
     purged = 0
-    for concept in list_memories(bundle, tier="archived"):
-        ts = concept.timestamp
-        if ts:
-            try:
-                age = (now - datetime.fromisoformat(ts)).days
-            except (ValueError, TypeError):
-                age = 0
-            if age > max_days:
-                file_path = Path(bundle.root) / f"{concept.concept_id}.md"
-                if file_path.exists():
-                    file_path.unlink()
-                purged += 1
+    with bundle.lock():
+        for concept in list_memories(bundle, tier="archived"):
+            ts = concept.timestamp
+            if ts:
+                try:
+                    age = (now - datetime.fromisoformat(ts)).days
+                except (ValueError, TypeError):
+                    age = 0
+                if age > max_days:
+                    file_path = Path(bundle.root) / f"{concept.concept_id}.md"
+                    if file_path.exists():
+                        file_path.unlink()
+                    purged += 1
     return purged
 
 
@@ -273,67 +276,68 @@ def consolidate_memories(bundle: OKFBundle) -> int:
     promotes the consolidated memory to 'tribal', and archives raw duplicates.
     Returns the number of memories consolidated.
     """
-    raw_ids = bundle.list_concepts(prefix="memory/raw")
-    if len(raw_ids) < 2:
-        return 0
+    with bundle.lock():
+        raw_ids = bundle.list_concepts(prefix="memory/raw")
+        if len(raw_ids) < 2:
+            return 0
 
-    concepts = []
-    for cid in raw_ids:
-        try:
-            concepts.append(bundle.read_concept(cid))
-        except Exception:
-            pass
+        concepts = []
+        for cid in raw_ids:
+            try:
+                concepts.append(bundle.read_concept(cid))
+            except Exception:
+                pass
 
-    groups: dict[str, list[OKFConcept]] = {}
-    for c in concepts:
-        key = (c.title or "").strip().lower()
-        if not key:
-            continue
-        groups.setdefault(key, []).append(c)
+        groups: dict[str, list[OKFConcept]] = {}
+        for c in concepts:
+            key = (c.title or "").strip().lower()
+            if not key:
+                continue
+            groups.setdefault(key, []).append(c)
 
-    consolidated_count = 0
-    for title_key, group in groups.items():
-        if len(group) < 2:
-            continue
+        consolidated_count = 0
+        for title_key, group in groups.items():
+            if len(group) < 2:
+                continue
 
-        primary = group[0]
-        merged_body_lines = [primary.body or ""]
-        for c in group[1:]:
-            if c.body and c.body not in merged_body_lines:
-                merged_body_lines.append(c.body)
+            primary = group[0]
+            merged_body_lines = [primary.body or ""]
+            for c in group[1:]:
+                if c.body and c.body not in merged_body_lines:
+                    merged_body_lines.append(c.body)
 
-        new_title = primary.title or title_key.title()
-        # UUID suffix so distinct consolidations that share a title don't
-        # clobber each other via write_concept's atomic os.replace.
-        import uuid
-        unique_suffix = uuid.uuid4().hex[:6]
-        unified_concept = OKFConcept(
-            type="TribalMemory",
-            title=new_title,
-            description=primary.description or f"Consolidated memory for {new_title}",
-            body="\n\n---\n\n".join(merged_body_lines),
-            tags=list(set(sum([c.tags for c in group if c.tags], []))),
-            concept_id=f"memory/tribal/{_slugify(new_title)}-{unique_suffix}",
-            extensions={
-                "memory_tier": "tribal",
-                "consolidated_from": [c.concept_id for c in group],
-            },
-        )
-        bundle.write_concept(unified_concept)
+            new_title = primary.title or title_key.title()
+            # UUID suffix so distinct consolidations that share a title don't
+            # clobber each other via write_concept's atomic os.replace.
+            import uuid
+            unique_suffix = uuid.uuid4().hex[:6]
+            unified_concept = OKFConcept(
+                type="TribalMemory",
+                title=new_title,
+                description=primary.description or f"Consolidated memory for {new_title}",
+                body="\n\n---\n\n".join(merged_body_lines),
+                tags=list(set(sum([c.tags for c in group if c.tags], []))),
+                concept_id=f"memory/tribal/{_slugify(new_title)}-{unique_suffix}",
+                extensions={
+                    "memory_tier": "tribal",
+                    "consolidated_from": [c.concept_id for c in group],
+                },
+            )
+            bundle.write_concept(unified_concept)
 
-        for c in group:
-            if c.concept_id and c.concept_id != unified_concept.concept_id:
-                try:
-                    c.extensions["memory_tier"] = "archived"
-                    # UUID suffix (same format as store_memory's non-raw tier)
-                    # so distinct memories that share a title don't clobber
-                    # each other via write_concept's atomic os.replace.
-                    archived_suffix = uuid.uuid4().hex[:6]
-                    c.concept_id = f"memory/archived/{_slugify(c.title or 'memory')}-{archived_suffix}"
-                    bundle.write_concept(c)
-                except Exception:
-                    pass
+            for c in group:
+                if c.concept_id and c.concept_id != unified_concept.concept_id:
+                    try:
+                        c.extensions["memory_tier"] = "archived"
+                        # UUID suffix (same format as store_memory's non-raw tier)
+                        # so distinct memories that share a title don't clobber
+                        # each other via write_concept's atomic os.replace.
+                        archived_suffix = uuid.uuid4().hex[:6]
+                        c.concept_id = f"memory/archived/{_slugify(c.title or 'memory')}-{archived_suffix}"
+                        bundle.write_concept(c)
+                    except Exception:
+                        pass
 
-        consolidated_count += len(group)
+            consolidated_count += len(group)
 
     return consolidated_count

--- a/src/cairn/okf/bundle.py
+++ b/src/cairn/okf/bundle.py
@@ -17,9 +17,12 @@ from .concept import OKFConcept
 
 logger = logging.getLogger(__name__)
 
-# flock() locks are per-fd, not per-process, so nested lock() calls in the
-# same thread must not re-open+flock (they'd block forever waiting on
-# themselves) -- tracked here instead of re-acquiring the OS lock.
+# flock() locks are per open-file-description: a second os.open() of the same
+# file -- even in the same thread/process -- gets an independent lock that
+# conflicts with the first (EAGAIN under LOCK_NB). So nested lock() calls must
+# NOT re-open+flock; the inner flock would hit the outer's lock and, because the
+# acquire path uses LOCK_NB, busy-wait to a spurious TimeoutError rather than
+# block forever. Tracked via a thread-local depth counter instead.
 _LOCK_DEPTH = threading.local()
 
 

--- a/src/cairn/okf/bundle.py
+++ b/src/cairn/okf/bundle.py
@@ -1,7 +1,13 @@
 """OKF bundle manager: read/write/list/search concepts in a .knowledge/ tree."""
 from __future__ import annotations
 
+import contextlib
+import errno
+import fcntl
 import logging
+import os
+import threading
+import time
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional
@@ -10,6 +16,58 @@ from typing import Any, Dict, List, Optional
 from .concept import OKFConcept
 
 logger = logging.getLogger(__name__)
+
+# flock() locks are per-fd, not per-process, so nested lock() calls in the
+# same thread must not re-open+flock (they'd block forever waiting on
+# themselves) -- tracked here instead of re-acquiring the OS lock.
+_LOCK_DEPTH = threading.local()
+
+
+@contextlib.contextmanager
+def _okf_bundle_lock(root: Path, timeout: float = 5.0):
+    """Advisory cross-process lock over mutations to the bundle at ``root``."""
+    key = str(root.resolve())
+    depth = getattr(_LOCK_DEPTH, "depth", None)
+    if depth is None:
+        depth = {}
+        _LOCK_DEPTH.depth = depth
+
+    if depth.get(key, 0) > 0:
+        # Already held by this thread (a nested call) -- no-op.
+        depth[key] += 1
+        try:
+            yield
+        finally:
+            depth[key] -= 1
+        return
+
+    root.mkdir(parents=True, exist_ok=True)
+    lock_path = root / ".okf.lock"
+    fd = os.open(str(lock_path), os.O_CREAT | os.O_WRONLY, 0o644)
+    deadline = time.monotonic() + timeout
+    try:
+        while True:
+            try:
+                fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                break
+            except OSError as e:
+                if e.errno not in (errno.EACCES, errno.EAGAIN):
+                    raise
+                if time.monotonic() >= deadline:
+                    raise TimeoutError(
+                        f"Timed out after {timeout}s waiting for the OKF bundle "
+                        f"lock at {lock_path} -- another process is mutating "
+                        f"{root}."
+                    )
+                time.sleep(0.05)
+        depth[key] = 1
+        try:
+            yield
+        finally:
+            depth[key] = 0
+            fcntl.flock(fd, fcntl.LOCK_UN)
+    finally:
+        os.close(fd)
 
 
 class OKFBundle:
@@ -22,6 +80,10 @@ class OKFBundle:
         # call and invalidated by any mutation (write/delete) so it can never
         # go stale.
         self._index: Optional[Dict[str, Dict[str, Any]]] = None
+
+    def lock(self, timeout: float = 5.0):
+        """Advisory cross-process lock guarding a read-modify-write sequence."""
+        return _okf_bundle_lock(self.root, timeout=timeout)
 
     def _validate_concept_path(self, concept_id: str) -> Path:
         self.root.mkdir(parents=True, exist_ok=True)

--- a/tests/test_embedding_backend_quality.py
+++ b/tests/test_embedding_backend_quality.py
@@ -4,7 +4,7 @@ Covers the fix for silent degradation under the dep-free hash fallback:
   1. is_hash_fallback() — the shared detector (replaces inline checks)
   2. warn_hash_fallback_once — one-time-per-process warning
   3. Provenance enrichment on the query-time paths:
-     - memory recall (_semantic_memory_fallback stamps provenance)
+     - memory recall (_semantic_memory_search stamps provenance)
      - semantic_search (semantic/fused provenance under hash)
      - knowledge search (semantic_knowledge provenance under hash)
 
@@ -177,19 +177,22 @@ def _write_memory(bundle, title="Test memory", body="a body"):
 
 
 class TestMemoryRecallProvenance:
-    """_semantic_memory_fallback stamps hash-backend provenance."""
+    """_semantic_memory_search stamps hash-backend provenance."""
 
     def test_provenance_under_hash_fallback(self, db, bundle, monkeypatch):
-        from cairn.memory.promotion import _semantic_memory_fallback
+        from cairn.graph.embeddings import embed_memory_concepts
+        from cairn.memory.promotion import _semantic_memory_search
 
-        _write_memory(bundle, title="Use JWT auth", body="Use JWT for authentication")
+        concept = _write_memory(bundle, title="Use JWT auth", body="Use JWT for authentication")
         monkeypatch.setattr(
             "cairn.graph.embeddings.is_hash_fallback", lambda: True
         )
         # embeddings_available() must be True for the path to run (hash returns True).
         monkeypatch.setattr("cairn.graph.embeddings.embeddings_available", lambda: True)
+        embed_memory_concepts(db, bundle, [concept.concept_id])
+        db.commit()
 
-        out = _semantic_memory_fallback(db, bundle, "JWT authentication")
+        out = _semantic_memory_search(db, bundle, "JWT authentication")
         assert out, "expected at least one semantic hit"
         for c in out:
             assert c.extensions["provenance"] == "semantic (hash backend)", (
@@ -197,15 +200,18 @@ class TestMemoryRecallProvenance:
             )
 
     def test_provenance_under_real_backend(self, db, bundle, monkeypatch):
-        from cairn.memory.promotion import _semantic_memory_fallback
+        from cairn.graph.embeddings import embed_memory_concepts
+        from cairn.memory.promotion import _semantic_memory_search
 
-        _write_memory(bundle, title="Use JWT auth", body="Use JWT for authentication")
+        concept = _write_memory(bundle, title="Use JWT auth", body="Use JWT for authentication")
         monkeypatch.setattr(
             "cairn.graph.embeddings.is_hash_fallback", lambda: False
         )
         monkeypatch.setattr("cairn.graph.embeddings.embeddings_available", lambda: True)
+        embed_memory_concepts(db, bundle, [concept.concept_id])
+        db.commit()
 
-        out = _semantic_memory_fallback(db, bundle, "JWT authentication")
+        out = _semantic_memory_search(db, bundle, "JWT authentication")
         # The hash embedder still runs in the test env, so we get hits; the point
         # is the provenance label reflects a real backend (no hash annotation).
         for c in out:

--- a/tests/test_mcp_connection_leaks.py
+++ b/tests/test_mcp_connection_leaks.py
@@ -12,8 +12,8 @@ The 12 leaky tools are:
 
 The 5 correct tools already use try/finally:
 - tools_graph.py: semantic_search
-- tools_memory.py: memory_promote, memory_delete
-- tools_memory.py: memory_demote (no DB, so no leak)
+- tools_memory.py: memory_delete
+- tools_memory.py: memory_promote, memory_demote (no DB, so no leak)
 - tools_compass.py: get_compass, search_knowledge (no DB, so no leak)
 
 Note (pruned 2026-07-31): this file previously had 22 tests -- one exception
@@ -192,8 +192,8 @@ class TestMCPConnectionLeaks:
     def test_record_memory_closes_conn_on_exception(self, mock_conn):
         """record_memory must close conn even when query raises.
 
-        record_memory uses _rw_conn() (a writable connection) rather than the
-        read-only _conn(), since its purpose is to write -- patch _rw_conn here.
+        capture_memory only reads through this connection (scoring lookups),
+        so record_memory uses the read-only _conn() -- patch that here.
         """
         from cairn.mcp_server.tools_memory import record_memory
 
@@ -201,7 +201,7 @@ class TestMCPConnectionLeaks:
             raise RuntimeError("Query failed")
 
         with patch("cairn.mcp_server.tools_memory._bundle", return_value=MagicMock()):
-            with patch("cairn.mcp_server.tools_memory._rw_conn", return_value=mock_conn):
+            with patch("cairn.mcp_server.tools_memory._conn", return_value=mock_conn):
                 with patch("cairn.memory.promotion.capture_memory", mock_capture_raises):
                     try:
                         record_memory("decision", "test_title", "test_body")

--- a/tests/test_memory_embeddings.py
+++ b/tests/test_memory_embeddings.py
@@ -427,3 +427,65 @@ class TestUnembeddedHint:
 
     def test_no_hint_when_corpus_empty(self, db, bundle):
         assert unembedded_memory_hint(db, bundle) == ""
+
+
+# ---------------------------------------------------------------------------
+# 8. decay reaps embedding rows orphaned by tier moves
+# ---------------------------------------------------------------------------
+
+
+class TestDecayReapsOrphans:
+    def test_decay_with_conn_reaps_orphaned_embedding(self, db, bundle):
+        """decay moves a stale memory to a new concept_id, orphaning its
+        embedding row at the old address. With a conn, decay reaps that orphan
+        instead of leaving a dead vector to bloat the brute-force cosine scan."""
+        from datetime import datetime, timedelta, timezone
+        from cairn.memory.promotion import decay
+
+        old_ts = (datetime.now(timezone.utc) - timedelta(days=10)).isoformat()
+        concept = OKFConcept(
+            type="Raw", title="Stale raw memory", description="Stale raw memory",
+            body="Body.", timestamp=old_ts, tags=[],
+            concept_id="memory/raw/stale-abc123",
+            extensions={"memory_tier": "raw", "memory_is_latest": True, "memory_type": "decision"},
+        )
+        bundle.write_concept(concept)
+        embed_memory_concepts(db, bundle, [concept.concept_id])
+        db.commit()
+        assert memory_is_embedded(db, concept.concept_id)  # baseline: row exists
+
+        result = decay(bundle, conn=db)
+        db.commit()
+
+        assert result["expired_raw"] >= 1, "stale raw memory should be archived"
+        # The row at the OLD concept_id is orphaned by the move and must be reaped.
+        assert not memory_is_embedded(db, concept.concept_id)
+        assert result["reaped_embeddings"] >= 1
+
+    def test_decay_without_conn_leaves_orphan(self, db, bundle):
+        """Without a conn, decay can't reap -- the orphan survives (the gap that
+        passing conn closes). This pins the behavior so the conn param stays
+        load-bearing rather than silently dropping the reap."""
+        from datetime import datetime, timedelta, timezone
+        from cairn.memory.promotion import decay
+
+        old_ts = (datetime.now(timezone.utc) - timedelta(days=10)).isoformat()
+        concept = OKFConcept(
+            type="Raw", title="Stale raw memory 2", description="Stale raw memory 2",
+            body="Body.", timestamp=old_ts, tags=[],
+            concept_id="memory/raw/stale-def456",
+            extensions={"memory_tier": "raw", "memory_is_latest": True, "memory_type": "decision"},
+        )
+        bundle.write_concept(concept)
+        embed_memory_concepts(db, bundle, [concept.concept_id])
+        db.commit()
+        old_id = concept.concept_id
+
+        decay(bundle, conn=None)  # no conn -> no reap
+        db.commit()
+
+        # The row is now orphaned (concept moved) but NOT reaped.
+        rows = db.execute(
+            "SELECT COUNT(*) AS c FROM memory_embeddings WHERE doc_id = ?", (old_id,)
+        ).fetchone()
+        assert rows["c"] > 0, "without conn, decay must leave the orphan in place"

--- a/tests/test_memory_embeddings.py
+++ b/tests/test_memory_embeddings.py
@@ -16,15 +16,19 @@ import sqlite3
 
 import pytest
 
+import cairn.graph.embeddings as emb
 from cairn.graph.embeddings import (
     chunk_memory_body,
     embed_memory,
     embed_memory_concepts,
     embed_memory_count,
+    memory_is_embedded,
     reap_orphaned_memory_embeddings,
+    rename_memory_embedding,
+    unembedded_memory_hint,
 )
 from cairn.graph.schema import _apply_schema
-from cairn.memory.promotion import _semantic_memory_search, search_memory
+from cairn.memory.promotion import _semantic_memory_search, promote_memory, search_memory
 from cairn.okf.bundle import OKFBundle
 from cairn.okf.concept import OKFConcept
 
@@ -156,6 +160,27 @@ class TestEmbedMemoryConcepts:
             "SELECT chunk_index FROM memory_embeddings WHERE doc_id = ?", (concept.concept_id,)
         ).fetchall()
         assert len(rows) == 1, "stale chunk rows from the longer body must not survive a re-embed"
+
+    def test_batch_embeds_all_concepts_in_one_embed_call(self, db, bundle, monkeypatch):
+        """All chunks across every concept are embedded in a SINGLE _embed call
+        (not one per concept) -- the backfill/flusher perf optimization."""
+        real_embed = emb._embed
+        calls = []
+
+        def counting_embed(texts):
+            calls.append(len(texts))
+            return real_embed(texts)
+
+        monkeypatch.setattr(emb, "_embed", counting_embed)
+        _write_memory(bundle, "memory/tribal/a", "A", "Why: a.\nHow to apply: b.")
+        _write_memory(bundle, "memory/tribal/c", "C", "Why: c.\nHow to apply: d.")
+        n = embed_memory_concepts(db, bundle, ["memory/tribal/a", "memory/tribal/c"])
+        db.commit()
+        assert n == 2
+        assert len(calls) == 1, "both concepts should share one _embed call"
+        # And that one call carried all chunks from both concepts (2 each:
+        # title+Why, and How-to-apply).
+        assert calls[0] == 4
 
 
 class TestEmbedMemoryBackfill:
@@ -305,3 +330,100 @@ class TestEmbedBuffering:
         ebuf._flush()  # must not raise
 
         assert list(ebuf._QUEUE) == ["memory/tribal/foo"], "failed flush must not drop the batch"
+
+
+# ---------------------------------------------------------------------------
+# 5. rename-on-tier-move (promote/demote carry the embedding forward in place)
+# ---------------------------------------------------------------------------
+
+
+class TestRenameOnTierMove:
+    def test_memory_is_embedded_truthiness(self, db, bundle):
+        concept = _write_memory(bundle, "memory/tribal/foo", "T", "Body.")
+        assert not memory_is_embedded(db, concept.concept_id)
+        embed_memory_concepts(db, bundle, [concept.concept_id])
+        db.commit()
+        assert memory_is_embedded(db, concept.concept_id)
+
+    def test_rename_moves_rows_in_place(self, db, bundle):
+        concept = _write_memory(bundle, "memory/tribal/foo", "T", "Body text.")
+        embed_memory_concepts(db, bundle, [concept.concept_id])
+        db.commit()
+        moved = rename_memory_embedding(db, concept.concept_id, "compass/promoted-x")
+        db.commit()
+        assert moved > 0
+        # The row now lives at the new address; nothing left at the old one.
+        assert not memory_is_embedded(db, concept.concept_id)
+        assert memory_is_embedded(db, "compass/promoted-x")
+
+    def test_promote_with_conn_renames_embedding(self, db, bundle):
+        concept = _write_memory(
+            bundle, "memory/tribal/foo", "Decision X",
+            "Why: a.\nHow to apply: b.", tier="tribal",
+        )
+        embed_memory_concepts(db, bundle, [concept.concept_id])
+        db.commit()
+
+        new_id = promote_memory(bundle, concept.concept_id, conn=db)
+        db.commit()
+
+        assert new_id is not None
+        # The embedding followed the (unchanged) content to the new address --
+        # no orphaned old row, no duplicate, no re-embed.
+        assert not memory_is_embedded(db, concept.concept_id)
+        assert memory_is_embedded(db, new_id)
+
+
+# ---------------------------------------------------------------------------
+# 6. _semantic_memory_search observability (logs, never raises)
+# ---------------------------------------------------------------------------
+
+
+class TestSemanticSearchLogging:
+    def test_logs_and_returns_empty_on_error(self, db, bundle, monkeypatch, caplog):
+        """recall_memory must stay available, so _semantic_memory_search never
+        raises -- but it now leaves a debug breadcrumb instead of swallowing
+        errors silently."""
+        import logging
+
+        # Need at least one embedded row so the function proceeds past the
+        # embed_memory_count==0 guard and reaches embed_query.
+        _write_memory(bundle, "memory/tribal/foo", "T", "Body.")
+        embed_memory_concepts(db, bundle, ["memory/tribal/foo"])
+        db.commit()
+
+        def _boom(_q):
+            raise RuntimeError("induced")
+
+        monkeypatch.setattr(emb, "embed_query", _boom)
+        with caplog.at_level(logging.DEBUG, logger="cairn.memory.promotion"):
+            result = _semantic_memory_search(db, bundle, "anything")
+        assert result == []
+        assert any(
+            "semantic memory search failed" in r.message for r in caplog.records
+        ), "expected a debug breadcrumb for the swallowed error"
+
+
+# ---------------------------------------------------------------------------
+# 7. unembedded_memory_hint (recall/digest footnote)
+# ---------------------------------------------------------------------------
+
+
+class TestUnembeddedHint:
+    def test_hint_when_some_memories_unembedded(self, db, bundle):
+        _write_memory(bundle, "memory/tribal/a", "A", "Body A.")
+        _write_memory(bundle, "memory/tribal/b", "B", "Body B.")
+        embed_memory_concepts(db, bundle, ["memory/tribal/a"])
+        db.commit()
+        hint = unembedded_memory_hint(db, bundle)
+        assert "1 of 2" in hint
+        assert "cairn memory embed" in hint
+
+    def test_no_hint_when_all_embedded(self, db, bundle):
+        _write_memory(bundle, "memory/tribal/a", "A", "Body A.")
+        embed_memory_concepts(db, bundle, ["memory/tribal/a"])
+        db.commit()
+        assert unembedded_memory_hint(db, bundle) == ""
+
+    def test_no_hint_when_corpus_empty(self, db, bundle):
+        assert unembedded_memory_hint(db, bundle) == ""

--- a/tests/test_memory_embeddings.py
+++ b/tests/test_memory_embeddings.py
@@ -1,0 +1,307 @@
+"""Tests for memory semantic embeddings: chunking, persistence, fused recall.
+
+Covers the feature that replaced the old _semantic_memory_fallback (which
+re-embedded every memory concept on every recall call with no persistence):
+  1. chunk_memory_body -- Why:/How-to-apply: marker splitting + paragraph
+     fallback, no title/description duplication.
+  2. embed_memory_concepts / embed_memory / reap_orphaned_memory_embeddings --
+     the memory_embeddings table's write/backfill/cleanup paths.
+  3. search_memory -- always-on lexical+semantic RRF fusion, chunk dedup,
+     provenance stamping ("semantic" / "fused").
+  4. embed_buffering -- enqueue now, flush later, best-effort on failure.
+"""
+from __future__ import annotations
+
+import sqlite3
+
+import pytest
+
+from cairn.graph.embeddings import (
+    chunk_memory_body,
+    embed_memory,
+    embed_memory_concepts,
+    embed_memory_count,
+    reap_orphaned_memory_embeddings,
+)
+from cairn.graph.schema import _apply_schema
+from cairn.memory.promotion import _semantic_memory_search, search_memory
+from cairn.okf.bundle import OKFBundle
+from cairn.okf.concept import OKFConcept
+
+
+@pytest.fixture
+def bundle(tmp_path):
+    return OKFBundle(str(tmp_path / "knowledge"))
+
+
+@pytest.fixture
+def db():
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    _apply_schema(conn)
+    yield conn
+    conn.close()
+
+
+def _write_memory(bundle, concept_id, title, body, tier="tribal", is_latest=True):
+    concept = OKFConcept(
+        type="Tribal-decision",
+        title=title,
+        description=title,
+        tags=["decision"],
+        body=body,
+        extensions={
+            "memory_tier": tier,
+            "memory_is_latest": is_latest,
+            "memory_type": "decision",
+        },
+        concept_id=concept_id,
+    )
+    bundle.write_concept(concept)
+    return concept
+
+
+# ---------------------------------------------------------------------------
+# 1. chunk_memory_body
+# ---------------------------------------------------------------------------
+
+
+class TestChunkMemoryBody:
+    def test_splits_on_why_and_how_to_apply(self):
+        concept = OKFConcept(
+            type="Tribal-decision", title="T", description="T",
+            body="The fact.\nWhy: the reasoning.\nHow to apply: the guidance.",
+            concept_id="memory/tribal/t",
+        )
+        chunks = chunk_memory_body(concept)
+        assert len(chunks) == 3
+        assert chunks[0] == "T The fact."
+        assert chunks[1] == "Why: the reasoning."
+        assert chunks[2] == "How to apply: the guidance."
+
+    def test_falls_back_to_paragraph_split_without_markers(self):
+        concept = OKFConcept(
+            type="Tribal-decision", title="T", description="T",
+            body="Para one.\n\nPara two.\n\nPara three.",
+            concept_id="memory/tribal/t",
+        )
+        chunks = chunk_memory_body(concept)
+        assert chunks == ["T Para one.", "Para two.", "Para three."]
+
+    def test_title_not_duplicated_via_description(self):
+        """create_memory always sets description=title; the header must use
+        title alone or a memory whose body echoes the title would triple up."""
+        concept = OKFConcept(
+            type="Tribal-decision", title="Echo title", description="Echo title",
+            body="Echo title restated in the body.",
+            concept_id="memory/tribal/t",
+        )
+        chunks = chunk_memory_body(concept)
+        assert chunks == ["Echo title Echo title restated in the body."]
+
+    def test_caps_at_max_chunks(self):
+        body = "\n\n".join(f"Paragraph {i}." for i in range(10))
+        concept = OKFConcept(
+            type="Tribal-decision", title="T", description="T", body=body,
+            concept_id="memory/tribal/t",
+        )
+        chunks = chunk_memory_body(concept)
+        assert len(chunks) == 5
+
+    def test_empty_body_falls_back_to_title(self):
+        concept = OKFConcept(
+            type="Tribal-decision", title="Just a title", description="Just a title",
+            body="", concept_id="memory/tribal/t",
+        )
+        assert chunk_memory_body(concept) == ["Just a title"]
+
+
+# ---------------------------------------------------------------------------
+# 2. embed_memory_concepts / embed_memory / reap
+# ---------------------------------------------------------------------------
+
+
+class TestEmbedMemoryConcepts:
+    def test_round_trip_writes_one_row_per_chunk(self, db, bundle):
+        concept = _write_memory(
+            bundle, "memory/tribal/foo",
+            "ApiFactory backoff",
+            "Uses exponential backoff.\nWhy: flaky staging network.\nHow to apply: check before adding retries.",
+        )
+        n = embed_memory_concepts(db, bundle, [concept.concept_id])
+        db.commit()
+        assert n == 1
+        assert embed_memory_count(db) == 1
+        rows = db.execute(
+            "SELECT chunk_index FROM memory_embeddings WHERE doc_id = ? ORDER BY chunk_index",
+            (concept.concept_id,),
+        ).fetchall()
+        assert [r["chunk_index"] for r in rows] == [0, 1, 2]
+
+    def test_deleted_concept_is_skipped_not_raised(self, db, bundle):
+        # Never written -- embed_memory_concepts must degrade gracefully.
+        n = embed_memory_concepts(db, bundle, ["memory/tribal/does-not-exist"])
+        assert n == 0
+
+    def test_reembed_replaces_old_chunks_not_appends(self, db, bundle):
+        concept = _write_memory(bundle, "memory/tribal/foo", "T", "Why: a.\nHow to apply: b.")
+        embed_memory_concepts(db, bundle, [concept.concept_id])
+        db.commit()
+        # Edit to a shorter body (fewer chunks) and re-embed.
+        concept.body = "Just one paragraph now."
+        bundle.write_concept(concept)
+        embed_memory_concepts(db, bundle, [concept.concept_id])
+        db.commit()
+        rows = db.execute(
+            "SELECT chunk_index FROM memory_embeddings WHERE doc_id = ?", (concept.concept_id,)
+        ).fetchall()
+        assert len(rows) == 1, "stale chunk rows from the longer body must not survive a re-embed"
+
+
+class TestEmbedMemoryBackfill:
+    def test_embeds_all_unembedded_memories(self, db, bundle):
+        _write_memory(bundle, "memory/tribal/a", "A", "Body A")
+        _write_memory(bundle, "memory/tribal/b", "B", "Body B")
+        summary = embed_memory(db, bundle)
+        assert summary["embedded"] == 2
+        assert embed_memory_count(db) == 2
+
+    def test_skips_already_embedded(self, db, bundle):
+        _write_memory(bundle, "memory/tribal/a", "A", "Body A")
+        embed_memory(db, bundle)
+        _write_memory(bundle, "memory/tribal/b", "B", "Body B")
+        summary = embed_memory(db, bundle)
+        # "a" is excluded from this round's work entirely (not attempted, not
+        # counted as skipped) -- only "b" (the newly unembedded one) is total.
+        assert summary["total"] == 1
+        assert summary["embedded"] == 1
+        assert embed_memory_count(db) == 2
+
+
+class TestReapOrphanedMemoryEmbeddings:
+    def test_removes_rows_for_deleted_concepts_only(self, db, bundle):
+        kept = _write_memory(bundle, "memory/tribal/kept", "Kept", "Body")
+        gone = _write_memory(bundle, "memory/tribal/gone", "Gone", "Body")
+        embed_memory_concepts(db, bundle, [kept.concept_id, gone.concept_id])
+        db.commit()
+
+        import os
+        os.remove(str(bundle.root / f"{gone.concept_id}.md"))
+
+        reaped = reap_orphaned_memory_embeddings(db, bundle)
+        assert reaped > 0
+        remaining = {
+            r["doc_id"] for r in db.execute("SELECT DISTINCT doc_id FROM memory_embeddings").fetchall()
+        }
+        assert remaining == {kept.concept_id}
+
+
+# ---------------------------------------------------------------------------
+# 3. search_memory fusion
+# ---------------------------------------------------------------------------
+
+
+class TestSearchMemoryFusion:
+    def test_semantic_only_hit_surfaces_without_lexical_overlap(self, db, bundle):
+        """A memory embedded but sharing zero substring/token overlap with the
+        query must still surface via the semantic path (the whole point of
+        moving off the old lexical-empty-only fallback)."""
+        concept = _write_memory(
+            bundle, "memory/tribal/foo", "Retry policy",
+            "ApiFactory retries with exponential backoff on 5xx responses.",
+        )
+        embed_memory_concepts(db, bundle, [concept.concept_id])
+        db.commit()
+
+        results = search_memory(db, bundle, "zzqx totally unrelated tokens")
+        # The hash embedder is token-based, so an utterly disjoint query
+        # legitimately scores near zero -- this asserts the plumbing doesn't
+        # error and returns a list (possibly empty), not that hash-backend
+        # "semantic" quality resembles real meaning-based retrieval.
+        assert isinstance(results, list)
+
+    def test_fused_provenance_when_found_both_ways(self, db, bundle):
+        concept = _write_memory(
+            bundle, "memory/tribal/foo", "ApiFactory backoff policy",
+            "Why: flaky staging network caused an outage.\nHow to apply: check before adding retries.",
+        )
+        embed_memory_concepts(db, bundle, [concept.concept_id])
+        db.commit()
+
+        results = search_memory(db, bundle, "flaky staging network outage")
+        assert results, "expected the memory to be found"
+        # bundle.read_concept() rewrites concept_id to an absolute path, so
+        # match on title rather than the pre-write relative concept_id.
+        hit = next(c for c in results if c.title == concept.title)
+        assert hit.extensions.get("provenance") == "fused"
+
+    def test_chunk_dedup_returns_one_entry_per_concept(self, db, bundle):
+        """A memory with 3 embedded chunks must appear once in results, not
+        once per matching chunk."""
+        concept = _write_memory(
+            bundle, "memory/tribal/foo", "T",
+            "Fact.\nWhy: reasoning here.\nHow to apply: guidance here.",
+        )
+        embed_memory_concepts(db, bundle, [concept.concept_id])
+        db.commit()
+        hits = _semantic_memory_search(db, bundle, "reasoning guidance fact")
+        ids = [c.concept_id for c in hits]
+        assert ids.count(concept.concept_id) <= 1
+
+    def test_no_embeddings_yet_degrades_to_pure_lexical(self, db, bundle):
+        """Before any backfill/capture has embedded anything, search_memory
+        must not error -- it just returns lexical-only results."""
+        _write_memory(bundle, "memory/tribal/foo", "Plain lexical hit", "Nothing embedded yet.")
+        results = search_memory(db, bundle, "plain lexical hit")
+        assert results
+        assert results[0].extensions.get("provenance") in (None, "")
+
+
+# ---------------------------------------------------------------------------
+# 4. embed_buffering
+# ---------------------------------------------------------------------------
+
+
+class TestEmbedBuffering:
+    def test_enqueue_then_flush_embeds_the_concept(self, tmp_path, bundle, monkeypatch):
+        from cairn.mcp_server import embed_buffering as ebuf
+
+        # _flush()'s contract closes whatever connection the factory returns
+        # (matching the real background-thread usage where each flush opens
+        # a fresh throwaway connection) -- so this needs a file-backed DB to
+        # reopen for verification, not the shared in-memory `db` fixture
+        # (which would be destroyed once its one connection is closed).
+        db_path = str(tmp_path / "graph.db")
+        setup_conn = sqlite3.connect(db_path)
+        _apply_schema(setup_conn)
+        setup_conn.close()
+
+        concept = _write_memory(bundle, "memory/tribal/foo", "Buffered", "Body text here.")
+
+        # Reset module state between tests -- it's process-global.
+        monkeypatch.setattr(ebuf, "_QUEUE", ebuf.collections.deque(maxlen=500))
+        monkeypatch.setattr(ebuf, "_FLUSHER_STARTED", True)  # skip spawning a real thread
+        ebuf.configure(lambda: sqlite3.connect(db_path), lambda: bundle)
+
+        ebuf.enqueue(concept.concept_id)
+        ebuf._flush()
+
+        verify_conn = sqlite3.connect(db_path)
+        verify_conn.row_factory = sqlite3.Row
+        assert embed_memory_count(verify_conn) == 1
+        verify_conn.close()
+
+    def test_flush_failure_leaves_batch_queued(self, monkeypatch):
+        from cairn.mcp_server import embed_buffering as ebuf
+
+        monkeypatch.setattr(ebuf, "_QUEUE", ebuf.collections.deque(maxlen=500))
+        monkeypatch.setattr(ebuf, "_FLUSHER_STARTED", True)
+
+        def _boom():
+            raise sqlite3.OperationalError("database is locked")
+
+        ebuf.configure(_boom, lambda: None)
+        ebuf.enqueue("memory/tribal/foo")
+        ebuf._flush()  # must not raise
+
+        assert list(ebuf._QUEUE) == ["memory/tribal/foo"], "failed flush must not drop the batch"

--- a/tests/test_okf_bundle_lock.py
+++ b/tests/test_okf_bundle_lock.py
@@ -1,0 +1,144 @@
+"""Tests for ``OKFBundle.lock()`` -- the fcntl advisory lock + thread-local
+re-entrancy guard that serializes cross-process/cross-thread read-modify-write
+of an OKF bundle (the centerpiece of the SSE-daemon lock-contention fix).
+
+Covers re-entrancy, timeout, release, and scope. Two contention strategies,
+because ``flock`` is per-process on macOS (a second ``os.open``+``flock`` in
+the *same* test thread does not block, so the cheap same-process pre-acquire
+trick can't reproduce exclusion there):
+
+* ``test_contention_timeout_logic`` patches ``fcntl.flock`` to always report
+  EAGAIN -- deterministic, fast, exercises the busy-wait/deadline/TimeoutError
+  wrapping logic every run.
+* ``test_cross_process_contention_and_release`` spawns a real child process
+  holding the lock -- the only reliable way to exercise genuine flock conflict
+  (and release) on macOS.
+"""
+from __future__ import annotations
+
+import errno
+import fcntl
+import multiprocessing as mp
+import time
+from pathlib import Path
+
+import pytest
+
+from cairn.okf.bundle import OKFBundle
+
+
+@pytest.fixture
+def bundle(tmp_path):
+    return OKFBundle(str(tmp_path / "knowledge"))
+
+
+def _hold_okf_lock(root_str: str, ready, release) -> None:
+    """Child-process target: acquire the OKF lock, signal ``ready``, hold it
+    until ``release`` is set (then exit the context manager, releasing)."""
+    from cairn.okf.bundle import OKFBundle as _B
+
+    b = _B(root_str)
+    with b.lock(timeout=5):
+        ready.set()
+        release.wait(30)  # hold until the parent is done probing
+
+
+class TestBundleLockReentrancy:
+    def test_nested_lock_does_not_self_deadlock(self, bundle):
+        """The re-entrancy fast path: a second ``lock()`` in the same thread
+        no-ops instead of re-flocking (flock is per-fd, so a second flock from
+        the same thread on a new fd would self-deadlock)."""
+        start = time.monotonic()
+        with bundle.lock():
+            with bundle.lock():
+                pass
+        # A self-deadlock would block until the 5s default timeout then raise;
+        # completing well under a second proves the fast path fired.
+        assert time.monotonic() - start < 1.0
+
+    def test_depth_resets_after_nested(self, bundle):
+        """After a nested sequence exits, the per-thread depth returns to 0, so
+        a fresh ``lock()`` re-acquires the real OS lock instead of silently
+        no-op'ing forever (which would let a concurrent writer interleave)."""
+        from cairn.okf.bundle import _LOCK_DEPTH
+
+        key = str(Path(bundle.root).resolve())
+        with bundle.lock():
+            with bundle.lock():
+                pass
+        depth = getattr(_LOCK_DEPTH, "depth", {})
+        assert depth.get(key, 0) == 0
+
+    def test_exception_in_body_still_resets_depth(self, bundle):
+        """An exception inside the ``with`` body still runs the unlock path
+        (the nested try/finally), so depth returns to 0 and the OS lock is
+        released -- the next holder isn't blocked forever by a crashed one."""
+
+        class _Boom(Exception):
+            pass
+
+        from cairn.okf.bundle import _LOCK_DEPTH
+
+        key = str(Path(bundle.root).resolve())
+        with pytest.raises(_Boom):
+            with bundle.lock():
+                raise _Boom
+        depth = getattr(_LOCK_DEPTH, "depth", {})
+        assert depth.get(key, 0) == 0
+
+
+class TestBundleLockContention:
+    def test_contention_timeout_logic(self, bundle, monkeypatch):
+        """When flock reports the lock unavailable, ``lock(timeout=...)``
+        busy-waits until its deadline then raises the built-in TimeoutError.
+        Patches flock to always raise EAGAIN so the wrapping logic is exercised
+        deterministically without a second process."""
+
+        def _always_busy(fd, op):
+            raise OSError(errno.EAGAIN, "simulated contention")
+
+        monkeypatch.setattr(fcntl, "flock", _always_busy)
+        with pytest.raises(TimeoutError):
+            with bundle.lock(timeout=0.1):
+                pass
+
+    def test_cross_process_contention_and_release(self, bundle):
+        """A child process holding the real OS lock blocks the parent (raised
+        TimeoutError); once the child releases, the parent acquires -- proving
+        genuine flock conflict + release, which same-process tests can't."""
+        ctx = mp.get_context("spawn")
+        ready = ctx.Event()
+        release = ctx.Event()
+        p = ctx.Process(target=_hold_okf_lock, args=(str(bundle.root), ready, release))
+        p.start()
+        try:
+            assert ready.wait(5), "child failed to acquire the lock"
+            # Child holds the OS lock -> parent times out.
+            with pytest.raises(TimeoutError):
+                with bundle.lock(timeout=0.3):
+                    pass
+            # Child releases -> parent acquires (also proves release works).
+            release.set()
+            p.join(5)
+            assert p.exitcode == 0, "child should exit cleanly after release"
+            with bundle.lock(timeout=2):
+                pass
+        finally:
+            release.set()
+            p.join(5)
+            if p.is_alive():
+                p.terminate()
+                p.join(2)
+
+
+class TestBundleLockScope:
+    def test_separate_roots_do_not_block_each_other(self, tmp_path):
+        """The lock is keyed by resolved bundle root, so two unrelated bundles
+        can be held simultaneously."""
+        a = OKFBundle(str(tmp_path / "a"))
+        b = OKFBundle(str(tmp_path / "b"))
+        with a.lock():
+            start = time.monotonic()
+            with b.lock():
+                pass
+            assert time.monotonic() - start < 1.0

--- a/tests/test_okf_bundle_lock.py
+++ b/tests/test_okf_bundle_lock.py
@@ -2,17 +2,21 @@
 re-entrancy guard that serializes cross-process/cross-thread read-modify-write
 of an OKF bundle (the centerpiece of the SSE-daemon lock-contention fix).
 
-Covers re-entrancy, timeout, release, and scope. Two contention strategies,
-because ``flock`` is per-process on macOS (a second ``os.open``+``flock`` in
-the *same* test thread does not block, so the cheap same-process pre-acquire
-trick can't reproduce exclusion there):
+flock semantics (verified on Darwin 25 / matches Linux flock(2)): locks are
+per *open file description*, so a second ``os.open()`` of the same file -- even
+within the same thread/process -- gets an independent lock that conflicts with
+the first (EAGAIN under ``LOCK_NB``). That is exactly why the re-entrancy guard
+in ``bundle._okf_bundle_lock`` is load-bearing: without it, a nested ``lock()``
+would flock a fresh fd and hit its own outer lock.
+
+Covers re-entrancy, timeout, release, and scope. Two contention strategies:
 
 * ``test_contention_timeout_logic`` patches ``fcntl.flock`` to always report
-  EAGAIN -- deterministic, fast, exercises the busy-wait/deadline/TimeoutError
-  wrapping logic every run.
+  EAGAIN -- deterministic and fast, isolates the busy-wait/deadline/TimeoutError
+  wrapping logic from any process/thread coordination.
 * ``test_cross_process_contention_and_release`` spawns a real child process
-  holding the lock -- the only reliable way to exercise genuine flock conflict
-  (and release) on macOS.
+  holding the lock -- exercises genuine flock conflict *and* the release path
+  (the actual deployment scenario: SSE daemon vs ``cairn build``).
 """
 from __future__ import annotations
 


### PR DESCRIPTION
## Summary
Memory semantic recall + embedding-pipeline improvements, MCP server lock-
contention gap fixes, and orphaned-embedding reaping at decay sites. Also adds
the scope-based audit checklist doc (docs/audit-checklist.md).

## Change type
- [x] Feature / improvement
- [x] Docs / chore / CI   (the audit-checklist doc)

## Audit checklist
- [ ] Blast radius checked
- [ ] Layering respected
- [ ] Graph updated (`cairn update`)
- [ ] Memory recorded
- [x] Tests — full suite green (695 passed, 1 skipped)
- [ ] CHANGELOG — confirm `[Unreleased]` covers the memory/MCP changes
- [x] Gates green — pre-commit, pip-audit clean; mypy/bandit advisory

## Blast-radius note
Touches the MCP server lifecycle + memory promotion/scoring. Confirm via
`explore`/`impact_analysis` on changed symbols before merge.

## Verification
pytest full suite green on a superset branch (fix/audit-2026-08-13).