### PR TITLE
chore(release): sync uv.lock project version to 0.11.0

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -189,7 +189,7 @@ filecache = [
 
 [[package]]
 name = "cairn-intel"
-version = "0.10.0"
+version = "0.11.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
One-line lockfile version sync (0.10.0 -> 0.11.0) that past releases carried in the tag but cz bump's version_files don't cover. The v0.11.0 tag is already published (PyPI live); this keeps main's lockfile consistent going forward and documents the gap. Docs-only change to lockfile metadata; no dependency changes (lock content identical beyond the project version line).