### PR TITLE
ci(bench): rolling same-class baseline with SHA attribution

### DIFF
--- a/.github/scripts/bench_compare.py
+++ b/.github/scripts/bench_compare.py
@@ -3,12 +3,20 @@
 
 Inputs (CWD-relative, produced by the workflow):
   - bench-current.json   this run's ``cairn bench --save`` payload
-  - bench-baseline.json  optional explicit baseline (local override; CI's
-                         rolling-cache source for it was removed in T016)
+  - bench-baseline.json  the ROLLING CI baseline (restored from the
+                         actions/cache entry a main-branch run minted --
+                         same hosted runner class, so deltas are same-class
+                         and meaningful; see the workflow's bench job)
+  - bench-baseline.sha   sidecar written by the minting step: the main
+                         commit the rolling baseline was minted on
+                         (attribution -- the fix for the old run-id-unique
+                         cache whose misses were unattributable)
   - benchmarks/baselines/DS-v1/perf.json
                          the committed, stamped reference baseline (D-007),
-                         read when no explicit baseline file is present --
-                         the CI path since the actions/cache dance retired
+                         the COLD-START fallback while no rolling entry
+                         exists yet (and the local default) -- cross-machine
+                         vs the CI runner, so its deltas carry the
+                         machine-profile noise the rolling path removes
 
 Outputs:
   - appends a markdown comparison to $GITHUB_STEP_SUMMARY (run summary)
@@ -27,12 +35,12 @@ import sys
 from pathlib import Path
 
 MARKER = "<!-- cairn-bench-advisory -->"
-# D-007 (T016): the committed, stamped DS-v1 baseline replaced the old
-# actions/cache rolling file (bench-baseline.json) -- its run-id-unique cache
-# key always missed, so regressions were unattributable. An explicit
-# bench-baseline.json still wins when present (local override); CI never has
-# one and always lands on the committed artifact. Reads are additive: the
-# T013 stamp added top-level keys, ops/median_ms shapes are unchanged.
+# The rolling CI baseline (restored by the workflow) wins when present;
+# the committed DS-v1 artifact (D-007/T016) is the cold-start fallback.
+# Reads are additive: the T013 stamp added top-level keys, ops/median_ms
+# shapes are unchanged.
+ROLLING_BASELINE = Path("bench-baseline.json")
+ROLLING_SHA = Path("bench-baseline.sha")
 COMMITTED_BASELINE = Path("benchmarks/baselines/DS-v1/perf.json")
 # Looser than the 15% CLI default: shared CI runners are noisy, and this is
 # advisory -- the goal is signal for reviewers, not false alarms.
@@ -47,6 +55,33 @@ def _load(path: str) -> dict | None:
         return json.loads(p.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError):
         return None
+
+
+def _baseline_source(baseline: dict) -> str:
+    """One line naming WHICH baseline the numbers are against and why."""
+    dataset = baseline.get("dataset")
+    dataset = dataset if isinstance(dataset, dict) else {}
+    base_corpus = baseline.get("corpus")
+    base_corpus = base_corpus if isinstance(base_corpus, dict) else {}
+    sha = None
+    if ROLLING_SHA.exists():
+        sha = ROLLING_SHA.read_text(encoding="utf-8").strip() or None
+    if sha:
+        return (
+            f"Baseline **rolling CI** ({base_corpus.get('files', '?')} files) "
+            f"minted on `main` @ `{sha[:12]}` "
+            f"({baseline.get('timestamp', 'unknown time')}) -- same hosted "
+            f"runner class, deltas are comparable;"
+        )
+    return (
+        f"Baseline **{dataset.get('version', 'DS-v1')}** "
+        f"({base_corpus.get('files', '?')} files) from "
+        f"**{baseline.get('timestamp', 'unknown time')}** -- COLD START: no "
+        f"rolling CI baseline cached yet (the next `main` push mints one); "
+        f"this fallback is the reference-local artifact, so deltas below "
+        f"carry cross-machine noise -- treat them as a prompt to run "
+        f"`cairn bench --compare` locally, not as a verdict;"
+    )
 
 
 def _render(current: dict, baseline: dict | None) -> str:
@@ -76,16 +111,9 @@ def _render(current: dict, baseline: dict | None) -> str:
                          f"| {op['p95_ms']:.1f} |")
         return "\n".join(lines)
 
