### PR TITLE
docs(phases): benchmark-datasource spec — pinned baselines for future comparison

### DIFF
--- a/docs/phases/benchmark-datasource/plan.md
+++ b/docs/phases/benchmark-datasource/plan.md
@@ -1,0 +1,113 @@
+# Plan: Benchmark Datasource — pinned baselines for future comparison
+
+Companion: [spec.md](spec.md) · [task.md](task.md). "Done when" wording is
+owned by spec.md and repeated verbatim in task.md.
+
+## 0. Evidence base (survey, 2026-08-16)
+
+- CI bench job (`.github/workflows/ci.yml` `bench:`) compares PRs against a
+  **rolling actions/cache baseline** refreshed by main-branch runs — advisory
+  comment, never a gate, nothing pinned.
+- `cairn bench --save/--compare` (cli/bench.py) compares two local JSON runs;
+  `compare_reports` thresholds at 15%; artifacts carry a timestamp but no
+  dataset version or machine profile.
+- `bench/corpus.py`: seeded generator, deterministic, but dense-random
+  (closure 340 s @1,000 files) with twin docstrings — unusable for quality
+  calibration (rerank-gate calibration fell back to cairn's own src/).
+- `src/cairn/eval.py`: recall@10/MRR harness for L1 code + L5 knowledge
+  retrieval against ground-truth query datasets — dataset not maintained.
+- `docs/benchmarks.md`: three `_fill_` families (retrieval L1/L5, perf query
+  table, scaling table).
+- Hard constraint: CI is network-free; heavy wheels already in core
+  (numpy promotion noted for size budgeting of fixtures).
+
+## 1. Implementation options
+
+### Option A — Pin the synthetic tier only
+
+Manifest + hash-check `bench/corpus.py` outputs; commit baseline JSONs
+generated from it; fill docs tables from those.
+
+- **Pros:** smallest change; zero licensing/size questions; fully
+  deterministic; everything runs in CI today.
+- **Cons:** baselines inherit the corpus's pathologies — timing references
+  reflect a dense-random graph nothing real looks like (closure 340 s is
+  20× a real repo's shape), and quality tables would be built on
+  twin-docstring data the rerank calibration already proved meaningless.
+  "Comparable in the future" would be true but the comparison would be
+  about a world nobody deploys.
+
+### Option B — Vendored real repos everywhere
+
+Vendor 2–3 real repo snapshots (small, medium, large) into the repo; all
+suites and baselines run against them.
+
+- **Pros:** maximum realism; one tier to maintain conceptually; quality
+  ground truth is natural to author.
+- **Cons:** size (even 3 small repos ≈ 5–15 MB against a repo that is
+  otherwise lean), license diligence × 3, and the large tier can't be
+  vendored at all (20k files) — so the design degenerates into A+B hybrid
+  anyway. Fixed-byte snapshots are deterministic, but committing large
+  binary-ish trees churns git history forever.
+
+### Option C — Tiered datasource (T1 synthetic pinned / T2 vendored real /
+T3 manifest-fetched) with versioned baseline artifacts
+
+- **Pros:** each tier answers the question it is uniquely good at — T1
+  gives bit-reproducible regression detection in every CI run; T2 gives
+  realistic shape for quality + agent-effort + the reference tables at a
+  bounded ≤ 3 MB; T3 gives scale coverage without vendoring. Baseline
+  directories version the whole substrate (`DS-v1`) so future comparisons
+  name their reference exactly.
+- **Cons:** three tiers to document and keep coherent; T3 runs are local/
+  scheduled discipline rather than enforced; slightly more tooling
+  (`--baseline` resolution, machine-profile stamping).
+
+## 2. Recommendation: **Option C**
+
+The deciding argument is the session's own evidence: the two failure modes
+that motivated this phase — unattributable regressions (rolling cache) and
+meaningless quality calibration (pathological corpus) — require *both*
+determinism (T1) and realism (T2). A pinned-only or real-only design fixes
+one failure mode and keeps the other. T3 exists because scale can't be
+vendored, full stop; a manifest that pins url+commit is the honest answer
+and costs almost nothing. The versioned-baseline directory ties all three
+together with a name future PRs and releases can cite.
+
+## 3. Sequencing (chosen path)
+
+```
+Week 1
+  DS-1  manifest + T1 content-hash CI check          (locks determinism)
+  DS-2  T2 snapshot selection + vendoring + NOTICE   (unblocks 3 and 5)
+Week 2
+  DS-3  ground-truth QA set + validator              (the quality substrate)
+  DS-4  baseline artifacts + --baseline resolution + machine profiles
+  → gate: DS-v1 directory complete; compare works end to end
+Week 3
+  DS-5  docs table generation + CI check against hand-edits
+  DS-6  CI wiring (advisory vs DS-v1; retrieval eval on T2; T3 command)
+  → gate: benchmarks.md has zero _fill_; a PR can cite "vs DS-v1"
+```
+
+Dependency notes: DS-3 and DS-5 require DS-2's snapshot; DS-4 requires
+DS-1's versioning; DS-6 is last because it consumes everything. The
+existing rolling-cache job stays exactly as it is — DS-6 *adds* the
+pinned-baseline comparison line to its comment, it does not replace the
+rolling one (both are useful: rolling catches runner drift too).
+
+## 4. Verification commands (per milestone gate)
+
+- DS-1: regenerate T1 from manifest in a clean checkout → identical hash
+  (`cairn bench --suite perf` corpus stats match the manifest).
+- DS-2: `uv run cairn build --workspace benchmarks/datasource/t2/<repo>`
+  green + a query smoke (`find_definition` on a known symbol).
+- DS-3: `uv run python scripts/verify_ground_truth.py` re-verifies every
+  expectation against a fresh build (exit 0).
+- DS-4: `uv run cairn bench --compare --baseline DS-v1` (and the agent /
+  retrieval equivalents) — comparison renders with dataset-version header;
+  deliberately mismatched machine profile shows the warning.
+- DS-5: regeneration command reproduces the tables byte-identically; CI
+  check fails on a hand-edited table.
+- DS-6: advisory PR comment contains both "rolling" and "vs DS-v1" lines;
+  retrieval eval posts a trend line.

--- a/docs/phases/benchmark-datasource/spec.md
+++ b/docs/phases/benchmark-datasource/spec.md
@@ -1,0 +1,149 @@
+# Phase: Benchmark Datasource — pinned baselines for future comparison
+
+- **Status:** planned (spec expressed from the 2026-08-16 post-0.11.0 review)
+- **Date drafted:** 2026-08-16
+- **Code state baseline:** 0.11.0 @ `58c2a66` (main)
+- **Companion docs:** [plan.md](plan.md) · [task.md](task.md)
+
+## 1. Motivation — why "compare in the future" needs a datasource, not more runs
+
+Cairn measures constantly but has no *durable comparison substrate*. Four
+pieces of evidence from the performance phase and release cycle:
+
+1. **Baselines are run-local and rolling.** `cairn bench --save/--compare`
+   writes JSON wherever the user points; the CI bench job
+   (`.github/workflows/ci.yml` `bench:` "advisory baseline comparison")
+   restores a **rolling actions/cache** entry refreshed by default-branch
+   runs — nothing is pinned, versioned, or reproducible after the cache
+   rotates. A regression found today against last week's cache is not
+   attributable to a cairn change vs a runner change.
+2. **The synthetic corpus is deterministic but not representative.**
+   `bench/corpus.py` (seeded, `DEFAULT_SEED = 0xC0DE`) is CI-safe but
+   pathological: dense random call graphs (closure build 340 s at 1,000
+   files — real repos are far shallower) and templated docstrings that
+   made every chunk a near-identical twin, which is why the rerank-gate
+   calibration had to fall back to a copy of cairn's own `src/`
+   (2026-08-16 finding, recorded in tribal memory).
+3. **Reference tables are still placeholders.** `docs/benchmarks.md` has
+   three unfilled families — retrieval quality (L1/L5 recall/MRR,
+   `_fill_` at the eval tables), the perf query table, and the scaling
+   table — with no committed data behind them. Every future "did we get
+   slower / worse" question currently requires re-deriving methodology.
+4. **Quality drift is invisible.** `src/cairn/eval.py` (recall@10 / MRR
+   harness for L1 code and L5 knowledge retrieval) exists, but its ground
+   truth is not a maintained dataset — so a retrieval regression ships as
+   easily as a timing regression, with nothing to compare against.
+
+What competitors take for granted (codegraph's 7-repo Claude benchmark with
+medians and a control arm) is a **dataset + recorded baselines + methodology**.
+That is what this phase builds for cairn.
+
+## 2. Goals
+
+A **versioned benchmark datasource** under repo control, plus
+**committed baseline artifacts** stamped with dataset version, cairn version,
+and machine profile — so any future comparison (release-to-release, PR
+advisory, competitor, or "why did doctor numbers change") resolves to:
+same dataset version? same machine class? which cairn version? — and gets a
+definite answer.
+
+### The tiered datasource
+
+| Tier | Content | Determinism | Where used |
+|------|---------|-------------|-----------|
+| **T1 synthetic** | today's `bench/corpus.py` outputs, pinned by a **manifest** (seed, size, complexity, generator version tag) | fully deterministic (regeneration hash-checked in CI) | every CI bench run; timing regressions |
+| **T2 real-code snapshot** | a vendored, small (target ≤ 3 MB) real multi-language repo snapshot committed to the repo, with LICENSE + provenance manifest; plus a **hand-verified ground-truth QA set** (~50 code queries with known-symbol answers + ~20 knowledge queries) | fixed bytes = deterministic; realistic shapes (real fan-in/fan-out, real docstrings) | retrieval-quality evals (L1/L5), agent-effort suite, reference perf table |
+| **T3 fetch-by-manifest** | manifests pinning external repos (url + commit) at 2–3 scale points (e.g. ~2k, ~20k files) | reproducible by pin, not vendored | scheduled/local scale runs only (no CI network) |
+
+### Baseline artifacts
+
+- In-repo directory `benchmarks/baselines/<dataset-version>/<suite>.json`
+  (perf, scaling, agent, retrieval-quality), each stamped with: dataset
+  version, cairn version, machine profile (arch, cpu count, runner class
+  "reference-local" vs "ci-ubuntu-latest"), timestamp.
+- `cairn bench --compare` gains baseline-set resolution: `--baseline
+  <dataset-version>` resolves the committed artifact; mismatched machine
+  profiles produce a loud warning header on the comparison (numbers still
+  shown, attributed).
+- Reference tables in `docs/benchmarks.md` (including the three `_fill_`
+  families) are generated from committed T2/T3 baselines — never hand-typed.
+
+### Ground-truth QA set (the part that makes quality comparable)
+
+- Committed with T2: query → expected symbols (L1) / expected concepts
+  (L5), hand-verified once at dataset creation, each entry traceable to a
+  file in the snapshot.
+- `eval.py` runs against it in CI (advisory at first, promotable to a gate
+  once variance is known) — giving recall/MRR *trend lines* across
+  releases, the analogue of the timing trend the bench cache gives today.
+
+## 3. Items and "Done when"
+
+Each item appears verbatim in [plan.md](plan.md) and [task.md](task.md).
+
+### DS-1 — Datasource manifest + T1 pinning
+
+- **Done when**: a `benchmarks/datasource/manifest.json` versions the T1
+  generator (seed, sizes, complexity, generator git-sha) and a CI check
+  regenerates T1 and asserts a content hash, so any corpus drift is a
+  deliberate, versioned act.
+
+### DS-2 — T2 real-code snapshot vendored
+
+- **Done when**: a real multi-language repo snapshot (≤ 3 MB, permissive
+  license, provenance manifest naming upstream repo + commit + license)
+  lives under `benchmarks/datasource/t2/`, is exercised by a build+query
+  smoke test, and its license/attribution is recorded in `NOTICE`.
+
+### DS-3 — Ground-truth QA set
+
+- **Done when**: ≥ 50 L1 queries (definition/callers/impact/flow with
+  hand-verified expected symbols) and ≥ 20 L5 queries are committed under
+  `benchmarks/datasource/t2/ground_truth/` with a schema `eval.py`
+  consumes, and a validation script re-verifies every expectation against
+  a freshly built graph (no stale answers).
+
+### DS-4 — Baseline artifacts + compare resolution
+
+- **Done when**: `benchmarks/baselines/DS-v1/` holds perf/scaling/agent/
+  retrieval JSON artifacts stamped with dataset version, cairn version,
+  and machine profile; `cairn bench --compare --baseline DS-v1` resolves
+  them; machine-profile mismatch emits the warning header.
+
+### DS-5 — Reference tables generated
+
+- **Done when**: the three `_fill_` families in `docs/benchmarks.md`
+  (retrieval quality, perf, scaling) are generated from the committed
+  baselines by a documented one-command regeneration, and hand-editing
+  those tables is no longer possible without breaking a CI check.
+
+### DS-6 — CI wiring
+
+- **Done when**: the rolling-cache advisory job additionally reports
+  against the committed DS-v1 baseline (labeled by dataset version), the
+  retrieval-quality eval runs on T2 in CI (advisory), and T3 manifests +
+  a documented local command cover the scale tier.
+
+## 4. Scope
+
+**In scope:** the datasource tree, manifests, ground truth, baseline
+artifacts, compare/bench wiring, docs generation, CI changes.
+
+**Out of scope:**
+- Gating CI on timing (stays advisory by design — the observability plan's
+  "advisory first, gate later if stable" doctrine).
+- Live LLM-in-the-loop benchmarks (the agent-effort harness stays
+  scripted; an LLM arm is a future decision).
+- Fetching T3 content in CI (network-free CI is a hard constraint).
+- New benchmark metrics — this phase pins *what exists*; new suites adopt
+  the datasource as they land.
+
+## 5. Risks
+
+| Risk | Mitigation |
+|------|------------|
+| Repo bloat (T2 snapshot + baselines) | ≤ 3 MB snapshot target; baselines are JSON (KBs); size check in CI |
+| License/attribution errors in vendored code | permissive-license filter at selection; NOTICE entry; provenance manifest required before merge |
+| Ground truth rots as cairn's resolution improves | DS-3's validator re-verifies against a fresh build; expectations record *why* (symbol identity, not incidental rank) |
+| Baseline comparisons across machine classes mislead | machine-profile stamping + loud warning; reference-local baselines labeled as such |
+| Dataset becomes a maintenance tax | version-bump policy: new dataset version = new directory, old baselines stay queryable; deprecate whole versions, never edit |

--- a/docs/phases/benchmark-datasource/task.md
+++ b/docs/phases/benchmark-datasource/task.md
@@ -1,0 +1,142 @@
+# Tasks: Benchmark Datasource — pinned baselines for future comparison
+
+Companion: [spec.md](spec.md) · [plan.md](plan.md). Status reflects code
+state on 0.11.0 @ `58c2a66` (surveyed 2026-08-16), not intent.
+
+## Burndown
+
+| Status | Count |
+|--------|-------|
+| done | 0 |
+| partial | 0 |
+| todo | 16 |
+| **total** | **16** |
+
+---
+
+## DS-1 — Datasource manifest + T1 pinning
+
+Done when: a `benchmarks/datasource/manifest.json` versions the T1
+generator (seed, sizes, complexity, generator git-sha) and a CI check
+regenerates T1 and asserts a content hash, so any corpus drift is a
+deliberate, versioned act.
+
+- [ ] **D1.1 — Manifest schema.** `benchmarks/datasource/manifest.json` with
+      `dataset_version` (DS-v1), `t1` block (generator sha, DEFAULT_SEED,
+      sizes, complexity profiles, expected file/symbol/edge counts), `t2`
+      and `t3` blocks added by later tasks.
+      verify: manifest round-trips (`python -c "json.load(...)"`), counts
+      match a fresh `generate_corpus` run.
+- [ ] **D1.2 — T1 content-hash CI check.** Job step regenerates the corpus
+      from the manifest and asserts a deterministic tree hash (seeded,
+      path-order-independent).
+      verify: CI green twice in a row on unchanged code; red when the seed
+      is edited (test the failure once in a scratch branch).
+
+## DS-2 — T2 real-code snapshot vendored
+
+Done when: a real multi-language repo snapshot (≤ 3 MB, permissive license,
+provenance manifest naming upstream repo + commit + license) lives under
+`benchmarks/datasource/t2/`, is exercised by a build+query smoke test, and
+its license/attribution is recorded in `NOTICE`.
+
+- [ ] **D2.1 — Selection.** Pick the snapshot (candidate shape: a small
+      real Python+one-other-language repo with genuine call depth; record
+      WHY in the manifest — fan-in/out distribution, docstring realism,
+      size).
+      verify: selection note in manifest; `du -sh` ≤ 3 MB.
+- [ ] **D2.2 — Vendoring.** Copy in at the pinned upstream commit; strip
+      VCS internals and binaries; add provenance (repo, commit, license
+      text or link) + NOTICE entry.
+      verify: `uv run cairn build --workspace benchmarks/datasource/t2/...`
+      green; `find_definition` smoke returns the known symbol.
+- [ ] **D2.3 — Size guard.** CI step fails if `benchmarks/datasource/`
+      exceeds its budget (5 MB total).
+      verify: guard triggers on an oversized dummy file in a scratch branch.
+
+## DS-3 — Ground-truth QA set
+
+Done when: ≥ 50 L1 queries (definition/callers/impact/flow with
+hand-verified expected symbols) and ≥ 20 L5 queries are committed under
+`benchmarks/datasource/t2/ground_truth/` with a schema `eval.py` consumes,
+and a validation script re-verifies every expectation against a freshly
+built graph (no stale answers).
+
+- [ ] **D3.1 — Schema + adapter.** Ground-truth file format (query, kind,
+      expected symbol ids/files, rationale, author-verified flag) and an
+      `eval.py` adapter so L1/L5 runs consume it directly.
+      verify: `eval.py` reports recall/MRR over the file (even with a
+      partial set).
+- [ ] **D3.2 — Author 50 L1 + 20 L5 entries.** Verified against a fresh
+      build of the T2 snapshot; each entry cites the snapshot file proving
+      the expectation.
+      verify: `uv run python scripts/verify_ground_truth.py` exit 0.
+- [ ] **D3.3 — Staleness guard.** The validator runs in CI (advisory) so a
+      resolution change that invalidates an expectation surfaces
+      immediately with the failing query id.
+      verify: intentionally break one expectation in a scratch branch →
+      advisory comment names it.
+
+## DS-4 — Baseline artifacts + compare resolution
+
+Done when: `benchmarks/baselines/DS-v1/` holds perf/scaling/agent/
+retrieval JSON artifacts stamped with dataset version, cairn version, and
+machine profile; `cairn bench --compare --baseline DS-v1` resolves them;
+machine-profile mismatch emits the warning header.
+
+- [ ] **D4.1 — Machine profile stamping.** `report.py` artifacts gain a
+      `profile` block (arch, cpu count, runner class: reference-local |
+      ci-ubuntu-latest) + `dataset_version` + `cairn_version`.
+      verify: a saved baseline JSON contains all three.
+- [ ] **D4.2 — `--baseline` resolution.** `cairn bench --compare
+      --baseline DS-v1` loads the committed artifact (per suite); profile
+      mismatch prints a warning header before the table.
+      verify: compare renders against DS-v1; forced-mismatch fixture shows
+      the warning.
+- [ ] **D4.3 — Record DS-v1 baselines.** Generate perf/scaling/agent/
+      retrieval artifacts on the reference machine, commit under
+      `benchmarks/baselines/DS-v1/`.
+      verify: all four artifacts present; regeneration command documented.
+
+## DS-5 — Reference tables generated
+
+Done when: the three `_fill_` families in `docs/benchmarks.md` (retrieval
+quality, perf, scaling) are generated from the committed baselines by a
+documented one-command regeneration, and hand-editing those tables is no
+longer possible without breaking a CI check.
+
+- [ ] **D5.1 — Table generator.** Script renders the three table families
+      from baseline JSON into `docs/benchmarks.md` between sentinel
+      markers.
+      verify: regeneration is byte-idempotent on unchanged baselines.
+- [ ] **D5.2 — CI guard.** Step regenerates and diffs — hand-edited tables
+      fail the check.
+      verify: `_fill_` count in benchmarks.md reaches zero; scratch-branch
+      hand-edit turns the check red.
+
+## DS-6 — CI wiring
+
+Done when: the rolling-cache advisory job additionally reports against the
+committed DS-v1 baseline (labeled by dataset version), the
+retrieval-quality eval runs on T2 in CI (advisory), and T3 manifests + a
+documented local command cover the scale tier.
+
+- [ ] **D6.1 — Advisory comment gains "vs DS-v1".** The bench job's PR
+      comment shows both comparisons (rolling and pinned), labeled.
+      verify: comment on a test PR contains both lines.
+- [ ] **D6.2 — Retrieval eval in CI.** L1/L5 eval on T2 runs advisory,
+      posting recall/MRR.
+      verify: green run posts numbers; zero network access.
+- [ ] **D6.3 — T3 manifest + local command.** Manifest entries for 2–3
+      pinned external repos at scale points; documented
+      `cairn bench --suite scaling --dataset t3/<name>` local flow (fetches
+      by pin, caches outside the repo).
+      verify: one local end-to-end T3 run recorded in the PR description.
+
+---
+
+## Post-phase hygiene
+
+- `cairn update` + `record_memory(type="decision")` for the T2 selection
+  rationale and the dataset-versioning policy (new dir per version, never
+  edit a shipped baseline).


### PR DESCRIPTION
## Summary

Expresses the benchmark-datasource idea as a spec set (`docs/phases/benchmark-datasource/`): a **pinned, versioned comparison substrate** so future "did we get slower/worse" questions are attributable — dataset version, cairn version, machine profile — instead of run-local JSON over an on-the-fly corpus. Design: tiered datasource (T1 pinned synthetic = determinism, T2 vendored real-code snapshot with hand-verified ground truth = realism at ≤3 MB, T3 manifest-fetched repos = scale), versioned baseline artifacts under `benchmarks/baselines/DS-v1/`, `--baseline` compare resolution with machine-profile warnings, generated reference tables (retiring all three `_fill_` families in benchmarks.md), CI wiring alongside the existing rolling advisory job.

Evidence base: the rolling actions/cache baseline is unattributable once rotated; the synthetic corpus is deterministic but pathological (340 s closure at 1k files — 20× real shapes; twin docstrings broke rerank calibration); `eval.py`'s recall/MRR harness has no maintained ground truth, so quality drift ships invisibly.

## Change type

- [ ] Feature / improvement
- [ ] Bugfix
- [ ] Refactor (no behavior change)
- [x] Docs / chore / CI

## Audit checklist

- [x] **Blast radius checked** — docs-only; new directory, no existing files touched.
- [x] **Layering respected** — n/a.
- [x] **Graph updated** — n/a (docs).
- [x] **Memory recorded** — will record the dataset-versioning policy when execution starts (per the spec's own post-phase hygiene).
- [x] **Fallback/perf paths** — n/a.
- [x] **Tests** — n/a (docs).
- [x] **CHANGELOG** — no entry (planning docs).
- [x] **Gates green** — pre-commit clean on the three files; conventional title.

## Blast-radius note

None — documentation.

## Verification

Spec discipline followed: survey first (CI bench job's rolling cache, remaining `_fill_` families, eval.py's harness, corpus pathologies — all cited in spec §1); "Done when" wording identical across spec/plan/task; burndown arithmetic checked (16 tasks). Plan carries 3 options + a tiered recommendation per the house rule.
