### PR TITLE
fix(graph): bare connections no longer silently degrade semantic_search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,7 +103,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (unindexed vs stale entries) with the recovery command.
 
 ### Fixed
-- _Nothing yet._
+- `semantic_search` no longer silently degrades to the FTS fallback when
+  called with a bare `sqlite3` connection (no `Row` factory): retrieval rows
+  are normalized at the fetch boundary, and a regression test pins it.
 
 ### Removed
 - _Nothing yet._

--- a/scripts/ci-local.sh
+++ b/scripts/ci-local.sh
@@ -184,19 +184,17 @@ case "$JOB" in
 
   bench)
     # ci.yml: bench job -- fixed corpus, hash backend, advisory throughout.
+    # Mirrors the T016 rewiring: compare against the COMMITTED DS-v1
+    # baseline (the old rolling bench-baseline.json cache dance is gone;
+    # bench_compare.py still honors an explicit bench-baseline.json as a
+    # local override, and falls back to the committed artifact without it).
     install_extras ""
-    log "cairn bench (CI: Run bench -- advisory)"
-    cairn bench --suite perf --n-files 60 --complexity medium \
-      --embed-backend hash --repeats 3 \
-      --json --save bench-current.json \
+    log "cairn bench vs committed DS-v1 (CI: Run bench -- advisory)"
+    cairn bench --suite perf --embed-backend hash --repeats 3 \
+      --json --save bench-current.json --baseline DS-v1 \
       || warn "bench failed (advisory in CI too)"
-    if [[ -f bench-baseline.json && -f bench-current.json ]]; then
-      log "comparing against bench-baseline.json (CI: Compare vs baseline)"
-      python .github/scripts/bench_compare.py || warn "comparison failed (advisory)"
-    else
-      log "no baseline yet -- this run establishes bench-baseline.json"
-    fi
-    [[ -f bench-current.json ]] && cp bench-current.json bench-baseline.json
+    log "advisory comparison (CI: Compare vs baseline)"
+    python .github/scripts/bench_compare.py || warn "comparison failed (advisory)"
     ;;
 
   *) die "inner: unknown job '$JOB'" ;;

--- a/specs/INDEX.md
+++ b/specs/INDEX.md
@@ -1,2 +1,2 @@
 # Specs index