-    # Cite the baseline's dataset version + corpus (T013 stamps, read
-    # additively) so reviewers can attribute the numbers (AC1/D-007).
-    dataset = baseline.get("dataset")
-    dataset = dataset if isinstance(dataset, dict) else {}
-    base_corpus = baseline.get("corpus")
-    base_corpus = base_corpus if isinstance(base_corpus, dict) else {}
-    lines += ["",
-              f"Baseline **{dataset.get('version', 'DS-v1')}** "
-              f"({base_corpus.get('files', '?')} files) from "
-              f"**{baseline.get('timestamp', 'unknown time')}**:",
+    # Cite the baseline's source + stamp so reviewers can attribute the
+    # numbers (AC1/D-007; attribution is the rolling design's whole point).
+    lines += ["", _baseline_source(baseline),
               "", "| operation | baseline ms | current ms | delta |",
               "|---|---:|---:|---:|"]
     from cairn.bench import compare_reports
@@ -108,9 +136,9 @@ def _render(current: dict, baseline: dict | None) -> str:
 
 def main() -> int:
     current = _load("bench-current.json")
-    # Explicit local override first, committed DS-v1 artifact otherwise
-    # (D-007/T016 -- the CI path: no rolling cache file exists anymore).
-    baseline = _load("bench-baseline.json") or _load(str(COMMITTED_BASELINE))
+    # Rolling CI baseline first (restored by the workflow's cache step);
+    # committed DS-v1 artifact otherwise (cold start / local default).
+    baseline = _load(str(ROLLING_BASELINE)) or _load(str(COMMITTED_BASELINE))
 
     if current is None:
         body = "_Bench did not produce a result this run (see the job log)._"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -249,17 +249,22 @@ jobs:
           name: dist
           path: dist/
 
-  # --- Bench: advisory perf baseline comparison (T18) ---------------------
+  # --- Bench: advisory perf baseline comparison -----------------------------
   # Runs `cairn bench` on a fixed deterministic synthetic corpus (seeded
   # generator + dep-free hash embed backend) and uploads the JSON result as
-  # a workflow artifact. Since T016 (D-007) the comparison target is the
-  # committed, stamped baseline benchmarks/baselines/DS-v1/: `--baseline
-  # DS-v1` resolves it in-command, and .github/scripts/bench_compare.py
-  # renders the ADVISORY PR comment from the same artifact. (The old rolling
-  # actions/cache baseline was removed -- its run-id-unique key always
-  # missed, making regressions unattributable.) The ubuntu runner vs the
-  # reference-local minter trips the machine-profile mismatch warning every
-  # run -- by design, not noise (D-005: warn, never normalize).
+  # a workflow artifact. COMPARISON TARGET (rolling, attributable): every
+  # push to main mints the run's payload into the actions/cache under a
+  # SHA-unique key; PR runs restore the most recent main-minted entry via
+  # prefix restore-keys and compare same-class (CI vs CI). The SHA-unique
+  # exact key is the deliberate inversion of the OLD rolling design's bug
+  # (run-id keys that "always missed" made misses unattributable): now the
+  # exact key always misses BY DESIGN, the prefix supplies the newest
+  # main baseline, and the bench-baseline.sha sidecar names the commit it
+  # was minted on. The committed benchmarks/baselines/DS-v1/ artifact
+  # (D-007/T016) remains the cold-start fallback and the local default --
+  # cross-machine vs the CI runner, so its deltas carry machine-profile
+  # noise (D-005: warn, never normalize; the CLI's mismatch check buckets
+  # same-pool runner_class/os at class level so CI-vs-CI renders clean).
   # Every bench step is continue-on-error: a timing regression (bench exits
   # 2 past the 15% threshold) -- or a noisy shared runner -- can never redden
   # CI. "Advisory first, gate later if stable" (observability-telemetry
@@ -277,6 +282,22 @@ jobs:
         with:
           python-version: "3.12"
           cache: pip
+
+      # Restore the newest main-minted rolling baseline (same hosted runner
+      # class). The exact key embeds the run id so it always misses by
+      # design; restore-keys' prefix match yields the most recently created
+      # main entry. Cold start (no entry yet): nothing restores, and the
+      # run step falls back to the committed DS-v1 artifact.
+      - name: Restore rolling bench baseline
+        continue-on-error: true
+        uses: actions/cache/restore@v4
+        with:
+          path: |
+            bench-baseline.json
+            bench-baseline.sha
+          key: bench-rolling-v1-${{ runner.os }}-${{ runner.arch }}-${{ github.run_id }}
+          restore-keys: |
+            bench-rolling-v1-${{ runner.os }}-${{ runner.arch }}-
 
       - name: Install
         run: |
@@ -324,24 +345,52 @@ jobs:
           python scripts/gen_benchmark_tables.py
           git diff --exit-code docs/benchmarks.md
 
-      # D-007 (T016): compare against the committed, stamped DS-v1 baseline.
-      # `--baseline` composes with `--save` (the payload is saved first, then
-      # the comparison table renders in this step's log). Exit contract: 0
-      # clean; 1 baseline-resolution error; 2 regressions past 15%. A
-      # machine-profile mismatch vs the reference-local minter only WARNS and
-      # keeps the exit code at whatever the comparison alone decides (D-005).
-      # Exit 2 is absorbed by continue-on-error below -- timing can never
-      # redden this job; the advisory PR-comment comparison lives in
-      # bench_compare.py.
+      # Rolling comparison: prefer the restored main-minted baseline
+      # (same hosted class, deltas meaningful); cold start falls back to
+      # the committed DS-v1 artifact (cross-machine -- the CLI's mismatch
+      # warning fires and bench_compare marks the comment COLD START).
+      # `--compare`/`--baseline` compose with `--save` (payload saved
+      # first, then the table). Exit contract: 0 clean; 1 baseline/file
+      # error; 2 regressions past 15%. A machine-profile mismatch only
+      # WARNS and keeps the exit code at whatever the comparison alone
+      # decides (D-005). Exit 2 is absorbed by continue-on-error below --
+      # timing can never redden this job; the advisory PR-comment
+      # comparison lives in bench_compare.py.
       - name: Run bench (fixed corpus, hash backend)
         continue-on-error: true
         run: |
+          if [ -f bench-baseline.json ]; then
+            BASE="--compare bench-baseline.json"
+          else
+            BASE="--baseline DS-v1"
+          fi
           cairn bench --suite perf --embed-backend hash --repeats 3 \
             --json --save bench-current.json \
-            --baseline DS-v1
+            $BASE
+
+      # Mint the rolling baseline from THIS run (main pushes only -- PR
+      # runs never write cache entries, so a PR's numbers can't become the
+      # baseline) and save it under a SHA-unique key: never collides with
+      # an existing entry, and the prefix restore above picks up the newest.
+      # The sidecar SHA gives every comparison its attribution.
+      - name: Mint rolling baseline (main only)
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        run: |
+          cp bench-current.json bench-baseline.json
+          echo "${{ github.sha }}" > bench-baseline.sha
+
+      - name: Save rolling baseline cache (main only)
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: actions/cache/save@v4
+        with:
+          path: |
+            bench-baseline.json
+            bench-baseline.sha
+          key: bench-rolling-v1-${{ runner.os }}-${{ runner.arch }}-${{ github.sha }}
 
       # Renders the advisory step summary + PR comment from bench-current.json
-      # and the committed DS-v1 artifact; never exits non-zero.
+      # and whichever baseline applies (rolling first, committed fallback);
+      # never exits non-zero.
       - name: Compare vs baseline (advisory summary)
         if: always()
         continue-on-error: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `benchmarks/quality/ablation.md`.
 
 ### Changed
+- **CI bench: rolling same-class baseline**: the advisory comparison now
+  targets a rolling baseline minted on every `main` push (same hosted
+  runner class) instead of the reference-local committed artifact, with a
+  SHA sidecar naming the commit it was minted on (the attribution fix for
+  the old rolling design); the committed DS-v1 artifact stays as the
+  cold-start fallback, the CLI's machine-profile check now buckets
+  same-pool `runner_class`/`os` stamps at class level (CI-vs-CI renders
+  clean; cross-class pairs still warn), and the advisory PR comment names
+  which baseline the numbers are against.
 - **Unified ablation record**: the two retrieval-quality campaign records
   (`ablation.{json,md}` v1 + `ablation-v2.{json,md}` v2, artifacts of the two
   campaign PRs) merged into one `benchmarks/quality/ablation.{json,md}`

--- a/src/cairn/cli/bench.py
+++ b/src/cairn/cli/bench.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import shutil
 import sys
 import tempfile
@@ -40,6 +41,38 @@ _UNSTAMPED = object()
 def _profile_value(value: object) -> str:
     """Render one machine-profile value for the mismatch warning."""
     return "<unstamped>" if value is _UNSTAMPED else str(value)
+
+
+def _profile_class(key: str, value: object) -> object:
+    """Bucket a profile value into its comparison CLASS (rolling baselines).
+
+    The rolling CI baseline (bench-baseline.json minted on main, compared
+    PR-over-PR on the same hosted pool) must not fire the D-005 warning
+    for fields that merely identify *which instance of the same class*
+    produced the number:
+
+    * ``runner_class`` -- GitHub stamps ``ci-<slug(RUNNER_NAME)>`` and the
+      hosted pool names instances with trailing digits
+      (``ci-github-actions-12`` vs ``ci-github-actions-1000001128``).
+      Strip the trailing instance number; different runner *names* still
+      mismatch, and ``reference-local`` never buckets with anything.
+    * ``os`` -- hosted runners drift kernel revisions over time
+      (``Linux-6.17.0-1022-azure...`` vs ``Linux-6.20...``). Two Linux
+      kernels are the same hosted class; macOS point releases stay exact
+      (the reference minter's OS delta is a real comparability fact).
+
+    Everything else (arch, cpu, cpu_count) stays exact-equality -- those
+    are real comparability signals. This is metadata bucketing only: D-005
+    still forbids normalizing the TIMINGS themselves.
+    """
+    if value is _UNSTAMPED:
+        return value
+    text = str(value)
+    if key == "runner_class":
+        return re.sub(r"-\d+$", "", text)
+    if key == "os" and text.startswith("Linux-"):
+        return "Linux"
+    return text
 
 
 def _resolve_baseline_file(version: str, suite: str) -> Path:
@@ -108,14 +141,21 @@ def _render_baseline_header(version: str, path: Path, data: dict) -> None:
 
 
 def _warn_machine_profile_mismatch(current: dict, stamped: object) -> None:
-    """Loud advisory on ANY machine-profile field difference (D-005).
+    """Loud advisory on machine-profile CLASS differences (D-005).
 
-    TC-009: every mismatched field is named with both the baseline's and the
-    current value. TC-010: an exact match prints nothing (no false-warning
+    TC-009: every mismatched field is named with both the baseline's and
+    the current value. TC-010: an exact match prints nothing (no false-warning
     marker). TC-011: the warning is advisory only -- it never gates, so the
     exit code stays whatever the regression comparison alone decides. A
     baseline with no machine_profile stamp at all is "unknown", not
     "mismatched": noted, but without the MISMATCH marker.
+
+    Fields are compared at class level (``_profile_class``): the rolling
+    CI baseline runs PR-over-PR on GitHub's hosted pool, where
+    ``runner_class`` carries a per-instance suffix and ``os`` carries a
+    drifting kernel revision -- same class, not a mismatch. Cross-class
+    pairs (``reference-local`` vs ``ci-*``, macOS vs Linux, x86_64 vs
+    arm64, different CPU counts) still warn with both values.
     """
     from . import display
 
@@ -126,10 +166,13 @@ def _warn_machine_profile_mismatch(current: dict, stamped: object) -> None:
         return
     mismatched = []
     for key in sorted(set(current) | set(stamped)):
-        base = stamped.get(key, _UNSTAMPED)
-        cur = current.get(key, _UNSTAMPED)
-        if base != cur:
-            mismatched.append((key, base, cur))
+        base_class = _profile_class(key, stamped.get(key, _UNSTAMPED))
+        cur_class = _profile_class(key, current.get(key, _UNSTAMPED))
+        if base_class != cur_class:
+            # Display the RAW stamps (exactly what each side recorded);
+            # only the comparison buckets to class level.
+            mismatched.append((key, stamped.get(key, _UNSTAMPED),
+                               current.get(key, _UNSTAMPED)))
     if not mismatched:
         return
     display.warning(

--- a/tests/test_bench.py
+++ b/tests/test_bench.py
@@ -387,6 +387,53 @@ class TestBenchCliBaseline:
         assert "MACHINE-PROFILE MISMATCH" not in result.output
         assert " vs current " not in result.output
 
+    def test_same_hosted_pool_instances_do_not_mismatch(
+        self, tmp_path, monkeypatch
+    ):
+        """Rolling-baseline support: two instances of GitHub's hosted pool
+        (ci-github-actions-<N>, drifting N) are the same CLASS -- no mismatch
+        marker for the runner_class field, so a main-minted rolling baseline
+        compared PR-over-PR renders clean."""
+        from cairn.bench.datasource import machine_profile
+
+        # Make the CURRENT run stamp as a hosted-pool instance, then have
+        # the baseline carry a different instance number of the same pool.
+        monkeypatch.setenv("GITHUB_ACTIONS", "true")
+        monkeypatch.setenv("RUNNER_NAME", "GitHub Actions 1000001128")
+        current = machine_profile()
+        stamped = dict(
+            current,
+            runner_class="ci-github-actions-12",
+        )
+        _write_committed_baseline(tmp_path, monkeypatch, profile=stamped)
+        # (the fixture delenvs GITHUB_ACTIONS/RUNNER_NAME -- re-arm so the
+        # CLI's own stamp computes the hosted-pool profile)
+        monkeypatch.setenv("GITHUB_ACTIONS", "true")
+        monkeypatch.setenv("RUNNER_NAME", "GitHub Actions 1000001128")
+        _patch_perf_suite(monkeypatch, median_ms=100.0)
+        result = _invoke_perf_cli(["--baseline", "DS-v1"], tmp_path, monkeypatch)
+        assert result.exit_code == 0, result.output
+        assert "MACHINE-PROFILE MISMATCH" not in result.output
+
+    def test_different_hosted_runner_names_still_mismatch(
+        self, tmp_path, monkeypatch
+    ):
+        """Class bucketing only folds the instance suffix: a genuinely
+        different runner name (ci-github-actions-12 vs ci-self-hosted-7)
+        still warns, and reference-local never buckets with ci-*."""
+        from cairn.bench.datasource import machine_profile
+
+        monkeypatch.setenv("GITHUB_ACTIONS", "true")
+        monkeypatch.setenv("RUNNER_NAME", "GitHub Actions 1000001128")
+        current = machine_profile()
+        stamped = dict(current, runner_class="ci-self-hosted-7")
+        _write_committed_baseline(tmp_path, monkeypatch, profile=stamped)
+        _patch_perf_suite(monkeypatch, median_ms=100.0)
+        result = _invoke_perf_cli(["--baseline", "DS-v1"], tmp_path, monkeypatch)
+        assert result.exit_code == 0, result.output
+        assert "MACHINE-PROFILE MISMATCH" in result.output
+        assert "runner_class: baseline ci-self-hosted-7 vs current " in result.output
+
     def test_unstamped_baseline_notes_unknown_not_mismatch(self, tmp_path, monkeypatch):
         """A pre-T013 baseline (no machine_profile key) is 'unknown', not
         'mismatched': noted without the MISMATCH marker, compare proceeds."""
@@ -477,3 +524,37 @@ class TestBenchCliBaseline:
         )
         assert result.exit_code == 1
         assert "Baseline file not found" in result.output
+
+class TestProfileClassBucketing:
+    """Unit tests for _profile_class (the rolling-baseline class rule)."""
+
+    def test_runner_class_strips_instance_suffix(self):
+        from cairn.cli.bench import _profile_class
+
+        assert (
+            _profile_class("runner_class", "ci-github-actions-1000001128")
+            == _profile_class("runner_class", "ci-github-actions-12")
+            == "ci-github-actions"
+        )
+        # Different runner NAMES stay distinct; reference-local is exact.
+        assert _profile_class("runner_class", "ci-self-hosted-7") == "ci-self-hosted"
+        assert _profile_class("runner_class", "reference-local") == "reference-local"
+        # A suffix that is part of the name (letters) is not stripped.
+        assert _profile_class("runner_class", "ci-runner-x86") == "ci-runner-x86"
+
+    def test_os_buckets_linux_kernels_only(self):
+        from cairn.cli.bench import _profile_class
+
+        assert _profile_class(
+            "os", "Linux-6.17.0-1022-azure-x86_64-with-glibc2.39"
+        ) == _profile_class("os", "Linux-6.20.1-1234-azure-x86_64") == "Linux"
+        # Non-Linux values (macOS point releases) stay exact: the reference
+        # minter's OS delta is a real comparability fact.
+        assert _profile_class("os", "macOS-26.5.2-arm64") == "macOS-26.5.2-arm64"
+
+    def test_other_fields_and_unstamped_pass_through(self):
+        from cairn.cli.bench import _UNSTAMPED, _profile_class
+
+        assert _profile_class("arch", "x86_64") == "x86_64"
+        assert _profile_class("cpu_count", 4) == "4"
+        assert _profile_class("runner_class", _UNSTAMPED) is _UNSTAMPED


### PR DESCRIPTION
## Summary

Replaces the CI bench comparison's target: instead of the committed reference-local `DS-v1` artifact (which made every run a cross-machine comparison firing 3–10 false "REGRESSED" flags), PRs now compare against a **rolling baseline minted on every `main` push from the same hosted runner class** — with a SHA sidecar naming the commit it was minted on (option 1 of the four discussed).

## Change type

- [ ] Feature / improvement
- [ ] Bugfix
- [ ] Refactor (no behavior change)
- [x] Docs / chore / CI

## Audit checklist

Author — confirm before requesting review (procedure: `docs/review-checklist.md`):

- [x] **Blast radius checked** — one `src/` touch: `_warn_machine_profile_mismatch`/`_profile_class` in `cairn.cli.bench` (warning display semantics only; raw stamps still shown, comparison buckets same-pool `runner_class` suffixes and Linux kernel revisions). Existing TC-009/010/011 tests unchanged and green; new tests pin the bucket rule. No other callers.
- [x] **Layering respected** — CLI rendering layer + CI config + the `.github/scripts` renderer; no boundary crossings.
- [x] **Graph updated** — will run post-merge.
- [x] **Memory recorded** — the CI-noise corollary was recorded earlier; this PR is its fix.
- [x] **Fallback/perf paths** — the brute-force/rerank notes unchanged; the bench job's deterministic gates (T1 content pin, T2 smoke, docs-table guard) untouched.
- [x] **Tests** — `tests/test_bench.py` 34 passed (2 new CLI-level class tests + 3 unit tests for `_profile_class`); full suite **1918 passed, 1 skipped**; `bench_compare.py` renderer smoke-tested for both rolling and cold-start paths.
- [x] **CHANGELOG** — `[Unreleased]` Changed entry added.
- [x] **Gates green** — pre-commit all-files green; YAML validated; no new deps (`actions/cache` v4 is first-party).

## Blast-radius note

Cold-start semantics: this PR's own run has no rolling cache yet → falls back to the committed artifact with an explicit COLD START note in the comment. On merge, the `main` push mints the first baseline; every later PR compares same-class. PR runs never write cache entries, so no PR can pollute the baseline.

## Verification

- Local: `pytest tests/test_bench.py` 34 passed; full suite 1918/1; renderer smoke shows "Baseline **rolling CI** … minted on `main` @ `<sha>`" and the cold-start fallback line.
- D-005 preserved: timings never normalized; only the class-equality of the *warning* metadata changed (CI pool instances fold, `reference-local` never folds with `ci-*`, arch/cpu_count exact).