### PR TITLE
fix: scope-audit findings and cut 0.9.1

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,7 +104,7 @@ every change:
 
 The PR template (`.github/PULL_REQUEST_TEMPLATE.md`) carries the author
 checklist; `docs/review-checklist.md` is the procedure behind each box.
-Layers 0-1 (pre-commit + CI: pip-audit, bandit, mypy, PR-title) are automated;
+Layers 0-1 (pre-commit + CI: tests, pip-audit, bandit, mypy, PR-title, dependency-review) are automated;
 this is the human/agent layer that catches what they can't.
 
 ## Tool Quirks (empirically verified)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - _Nothing yet._
 
 ### Fixed
-- _Nothing yet._
+- **Memory:** `evolve_memory` (the `memory_evolve` MCP tool / `cairn memory`
+  evolve CLI) now redacts secrets from the new body before storage, matching
+  `capture_memory`'s floor. A secret in an evolved body was previously
+  persisted verbatim -- the same two-codepath divergence that once left
+  `record_memory` unredacted.
+- **Parsers:** constructor calls (`new Foo()`) in Java and PHP, and call edges
+  inside class-field initializers in TypeScript and Java (`repo = createRepo()`),
+  are now indexed as `calls` edges. They were previously dropped silently --
+  the same edge-drop family as the `var-declarator` fix.
+- **Agent install:** `cairn agents uninstall` now refuses to delete a directory
+  that isn't cairn-scoped (named `cairn`). The `_rm_tree_if_cairn` helper
+  promised this guard in its name but never enforced it; current callers were
+  safe, but a broader path would have been wiped.
+- **MCP server:** the background memory-embed flusher now escalates to a
+  `WARNING` log after repeated failures instead of retrying invisibly at
+  `debug` level every 15s forever, so a broken embed model is observable.
 
 ### Removed
 - _Nothing yet._

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - _Nothing yet._
 
 ### Fixed
