### PR TITLE
chore(release): sync main with 0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- _Nothing yet._
+
+### Changed
+- _Nothing yet._
+
+## [0.11.0] - 2026-08-16
+
+> **Focus:** performance across the whole arc an agent feels — query path,
+> write path, freshness, and evidence. Impact queries answer from the
+> precomputed closure (20.9 ms → 0.1 ms p50); the server pools connections
+> (11.7×) and pre-warms its models (first semantic query 9.4 s → 0.3 s);
+> rerank is confidence-gated behind a calibrated threshold; `cairn update`
+> maintains derived indexes incrementally (single-file update at 1,000 files:
+> 377 s → 9.7 s, 2.5% of a build); the ANN index stays in sync per
+> upsert/delete with drift surfaced in doctor and status; with the `[watch]`
+> extra, `cairn serve` sees edits live (save → queryable in ~2 s); and a new
+> agent-effort benchmark publishes the harness cost story (99% fewer tool
+> calls, 99.5% fewer tokens vs a grep/read control). numpy became a core
+> dependency to keep the fallback scan fast. Full methodology and tables in
+> `docs/benchmarks.md`; phase record in `docs/phases/performance-gap/`.
+
+### Added
 - **Live file watching**: with the `[watch]` extra installed, `cairn serve`
   now sees source edits made while it runs — debounced (≤2 s) file events
   insert `pending_sync` rows (so concurrent readers get staleness banners)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "cairn-intel"
-version = "0.10.0"
+version = "0.11.0"
 description = "Local codebase intelligence system: structural graph + compass + wiki + agent memory"
 readme = "README.md"
 license = "MIT"
@@ -194,7 +194,7 @@ select = ["F"]
 # The custom template (.cz_templates/keepachangelog.j2) renders that draft in
 # the existing `## [X.Y.Z] - YYYY-MM-DD` format rather than commitizen's
 # default `## X.Y.Z (YYYY-MM-DD)`.
-version = "0.10.0"
+version = "0.11.0"
 version_scheme = "pep440"
 tag_format = "v$version"
 update_changelog_on_bump = false

--- a/src/cairn/__init__.py
+++ b/src/cairn/__init__.py
@@ -1,3 +1,3 @@
 """Cairn: local codebase intelligence system."""
-__version__ = "0.10.0"
+__version__ = "0.11.0"
 __package_name__ = "cairn-intel"


### PR DESCRIPTION
Version-bump sync for the 0.11.0 release: hand-finalized CHANGELOG ([0.11.0] - 2026-08-16 with focus prose; [Unreleased] reset) + `cz bump` version files (pyproject, __init__). The v0.11.0 tag is pushed after this merges, triggering the Trusted Publishing pipeline. Checklist run in full: suite 1325 passed, real-workspace build clean, portability check 0 absolute paths, embed+semantic sane (3,293 vectors bge-m3), serve-during-build concurrency clean, pip-audit clean with numpy now core.