-- [benchmark-datasource](benchmark-datasource/spec.md) — draft (created 2026-08-16)
+- [benchmark-datasource](benchmark-datasource/spec.md) — done (20/20 tasks, merged via #35 2026-08-16)

--- a/src/cairn/graph/semantic.py
+++ b/src/cairn/graph/semantic.py
@@ -188,6 +188,25 @@ def _fused_confident(query: str, candidates: List[dict], limit: int) -> bool:
     return _exact_name_hit(query, candidates[0])
 
 
+def _mapping_rows(cursor) -> list:
+    """Normalize fetched rows to mapping access regardless of ``row_factory``.
+
+    A bare ``sqlite3.connect()`` (no ``Row`` factory) yields plain tuples;
+    this module reads rows by column name (``r["vec"]``, ``r["symbol_id"]``),
+    so a bare connection used to raise ``TypeError`` inside the retrieval
+    path and the search silently degraded to the FTS fallback (found while
+    minting the DS-v1 quality baseline: a quality run through a bare
+    connection measured recall 0.0). Normalizing once at each fetch boundary
+    makes any caller's connection shape safe. Row-connection rows pass
+    through untouched (zero copies on the standard path).
+    """
+    rows = cursor.fetchall()
+    if not rows or not isinstance(rows[0], tuple):
+        return rows
+    cols = [d[0] for d in cursor.description]
+    return [dict(zip(cols, r)) for r in rows]
+
+
 def _candidates_from_ann_hits(
     conn: sqlite3.Connection, ann_hits: List[Tuple[str, float]], threshold: float
 ) -> List[dict]:
@@ -202,15 +221,17 @@ def _candidates_from_ann_hits(
         return []
     score_by_id = {sid: score for sid, score in ann_hits}
     placeholders = ",".join("?" for _ in ids)
-    rows = conn.execute(
-        f"SELECT e.symbol_id, e.chunk, "
-        "s.name, s.kind, s.qualified_name, f.path AS file_path, f.repo_id AS repo "
-        "FROM embeddings e "
-        "JOIN symbols s ON e.symbol_id = s.id "
-        "JOIN files f ON s.file_id = f.id "
-        f"WHERE e.symbol_id IN ({placeholders})",
-        tuple(ids),
-    ).fetchall()
+    rows = _mapping_rows(
+        conn.execute(
+            f"SELECT e.symbol_id, e.chunk, "
+            "s.name, s.kind, s.qualified_name, f.path AS file_path, f.repo_id AS repo "
+            "FROM embeddings e "
+            "JOIN symbols s ON e.symbol_id = s.id "
+            "JOIN files f ON s.file_id = f.id "
+            f"WHERE e.symbol_id IN ({placeholders})",
+            tuple(ids),
+        )
+    )
     by_id = {r["symbol_id"]: r for r in rows}
     candidates = []
     for sid in ids:
@@ -406,16 +427,18 @@ def semantic_search(
         if not ann_enabled:
             ann.warn_ann_fallback_once(logger, context="semantic_search")
         brute_force_limit = 50000
-        rows = conn.execute(
-            "SELECT e.symbol_id, e.vec, e.chunk, e.dim, "
-            "s.name, s.kind, s.qualified_name, f.path AS file_path, f.repo_id AS repo "
-            "FROM embeddings e "
-            "JOIN symbols s ON e.symbol_id = s.id "
-            "JOIN files f ON s.file_id = f.id "
-            "WHERE e.model = ? "
-            "LIMIT ?",
-            (model, brute_force_limit),
-        ).fetchall()
+        rows = _mapping_rows(
+            conn.execute(
+                "SELECT e.symbol_id, e.vec, e.chunk, e.dim, "
+                "s.name, s.kind, s.qualified_name, f.path AS file_path, f.repo_id AS repo "
+                "FROM embeddings e "
+                "JOIN symbols s ON e.symbol_id = s.id "
+                "JOIN files f ON s.file_id = f.id "
+                "WHERE e.model = ? "
+                "LIMIT ?",
+                (model, brute_force_limit),
+            )
+        )
         if not rows:
             return _finish([])
 

--- a/tests/test_semantic_events.py
+++ b/tests/test_semantic_events.py
@@ -310,3 +310,55 @@ def test_telemetry_off_suppresses_semantic_events(fresh_db, monkeypatch):
     semantic_search(fresh_db, "safeApiCall", limit=5)  # empty -> would normally fire both
 
     assert _buffered_events() == [], "telemetry off -> zero events buffered"
+
+
+def test_bare_connection_returns_semantic_results(tmp_path, monkeypatch):
+    """A raw sqlite3.connect (no Row factory) must not silently degrade
+    semantic_search to the FTS fallback.
+
+    Found while minting the DS-v1 quality baseline: the brute-force scan
+    reads rows by column name (r["vec"]), a bare connection yields tuples,
+    and the TypeError was swallowed into retrieval degradation -- a quality
+    run through a bare connection measured recall 0.0. The fix normalizes
+    rows at the fetch boundary (_mapping_rows).
+    """
+    import sqlite3 as _sq
+
+    from cairn.graph import embeddings as emb
+    from cairn.graph.queries import semantic_search
+    from cairn.graph.schema import _apply_schema
+
+    monkeypatch.setenv("CAIRN_EMBED_BACKEND", "hash")
+    emb.reset_backend_cache()
+
+    db = tmp_path / "bare.kg"
+    conn = _sq.connect(str(db))
+    conn.row_factory = _sq.Row
+    _apply_schema(conn)
+    conn.execute("INSERT INTO repos (id, name, path, language) VALUES ('r1','r1','/r1','python')")
+    conn.execute("INSERT INTO files (id, repo_id, path, language) VALUES ('f1','r1','m.py','python')")
+    conn.execute(
+        "INSERT INTO symbols (id, file_id, name, qualified_name, kind, docstring) "
+        "VALUES ('s1','f1','alpha_handler','alpha_handler','function','handles retries with backoff')"
+    )
+    conn.commit()
+
+    # Embed through the hash backend so the corpus has real vectors.
+    emb.embed_symbols(conn, ["s1"])
+    conn.commit()
+    model = emb.current_model()
+    n = conn.execute("SELECT COUNT(*) AS c FROM embeddings WHERE model = ?", (model,)).fetchone()["c"]
+    assert n == 1
+    conn.close()
+
+    # The regression: a BARE connection (tuple rows) doing the same search.
+    bare = _sq.connect(str(db))  # no row_factory -- tuples
+    try:
+        assert isinstance(bare.execute("SELECT 1").fetchone(), tuple)
+        results = semantic_search(bare, "retry backoff handler", limit=5)
+        assert results, "bare connection returned nothing -- silent degradation returned"
+        assert any("alpha_handler" == r["name"] for r in results), (
+            f"semantic hit missing under bare connection: {[r['name'] for r in results]}"
+        )
+    finally:
+        bare.close()


### PR DESCRIPTION
## Summary

Three follow-ups from the benchmark-datasource merge's own findings ledger:

1. **Latent bug fixed**: a bare `sqlite3.connect` (no Row factory) silently degraded `semantic_search` to the FTS fallback — the retrieval path reads rows by column name, tuples raise TypeError, and the swallow path turned it into recall 0.0 (exactly how the DS-v1 mint first measured quality). `_mapping_rows` normalizes tuple rows at the two fetch boundaries; Row connections pass through uncopied. Regression test **revert-verified** (fails without the fix, passes with it).
2. **ci-local.sh** bench job mirrors the T016 CI rewiring: committed DS-v1 baseline via `--baseline`, corpus aligned to the default 300, cache dance removed.
3. **specs/INDEX** flips benchmark-datasource to done (20/20, merged #35).

## Change type

- [x] Bugfix
- [ ] Feature / improvement
- [ ] Refactor (no behavior change)
- [ ] Docs / chore / CI

## Audit checklist

- [x] **Blast radius checked** — `_mapping_rows` is module-private to semantic.py, applied at its two fetch sites; no signature changes.
- [x] **Layering respected** — no new imports beyond stdlib zip/dict.
- [x] **Graph updated** — post-merge.
- [x] **Memory recorded** — the bug was recorded at T015 discovery; fix ties to it.
- [x] **Fallback/perf paths** — this FIXES a silent-fallback path; doctor exit 0.
- [x] **Tests** — regression test + full suite **1523 passed**; pre-commit clean.
- [x] **CHANGELOG** — bugfix entry under Fixed added below.
- [x] **Gates green** — conventional title, no new deps.

## Verification

`pytest tests/test_semantic_events.py -q` → 10 passed incl. the bare-connection test; revert-check → 1 failed (proof the guard bites); full suite 1523 passed.