+- _Nothing yet._
+
+### Removed
+- _Nothing yet._
+
+## [0.9.1] - 2026-08-13
+
+> **Focus:** memory semantic recall + MCP lock-contention hardening (PR #23),
+> plus a scope-audit pass that closed secret-redaction and dropped-edge gaps.
+
+### Added
+- **Memory + MCP server:** semantic recall pipeline and MCP server
+  lock-contention hardening (#23). `recall_memory` now falls back to semantic
+  similarity when lexical matching comes up empty; remaining MCP server
+  lock-contention gaps are closed; orphaned memory embeddings are reaped at
+  decay sites; lock behavior is covered by new tests.
+
+### Changed
+- **MCP server:** the background memory-embed flusher escalates to a `WARNING`
+  log after repeated failures instead of retrying invisibly at `debug` level
+  every 15s forever, so a chronically broken embed model is observable.
+- **CI:** mypy is now advisory (step-level `continue-on-error`) so the ~60
+  known type errors don't block PRs; new type regressions still print in the
+  log for visibility.
+
+### Fixed
 - **Memory:** `evolve_memory` (the `memory_evolve` MCP tool / `cairn memory`
   evolve CLI) now redacts secrets from the new body before storage, matching
   `capture_memory`'s floor. A secret in an evolved body was previously
@@ -32,9 +58,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   that isn't cairn-scoped (named `cairn`). The `_rm_tree_if_cairn` helper
   promised this guard in its name but never enforced it; current callers were
   safe, but a broader path would have been wiped.
-- **MCP server:** the background memory-embed flusher now escalates to a
-  `WARNING` log after repeated failures instead of retrying invisibly at
-  `debug` level every 15s forever, so a broken embed model is observable.
 
 ### Removed
 - _Nothing yet._

--- a/README.md
+++ b/README.md
@@ -296,7 +296,7 @@ end user at install time.
 
 ## Status
 
-**Beta — pre-1.0 (v0.9.0).** Public surfaces (CLI flags, MCP tool shapes,
+**Beta — pre-1.0 (v0.9.1).** Public surfaces (CLI flags, MCP tool shapes,
 knowledge-file layout) may still shift before 1.0. Feedback welcome via
 [GitHub issues](https://github.com/tanlnm512/cairn/issues).
 

--- a/docs/audit-checklist.md
+++ b/docs/audit-checklist.md
@@ -179,7 +179,8 @@ swallowed `.get()` once disabled fusion entirely.
 
 ## Scope 5 — Parser correctness
 
-**What:** the 13 tree-sitter parsers + SCIP importer. Steady drip of edge cases;
+**What:** the 14 languages (12 tree-sitter parser modules; c+cpp share c_family,
+ts+js share typescript) + SCIP importer. Steady drip of edge cases;
 run after adding/touching a parser.
 
 **Load context:** `explore("parse")`, `explore("language inference")`,
@@ -258,7 +259,7 @@ memory). Run per release.
 
 - [ ] **Version refs** — version string consistent across README, CHANGELOG,
       cli-reference, architecture docs, pyproject.
-- [ ] **Tool counts / language counts** — "27 tools", "13 parsers" etc. match
+- [ ] **Tool counts / language counts** — "27 tools", "14 languages" etc. match
       reality (recount, don't trust the doc).
 - [ ] **BUGS.md structure** — index table present, one TL;DR per entry, each entry
       maps to a regression test (per the structure convention).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "cairn-intel"
-version = "0.9.0"
+version = "0.9.1"
 description = "Local codebase intelligence system: structural graph + compass + wiki + agent memory"
 readme = "README.md"
 license = "MIT"
@@ -174,7 +174,7 @@ select = ["F"]
 # The custom template (.cz_templates/keepachangelog.j2) renders that draft in
 # the existing `## [X.Y.Z] - YYYY-MM-DD` format rather than commitizen's
 # default `## X.Y.Z (YYYY-MM-DD)`.
-version = "0.9.0"
+version = "0.9.1"
 version_scheme = "pep440"
 tag_format = "v$version"
 update_changelog_on_bump = false

--- a/src/cairn/__init__.py
+++ b/src/cairn/__init__.py
@@ -1,3 +1,3 @@
 """Cairn: local codebase intelligence system."""
-__version__ = "0.9.0"
+__version__ = "0.9.1"
 __package_name__ = "cairn-intel"

--- a/src/cairn/agent_install/merge.py
+++ b/src/cairn/agent_install/merge.py
@@ -303,10 +303,25 @@ def _rm_if_exists(path: Path, res: InstallResult) -> None:
 
 
 def _rm_tree_if_cairn(path: Path, res: InstallResult) -> None:
-    """Remove a dir tree only if it contains cairn content."""
-    if path.is_dir() and path.exists():
-        shutil.rmtree(path)
-        res.written.append(f"removed {path}/")
+    """Remove a dir tree only if it is cairn-scoped.
+
+    All callers target a directory *named* ``cairn`` (e.g.
+    ``.claude/skills/cairn``). The name check is the guard the function's name
+    promises: without it a future caller passing a broader path (say
+    ``.claude`` itself) would ``rmtree`` the user's whole directory. If the
+    final path component isn't ``cairn``, refuse and record a note rather than
+    delete something that isn't ours.
+    """
+    if not (path.is_dir() and path.exists()):
+        return
+    if path.name != "cairn":
+        res.notes.append(
+            f"refused to remove {path}/: not cairn-scoped (directory must be "
+            f"named 'cairn'). Remove manually if intended."
+        )
+        return
+    shutil.rmtree(path)
+    res.written.append(f"removed {path}/")
 
 
 def _rm_if_cairn(path: Path, res: InstallResult) -> None:

--- a/src/cairn/mcp_server/embed_buffering.py
+++ b/src/cairn/mcp_server/embed_buffering.py
@@ -29,6 +29,15 @@ _QUEUE: collections.deque = collections.deque(maxlen=500)
 _LOCK = threading.Lock()
 _FLUSHER_STARTED = False
 _FLUSH_INTERVAL = 15.0  # seconds
+# Consecutive flush-failure count (mutated only by the single flusher thread).
+# Failures are expected to be transient (lock contention, a model hiccup), so
+# the batch is retried indefinitely rather than dropped -- but a CHRONIC
+# failure (e.g. a broken embed model) would otherwise retry invisibly at debug
+# level every 15s forever. After _WARN_AFTER consecutive failures we escalate
+# to WARNING so the broken flusher is observable. Reset to 0 on the first
+# success.
+_FAILURES = 0
+_WARN_AFTER = 4
 
 _conn_factory: Optional[Callable[[], "object"]] = None
 _bundle_factory: Optional[Callable[[], "object"]] = None
@@ -60,6 +69,7 @@ def _flush() -> None:
     from cairn.graph import embeddings as emb
 
     conn = None
+    global _FAILURES
     try:
         conn = _conn_factory()
         bundle = _bundle_factory()
@@ -67,8 +77,22 @@ def _flush() -> None:
         conn.commit()
     except Exception:
         # Lock contention or a transient error -- leave the batch queued for
-        # the next flush attempt rather than dropping it.
-        logger.debug("memory embed flush failed; %d concept(s) remain queued", len(batch), exc_info=True)
+        # the next flush attempt rather than dropping it (a poison concept_id
+        # is already skipped per-cid inside embed_memory_concepts, so a failure
+        # here is environmental, not a bad cid). Escalate to WARNING once the
+        # failure is chronic so a broken embed model doesn't fail silently.
+        _FAILURES += 1
+        if _FAILURES >= _WARN_AFTER:
+            logger.warning(
+                "memory embed flush has failed %d consecutive times; "
+                "%d concept(s) remain queued. Check the embed model / DB.",
+                _FAILURES, len(batch), exc_info=True,
+            )
+        else:
+            logger.debug(
+                "memory embed flush failed (%d); %d concept(s) remain queued",
+                _FAILURES, len(batch), exc_info=True,
+            )
         return
     finally:
         if conn is not None:
@@ -76,6 +100,7 @@ def _flush() -> None:
                 conn.close()
             except Exception:
                 pass
+    _FAILURES = 0
     with _LOCK:
         for cid in batch:
             try:

--- a/src/cairn/memory/promotion.py
+++ b/src/cairn/memory/promotion.py
@@ -596,7 +596,18 @@ def evolve_memory(
     ``memory_supersedes``, flips the old to ``memory_is_latest: false``, and
     stores the new version. At least one of new_title / new_body must differ
     from the old memory.
+
+    The new body is redacted via :func:`strip_private_data` before storage,
+    mirroring ``capture_memory``'s floor -- the MCP ``memory_evolve`` tool and
+    the CLI both reach this function, so without redaction here a secret in an
+    evolved body would persist verbatim (the same two-codepath divergence that
+    once left ``record_memory`` unredacted). ``new_body`` is None when only the
+    title changes; the old body was already redacted at capture time.
     """
+    from .privacy import strip_private_data
+
+    if new_body is not None:
+        new_body = strip_private_data(new_body)
     with bundle.lock():
         old = store_mod.get_memory(bundle, memory_path)
         if old is None:

--- a/src/cairn/parsers/java.py
+++ b/src/cairn/parsers/java.py
@@ -86,10 +86,26 @@ class JavaParser(BaseParser, TreeSitterParserBase):
         if t == "field_declaration":
             for sym in self._parse_field(node, source):
                 pf.symbols.append(sym)
+            # Descend into initializers so calls in field initializers (e.g.
+            # `private final Repo repo = createRepo();`) emit edges. Mirrors
+            # method_declaration above; without this, field-initializer calls
+            # were silently dropped.
+            self._walk(node, source, pf)
             return
 
         if t == "method_invocation":
             edge = self._parse_call(node, source)
+            if edge:
+                pf.edges.append(edge)
+            self._walk(node, source, pf)
+            return
+
+        if t == "object_creation_expression":
+            # `new Foo()` -- a constructor call. Emit a calls edge to the
+            # constructed type so get_callers/impact_analysis see it (C# does
+            # the same for its object_creation_expression). Without this,
+            # every `new Foo()` in Java produced no edge at all.
+            edge = self._parse_new(node, source)
             if edge:
                 pf.edges.append(edge)
             self._walk(node, source, pf)
@@ -273,3 +289,25 @@ class JavaParser(BaseParser, TreeSitterParserBase):
             line=node.start_point[0] + 1,
             receiver_type=self._infer_receiver_type(receiver_text),
         )
+
+    def _parse_new(self, node: Node, source: bytes) -> Optional[Edge]:
+        # object_creation_expression: 'new' <type> argument_list. The
+        # constructed type is the type node after 'new' (type_identifier for a
+        # simple name; class_type/scoped_type_identifier when qualified). Use
+        # the trailing identifier so the resolver can match it to the class
+        # symbol, mirroring the method-name-only call convention.
+        owner = self._current_edge_owner()
+        for child in node.children:
+            if child.type == "argument_list":
+                break
+            if child.type in ("type_identifier", "class_type", "scoped_type_identifier"):
+                txt = self._node_text(child, source).strip()
+                callee = txt.split(".")[-1]
+                return Edge(
+                    source_name=owner,
+                    kind="calls",
+                    target_name=callee,
+                    line=node.start_point[0] + 1,
+                    receiver_type=None,
+                )
+        return None

--- a/src/cairn/parsers/php.py
+++ b/src/cairn/parsers/php.py
@@ -58,6 +58,7 @@ _CALL_NODES = frozenset(
         "member_call_expression",
         "nullsafe_member_call_expression",  # $obj?->method()
         "scoped_call_expression",           # Class::method() / $inst::method()
+        "object_creation_expression",       # new Foo() -- constructor call
     }
 )
 # Declaration node types that introduce a named type (class/interface/trait/enum).
@@ -346,6 +347,8 @@ class PhpParser(BaseParser, TreeSitterParserBase):
             callee, receiver = self._split_function_call(node, source)
         elif node.type in ("member_call_expression", "nullsafe_member_call_expression"):
             callee, receiver = self._split_member_call(node, source)
+        elif node.type == "object_creation_expression":
+            callee, receiver = self._split_object_creation(node, source)
         else:  # scoped_call_expression: Class::method() / $inst::method()
             callee, receiver = self._split_scoped_call(node, source)
         if not callee:
@@ -357,6 +360,16 @@ class PhpParser(BaseParser, TreeSitterParserBase):
             line=node.start_point[0] + 1,
             receiver_type=self._infer_receiver_type(receiver),
         )
+
+    def _split_object_creation(self, node: Node, source: bytes):
+        # object_creation_expression: 'new' name arguments. The constructed
+        # class is the `name` child. (new Foo() -> Foo.)
+        for child in node.children:
+            if child.type == "name":
+                return self._strip_leading_backslash(
+                    self._node_text(child, source).strip()
+                ), None
+        return None, None
 
     def _split_function_call(self, node: Node, source: bytes):
         # function_call_expression: name | qualified_name, arguments

--- a/src/cairn/parsers/typescript.py
+++ b/src/cairn/parsers/typescript.py
@@ -228,6 +228,13 @@ class _JSFamilyParser(BaseParser, TreeSitterParserBase):
             sym = self._parse_field(node, source)
             if sym:
                 pf.symbols.append(sym)
+            # Descend into the initializer so call edges in field initializers
+            # (e.g. `defaultRepo = createRepo()`) are emitted. function_declaration
+            # and method_definition call _walk for the same reason; a field
+            # initializer is not a new function scope, so _callable_scope /
+            # _func_depth are left untouched. Without this, every call inside a
+            # class-field initializer was silently dropped.
+            self._walk(node, source, pf)
             return
 
         if t in VAR_DECL_NODES:

--- a/tests/fixtures/golden/php/expected.json
+++ b/tests/fixtures/golden/php/expected.json
@@ -226,6 +226,14 @@
     {
       "source_name": "greet",
       "kind": "calls",
+      "target_name": "Logger",
+      "line": 40,
+      "column": 0,
+      "receiver_type": null
+    },
+    {
+      "source_name": "greet",
+      "kind": "calls",
       "target_name": "getName",
       "line": 42,
       "column": 0,

--- a/tests/test_agent_install_dry.py
+++ b/tests/test_agent_install_dry.py
@@ -71,8 +71,39 @@ def test_cairn_prep_grep_count():
     print(f"grep count verified: {len(matches)} match")
 
 
+def test_rm_tree_if_cairn_refuses_non_cairn_dir(tmp_path):
+    """_rm_tree_if_cairn must NOT delete a directory that isn't cairn-scoped.
+
+    Regression for the guard-in-name-only footgun: the function promised a
+    content check but deleted any existing dir. A broader path must be refused.
+    """
+    from cairn.agent_install.merge import _rm_tree_if_cairn
+    from cairn.agent_install._common import InstallResult
+
+    # A user directory NOT named 'cairn' -- must survive.
+    victim = tmp_path / ".claude"
+    victim.mkdir()
+    (victim / "settings.json").write_text("{}")
+    res = InstallResult(client="test")
+    _rm_tree_if_cairn(victim, res)
+    assert victim.exists(), "non-cairn directory was deleted"
+    assert (victim / "settings.json").exists()
+    assert any("not cairn-scoped" in n for n in res.notes)
+
+    # A cairn-named directory -- removed as before.
+    skill = tmp_path / ".claude" / "skills" / "cairn"
+    skill.mkdir(parents=True)
+    (skill / "SKILL.md").write_text("x")
+    res2 = InstallResult(client="test")
+    _rm_tree_if_cairn(skill, res2)
+    assert not skill.exists()
+    assert any("removed" in w for w in res2.written)
+
+
 if __name__ == "__main__":
     test_slash_commands_constant_exists()
     test_slash_commands_constant_is_used()
     test_cairn_prep_grep_count()
+    # test_rm_tree_if_cairn_refuses_non_cairn_dir needs pytest's tmp_path fixture.
+    print("Run pytest for the full suite (incl. tmp_path fixtures).")
     print("All tests passed!")

--- a/tests/test_jsx_references.py
+++ b/tests/test_jsx_references.py
@@ -233,5 +233,26 @@ export function greet(name: string): string {
         assert any(s.kind == "function" for s in pf.symbols)
 
 
+# --------------------------------------------- class-field initializer call edges
+
+class TestFieldInitializerCallEdges:
+    """Call edges inside class field initializers (e.g. ``repo = createRepo()``).
+
+    Regression: ``public_field_definition`` returned without descending into
+    the initializer, so every call there was dropped -- the same family as the
+    var-declarator edge-drop fix covered above.
+    """
+
+    def test_call_in_field_initializer_is_emitted(self):
+        src = b"class Service {\n  defaultRepo = createRepo();\n}\n"
+        pf = _parse(TypeScriptParser, src, ".ts")
+        assert "createRepo" in _call_targets(pf)
+
+    def test_single_call_emits_exactly_one_edge(self):
+        src = b"class S { a = build(); }\n"
+        pf = _parse(TypeScriptParser, src, ".ts")
+        assert _call_targets(pf).count("build") == 1
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/test_memory_embeddings.py
+++ b/tests/test_memory_embeddings.py
@@ -258,7 +258,12 @@ class TestSearchMemoryFusion:
         # bundle.read_concept() rewrites concept_id to an absolute path, so
         # match on title rather than the pre-write relative concept_id.
         hit = next(c for c in results if c.title == concept.title)
-        assert hit.extensions.get("provenance") == "fused"
+        # Found both ways -> a "fused" provenance. The exact string is
+        # backend-dependent: real vectors give "fused", the dep-free hash
+        # fallback (token-overlap, e.g. on CI without the embedding model)
+        # gives "fused (hash backend)". Both are correct fused results; only a
+        # non-fused provenance ("semantic"/"lexical") would fail this.
+        assert hit.extensions.get("provenance", "").startswith("fused")
 
     def test_chunk_dedup_returns_one_entry_per_concept(self, db, bundle):
         """A memory with 3 embedded chunks must appear once in results, not

--- a/tests/test_memory_lifecycle.py
+++ b/tests/test_memory_lifecycle.py
@@ -144,6 +144,27 @@ class TestEvolveMemory:
         result = evolve_memory(db, bundle, "memory/tribal/nonexistent", new_body="x")
         assert result is None
 
+    def test_evolve_redacts_secret_in_new_body(self, db, bundle):
+        """A secret in an evolved body never reaches disk verbatim.
+
+        Regression for the evolve_memory redaction bypass: capture_memory
+        redacts, but evolve_memory once passed new_body straight through.
+        """
+        secret = "api_key=sk-1234567890abcdef1234567890abcdef"
+        r1 = capture_memory(
+            db, bundle, type_="pattern", title="evolve redact",
+            body="original clean body", confidence=0.7,
+        )
+        result = evolve_memory(
+            db, bundle, r1["path"],
+            new_body=f"Updated: rotated {secret} during deploy.",
+        )
+        assert result is not None
+        stored = bundle.read_concept(result["path"])
+        assert secret not in stored.body
+        assert "sk-1234567890" not in stored.body
+        assert "REDACTED_SECRET" in stored.body
+
 
 # ---------------------------------------------------------------------------
 # FEATURE 2: Exponential freshness + reinforcement

--- a/tests/test_parser_new_edges.py
+++ b/tests/test_parser_new_edges.py
@@ -1,0 +1,65 @@
+"""Regression tests for dropped call edges:
+
+- Java field-initializer calls — ``field_declaration`` now descends via ``_walk``
+  (previously returned, dropping e.g. ``Repo r = createRepo();``).
+- Java constructor calls ``new Foo()`` — ``object_creation_expression`` handler
+  (previously had no handler, so every ``new`` produced no edge).
+- PHP constructor calls ``new Foo()`` — ``object_creation_expression`` added to
+  ``_CALL_NODES`` (previously omitted).
+
+Same edge-drop family as the TS var-declarator / ``public_field_definition``
+fixes (see ``test_jsx_references.py``).
+"""
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from cairn.parsers.java import JavaParser
+from cairn.parsers.php import PhpParser
+
+
+def _parse(parser_cls, source: bytes, suffix: str):
+    """Parse ``source`` with ``parser_cls`` via a temp file. Returns ParsedFile."""
+    with tempfile.NamedTemporaryFile(suffix=suffix, delete=False, mode="wb") as f:
+        f.write(source)
+        path = f.name
+    try:
+        return parser_cls().parse(path)
+    finally:
+        Path(path).unlink(missing_ok=True)
+
+
+def _call_targets(pf):
+    """All `calls` edge target_names from a ParsedFile."""
+    return [e.target_name for e in pf.edges if e.kind == "calls"]
+
+
+class TestJavaNewAndFieldEdges:
+    def test_field_initializer_call_emitted(self):
+        src = b"class S { Repo r = createRepo(); }\n"
+        pf = _parse(JavaParser, src, ".java")
+        assert "createRepo" in _call_targets(pf)
+
+    def test_new_expression_emits_constructor_call(self):
+        src = b"class S { void f() { Foo x = new Foo(); } }\n"
+        pf = _parse(JavaParser, src, ".java")
+        assert "Foo" in _call_targets(pf)
+
+    def test_qualified_new_uses_simple_name(self):
+        src = b"class S { void f() { Object o = new com.example.Bar(); } }\n"
+        pf = _parse(JavaParser, src, ".java")
+        assert "Bar" in _call_targets(pf)
+
+
+class TestPhpNewEdge:
+    def test_new_expression_emits_constructor_call(self):
+        src = b"<?php class S { function f() { $x = new Foo(); } }\n"
+        pf = _parse(PhpParser, src, ".php")
+        assert "Foo" in _call_targets(pf)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/uv.lock
+++ b/uv.lock
@@ -189,7 +189,7 @@ filecache = [
 
 [[package]]
 name = "cairn-intel"
-version = "0.9.0"
+version = "0.9.1"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary
Closes the 2026-08-13 scope-audit findings and cuts the 0.9.1 release. Builds
on #23 (memory semantic recall + MCP lock-contention, already on main); this PR
layers the audit fixes on top and bumps 0.9.0 → 0.9.1.

Six fixes from `docs/audit-checklist.md`, all in recurring bug classes:
- **memory:** `evolve_memory` now redacts the new body (was a secret bypass —
  same class as `record-memory-unredacted-secrets`)
- **parsers:** Java/PHP `new Foo()` and TS/Java class-field initializer calls
  now indexed as `calls` edges (same family as the `var-declarator` fix)
- **agent-install:** `_rm_tree_if_cairn` now enforces its cairn-scope guard
- **mcp:** embed-flusher escalates to WARNING on chronic failure (was invisible)
- **docs:** parser count + AGENTS.md CI-gate accuracy
- **release:** version 0.9.0 → 0.9.1 across all surfaces (pyproject, __init__,
  README, uv.lock); CHANGELOG `[0.9.1]` finalized.

The `v0.9.1` tag is on the bump commit. Pushing the tag
(`git push origin v0.9.1`) triggers `release.yml` (PyPI + GitHub Release from
the `[0.9.1]` section) independently of this PR merging.

## Change type
- [x] Bugfix
- [x] Refactor (no behavior change) — embed-flusher logging
- [x] Docs / chore / CI — docs accuracy + version bump

## Audit checklist
Filled via the `docs/review-checklist.md` walkthrough (cairn CLI tools):
- [x] **Blast radius checked** — `cairn impact`/`callers` on `evolve_memory`
  (5 callers, all safe) and `_rm_tree_if_cairn` (3 callers, all pass
  `…/skills/cairn` → zero behavior change). No public-API signature change →
  `cross_repo_deps` N/A.
- [x] **Layering respected** — each fix internal to its layer (memory / parsers / agent_install / mcp_server)
- [x] **Graph updated** — `cairn build` ran (2,210 symbols)
- [x] **Memory recorded** — redaction mistake + parser `_walk` pattern (both tribal)
- [x] **Tests** — every fix has a regression test; full suite 695 passed, 1 skipped; core smoke 26
- [x] **CHANGELOG** — `[0.9.1]` section finalized
- [x] **Gates green** — pre-commit `--all-files`, pip-audit clean; mypy/bandit advisory, 0 new mypy errors

## Blast-radius note
No signature changes. Parser fixes add edges (more graph data, no schema
change). Redaction tightens `evolve_memory` at its single chokepoint (CLI + MCP
both pass `new_body` through unchanged). `_rm_tree_if_cairn` guard accepts all
3 existing callers — pure safety addition.

## Verification
Full CI repro green locally: pip-audit, pre-commit `--all-files`, skill-eval
validation (6/6), `pytest -m core` (26) + full suite (695 passed, 1 skipped),
`python -m build` + isolated wheel import. PHP golden regenerated to include
the previously-missing `Logger` constructor edge. `cairn --version` → 0.9.1.

Caveat: verified on macOS arm64; CI runs the Linux / Python 3.10–3.14 matrix.
The one pre-existing risk (3.14 tree-sitter/sqlite-vec wheel gaps) would fail
any PR including main, independent of these changes.