### PR TITLE
feat(cli): add config --db and close code-vs-docs drift from audit

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ All AI coding agents working in this workspace should use these tools.
 ## MCP Server
 - Name: `cairn` (auto-connected at session start)
 - Transport: stdio
-- 27 tools across 5 layers: graph (9), knowledge base + compass (5), memory (8), knowledge (5)
+- 27 tools across 4 layers: graph (9), knowledge base + compass (5), memory (8), knowledge (5)
   (`explore` is the recommended first call -- it aggregates the graph layer;
   `ask_compass` is the cross-layer router)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `docs/contribution-workflow.md`: counts all nine CI jobs (the test matrix
   expands to five per-version checks) and adds the DS-v2-seal and advisory
   Bench rows to the gate-failure decision table.
+- Second strict docs re-audit: the MCP server exposes 27 tools across **4**
+  layers, not 5 — corrected across every surface that carries the phrase
+  (mcp-tools.md, architecture.md, architecture-overview.md, quickstart.md,
+  cli-reference.md, README, AGENTS.md, the server.py docstring, the
+  agent-install template `_common.py`, and the two surface-sync assertions in
+  test_agent_surface.py). The 1/2/4/5 tool-layer numbering stays: it follows
+  the router's L1–L5 taxonomy (L1 graph, L2 wiki, L3 compass, L4 memory, L5
+  knowledge), where wiki (L2) + compass (L3) share one tool group — so there
+  is no Layer 3 section (the router itself genuinely routes across 5 layers
+  and is unchanged). `architecture-overview.md` states the transitive closure
+  depth correctly: `transitive_edges` is materialised to distance 4
+  (`CLOSURE_MAX_DEPTH`), serving depth ≤ 3 DFS queries — the doc said
+  "depth 3". The `resolver.py` module docstring now lists the type-aware tier
+  (Tier 0) it actually runs first.
 
 ## [0.12.1] - 2026-08-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- _Nothing yet._
+- `cairn config --db` — prints only the resolved graph DB path (machine-readable,
+  for scripting). The README self-demo already piped this into `sqlite3`; the
+  flag now exists to match.
 
 ### Changed
-- _Nothing yet._
+- Code-vs-docs drift fixes from a full docs audit. `docs/mcp-tools.md`: the
+  freshness section now describes the live file watcher (`[watch]` extra, ~2s
+  debounce, `pending_sync` staleness banners) instead of the pre-watcher
+  boot-only model, and `semantic_search` documents its `rerank` parameter and
+  the `CAIRN_RERANK_MIN_MARGIN` auto gate. `docs/cli-reference.md`: 15 (not 14)
+  memory subcommands with `cairn memory embed` documented, `update
+  --knowledge`, `config --db`, and the `build --staging`/`--repo` mutual
+  exclusion. `docs/configuration.md`: `CAIRN_WORKERS` is clamped to [1, 256]
+  (not uncapped); `CAIRN_LLM_BACKEND` documents `droid`/`opencode`/`claude`;
+  `CAIRN_CHUNK_VARIANT` documents all seven variants; the `openai` embed
+  backend's `OPENAI_API_KEY` requirement is stated; `CAIRN_CONN_POOL`,
+  `CAIRN_WARM_MODELS`, and `CAIRN_RERANK_MIN_MARGIN` are documented.
+  `docs/contribution-workflow.md`: counts all nine CI jobs (the test matrix
+  expands to five per-version checks) and adds the DS-v2-seal and advisory
+  Bench rows to the gate-failure decision table.
 
 ## [0.12.1] - 2026-08-18
 

--- a/README.md
+++ b/README.md
@@ -273,7 +273,7 @@ Deep reference: [docs/cli-reference.md](docs/cli-reference.md).
 
 ## MCP Tools
 
-27 tools across five layers — same store as the CLI:
+27 tools across four layers — same store as the CLI:
 
 | Layer | Tools |
 |-------|-------|

--- a/docs/architecture-overview.md
+++ b/docs/architecture-overview.md
@@ -11,7 +11,7 @@
 ## Table of contents
 
 1. [System at a glance](#1-system-at-a-glance)
-2. [The five layers](#2-the-five-layers)
+2. [The four tool layers](#2-the-four-tool-layers)
 3. [How the layers interact](#3-how-the-layers-interact)
 4. [Build flow: source → graph](#4-build-flow-source--graph)
 5. [Query flow: agent → answer](#5-query-flow-agent--answer)
@@ -79,7 +79,7 @@ fact-checked by a deterministic critic against the graph. See the
 
 ---
 
-## 2. The five layers
+## 2. The four tool layers
 
 | Layer | Tools | Purpose | Backed by |
 |-------|-------|---------|-----------|
@@ -156,7 +156,7 @@ flowchart TB
     RESOLVE --> PERSIST{in-memory<br/>build?}
     PERSIST -- "yes (full workspace)" --> SWAP["5a. persist<br/>atomic .tmp + os.replace<br/>(SQLite page copy)"]
     PERSIST -- "no (single repo)" --> DERIVED
-    SWAP --> DERIVED["6. derived indexes<br/>dataflow (O(1) impact)<br/>+ transitive closure (depth 3)"]
+    SWAP --> DERIVED["6. derived indexes<br/>dataflow (O(1) impact)<br/>+ transitive closure (distance 4)"]
     DERIVED --> DONE([done])
 ```
 
@@ -441,7 +441,7 @@ erDiagram
 - **FTS5** external-content table over `symbols` (name, qualified_name,
   docstring), synced by triggers, powers BM25-ranked lexical search.
 - **Derived tables**: `dataflow` (O(1) blast radius for public symbols),
-  `transitive_edges` (closure matrix, default depth 3) — built by `cairn build`
+  `transitive_edges` (closure matrix, materialised to distance 4) — built by `cairn build`
   and rebuilt by `cairn update` whenever any file changed.
 - **Vector search artifacts**: per-model sqlite-vec `vec0` ANN tables —
   `vec_<model>` over `embeddings` (populated by every `cairn embed`) and

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -3,7 +3,7 @@
 ← [Docs index](README.md)
 
 This document describes cairn's design: what it is, how a query flows
-through its five layers, how it resolves symbols, where it draws the LLM
+through its four tool layers, how it resolves symbols, where it draws the LLM
 boundary, and where data lives on disk.
 Read it when you need the system-level picture — when onboarding, before
 the per-topic pages, or when deciding which layer a question belongs to.
@@ -29,7 +29,7 @@ machine-check:
    (critic gate).
 3. **Every answer is re-derivable from local data** (LLM never in the query path).
 
-The five layers below are how the contract is delivered; resolution-labeled
+The four tool layers below are how the contract is delivered; resolution-labeled
 edges are the *evidence* for promise #1, not the headline.
 
 - **Local.** Everything runs on your machine. The store is a SQLite database
@@ -58,7 +58,7 @@ edges are the *evidence* for promise #1, not the headline.
 
 ## Layers and query flow
 
-cairn is organized into five layers. The router (`explore`) is the front
+cairn is organized into four tool layers. The router (`explore`) is the front
 door: it fans a query across the graph layer and returns one consolidated
 answer. The other layers answer specific question types.
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -503,7 +503,7 @@ editable installs.
 ## Where to look next
 
 - For the **MCP server** tool surface that AI agents consume, see
-  [mcp-tools.md](./mcp-tools.md) (27 tools across 5 layers; `explore` is the
+  [mcp-tools.md](./mcp-tools.md) (27 tools across 4 layers; `explore` is the
   recommended first call).
 - For the explore-first workflow, precise-vs-fuzzy rules, and per-tool quirks,
   see `AGENTS.md` in the workspace root.

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -80,7 +80,7 @@ read-only, contention-safe model that replaces one-stdio-server-per-client.
 > SSE `start`/`stop`/`status`/`restart` are macOS-only (launchd). On other
 > platforms run `cairn serve --port 9876` under a process supervisor.
 
-### `cairn memory` — agent memory (14 subcommands)
+### `cairn memory` — agent memory (15 subcommands)
 
 `cairn memory` records and curates agent learnings (decisions, patterns,
 mistakes, workarounds) across the tiers raw → drafts → tribal → canonical.
@@ -101,6 +101,7 @@ mistakes, workarounds) across the tiers raw → drafts → tribal → canonical.
 | `cairn memory demote PATH` | Demote a memory to a lower tier (`--tier raw\|archived`); rejects promotions. |
 | `cairn memory purge` | Delete old archived memories (`--max-days 90`, `--dry-run`). CLI-only — not exposed as MCP. |
 | `cairn memory consolidate` | Consolidate redundant raw memories into unified tribal knowledge. |
+| `cairn memory embed` | Backfill semantic embeddings for memories captured before embedding existed, or after a model swap (`--batch-size 64`, `--reap/--no-reap` to also delete rows whose memory no longer exists — default on). Ongoing capture/evolve embed on their own; this catches up the rest. |
 
 `record` options: `--body`, `--resource`, `--confidence 0.7`, `--db`, `--knowledge`.
 
@@ -233,7 +234,7 @@ These are registered directly on `cairn` (bare `@main.command()`).
 | Command | Description |
 |---------|-------------|
 | `cairn init` | Register this workspace with cairn's central store and build the graph. |
-| `cairn config` | Show resolved store paths (`--list` all workspaces, `--mcp-config` prints a path-free `.mcp.json` snippet). Also echoes the resolved [SCIP](./scip.md) config and whether each index file exists. |
+| `cairn config` | Show resolved store paths (`--list` all workspaces, `--mcp-config` prints a path-free `.mcp.json` snippet, `--db` prints only the resolved graph DB path — machine-readable, for scripting). Also echoes the resolved [SCIP](./scip.md) config and whether each index file exists. |
 | `cairn build` | Build (or rebuild) the code graph; also builds dataflow + transitive closure. |
 | `cairn stats` | Show graph statistics (repos, symbols, edges, by-repo/by-kind/skipped tables). |
 | `cairn checkpoint` | Checkpoint the graph DB's WAL back into the main file (TRUNCATE). |
@@ -244,13 +245,17 @@ These are registered directly on `cairn` (bare `@main.command()`).
 `cairn/.kg`), `--no-build`, `--import-docs` (ingest `docs/**/*.md`).
 
 `build` options: `--repo`, `--workspace`, `--db`, `-v/--verbose`, `--staging`
-(build to temp DB and atomic-swap for zero downtime). When `cairn.json`
+(build to temp DB and atomic-swap for zero downtime; **cannot be combined with
+`--repo`** — a staged single-repo build would swap in a DB containing only that
+repo, silently deleting every other repo's graph, so the combination is
+rejected). When `cairn.json`
 declares [SCIP](./scip.md) indexes, languages whose index file exists are
 imported from SCIP (exact resolution) and skipped by tree-sitter; the summary
 panel reports per-language SCIP symbol counts.
 
 `update` options: `--repo`, `--file PATH` (single-file, for PostToolUse hooks),
-`--workspace`, `--db`. Runs memory decay after reindex.
+`--workspace`, `--db`, `--knowledge` (knowledge bundle path, for the
+post-update memory staleness scan). Runs memory decay after reindex.
 
 ### Graph queries (L1)
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -56,8 +56,10 @@ database and a `.knowledge/` markdown bundle. Resolution order is
 | `CAIRN_OTEL_ENDPOINT` | URL, default unset (off) | Opt-in OTLP export of the local telemetry events as OpenTelemetry LogRecords (`body` = event name, attributes = the event's enum attrs + `session_id`, resource `service.name=cairn` — metadata only, never paths or payloads). **Unset (default) = completely off**: no export, no OpenTelemetry import, zero overhead — telemetry stays local-only in the `.kg` store, byte-identical to a build without this variable. Setting it (e.g. `http://localhost:4318/v1/logs`) requires the optional extra `pip install 'cairn-intel[otlp]'` (OpenTelemetry SDK + OTLP/http exporter); the SDK is imported lazily on the first flush only after this env var is set, and if it is absent cairn logs **one** warning and stays local — never an error, never a required install. Export rides the existing 30s background flush thread (never the tool/build hot path), is best-effort — a failed export retains the rows and retries on the next tick, logging at DEBUG, never raising — and the SQLite `events` table remains the source of truth (OTLP is an additional sink, not a replacement; read-only daemons export nothing, same as they write nothing). `CAIRN_TELEMETRY=off` overrides this variable: no export happens even when the endpoint is set. |
 | `CAIRN_READ_ONLY` | `0`/`1`, default unset (writable) | When `1`/`true`/`yes`, the MCP server opens the DB read-only. Set automatically by the SSE daemon (the safe shared-instance mode) and by `cairn serve` when read-only is requested. |
 | `CAIRN_WATCH` | `0`/`1`, default unset (on) | Hard kill switch for the MCP server's **live file watching**. When unset (or `1`), a running `cairn serve` watches the workspace repos with `watchdog` and reindexes source edits within a ~2s debounce window, so the graph stays fresh without restarting the server or running `cairn update`. Set `0`/`false`/`no`/`off` to disable. Requires the optional `[watch]` extra (`pip install cairn-intel[watch]`); without it (and with `CAIRN_WATCH` unset) the watcher degrades to a single info log line and freshness falls back to boot catch-up + explicit `cairn update`. Never runs when `CAIRN_READ_ONLY` is set — a read-only server must never write. |
-| `CAIRN_WORKERS` | int, default = CPU count | Number of parallel parse/build workers. Honored by the builder; uncapped so you can raise it on big machines. |
+| `CAIRN_WORKERS` | int, default = CPU count | Number of parallel parse/build workers. Honored by the builder; clamped to `[1, 256]`, and an unparseable value falls back to the CPU count. |
 | `CAIRN_MAX_RESULT_CHARS` | int, default `60000` | Cap on the character count of MCP tool results. Truncates oversized responses to keep agent context windows bounded. |
+| `CAIRN_CONN_POOL` | `0`/`1`, default `1` (on) | The MCP server pools one thread-local SQLite connection per DB path instead of opening/closing per tool call. Set `0`/`false`/`no` to disable pooling (escape hatch for connection-state debugging); pooled connections are closed on shutdown. |
+| `CAIRN_WARM_MODELS` | `0`/`1`, default unset (on) | Boot-time warm-up pre-loads the embedder/reranker models in a background thread so the first semantic query doesn't pay the cold-model cost. Set `0`/`false`/`no` to skip warm-up entirely. |
 
 **Live file watching behavior.** With the `[watch]` extra installed, `cairn serve`
 starts a filesystem observer at boot (after the DB guard and the boot catch-up
@@ -83,7 +85,7 @@ and the variables are inert. See also the `CAIRN_FUSION` note below.
 |----------|----------------|--------|
 | `CAIRN_FUSION` | `0`/`1`, default `1` | Reciprocal Rank Fusion of BM25 + vector scores. When on (default), the returned `score` is a fusion rank number (~0.01–0.02), not cosine similarity. Set to `0` to expose raw cosine scores. |
 | `CAIRN_ANN_BACKEND` | string, default `sqlite-vec` | When unset or `sqlite-vec` (and the `sqlite-vec` package is importable), uses a native ANN index. Set to `off` (or any other value) to force the brute-force cosine scan. Any load failure degrades to brute force automatically. |
-| `CAIRN_EMBED_BACKEND` | `local`/`openai`/`hash`, default `local` | Embedding provider. `local` uses sentence-transformers in-process (and silently falls back to `hash` when the package is missing); `openai` calls the OpenAI embeddings API; `hash` is a deterministic dep-free hash embedder (low quality, for tests/offline smoke checks). |
+| `CAIRN_EMBED_BACKEND` | `local`/`openai`/`hash`, default `local` | Embedding provider. `local` uses sentence-transformers in-process (and silently falls back to `hash` when the package is missing); `openai` calls the OpenAI embeddings API and **requires `OPENAI_API_KEY`** to be set (load fails fast otherwise); `hash` is a deterministic dep-free hash embedder (low quality, for tests/offline smoke checks). |
 | `CAIRN_EMBED_LOCAL_MODEL` | string, default `BAAI/bge-m3` | HuggingFace model id for the `local` backend. |
 | `CAIRN_EMBED_OPENAI_MODEL` | string, default `text-embedding-3-small` | Model name for the `openai` backend. |
 | `CAIRN_EMBED_KNOWLEDGE_MODEL` | string, default unset | Optional separate model for embedding the `.knowledge/` markdown corpus (lets docs use a different model than code). Falls back to the main model. |
@@ -93,6 +95,7 @@ and the variables are inert. See also the `CAIRN_FUSION` note below.
 | `CAIRN_EMBED_TRUST_REMOTE_CODE` | `0`/`1`, default unset | When `1`, sets `trust_remote_code=True` on model load — required by some custom-architecture models. |
 | `CAIRN_RERANK` | `0`/`1`, default unset | When `1`/`true`/`on`, runs a CrossEncoder reranker over retrieval results. Also auto-enabled by a successful `cairn download-reranker` (writes a `~/.cairn/rerank_enabled` marker). Set to `0`/`false`/`off` to force it OFF (hard kill switch — wins over the marker). Needs the `[semantic]` extra (no separate install); if the configured model isn't cached, falls back to hybrid (vector + BM25 + RRF) order. |
 | `CAIRN_RERANK_MODEL` | string, default `BAAI/bge-reranker-base` | CrossEncoder model used when reranking. The default is the natural pair for the `bge-m3` embedder (same BAAI family). |
+| `CAIRN_RERANK_MIN_MARGIN` | float, default `0.45` | Confidence gate for the rerank stage: when a fused ranking's top-to-edge margin is at or above this (and the top hit is an exact name match), rerank is skipped — the cross-encoder can't change such an answer and costs most of the latency. Clamped to `[0, 1]` (`1.0` effectively never skips, `0.0` skips on every decisive fused ranking); unparseable values fall back to the default. A latency knob, not correctness. The `semantic_search` tool's per-call `rerank` parameter bypasses this gate (`True` forces, `False` never). |
 
 ### Disabling fusion to read real cosine scores
 
@@ -122,13 +125,13 @@ claims and completes. See `cairn task list / show / claim / complete`.
 
 | Variable | Type / Default | Effect |
 |----------|----------------|--------|
-| `CAIRN_LLM_BACKEND` | string, default `file-queue` | How LLM-driven commands route their work. `file-queue` (default) enqueues tasks for an external agent; a deterministic critic fact-checks every completed result before it is committed. Recognized by the compass and memory commands. |
+| `CAIRN_LLM_BACKEND` | string, default `file-queue` | How LLM-driven commands route their work. `file-queue` (default) enqueues tasks for an external agent; a deterministic critic fact-checks every completed result before it is committed. Set to `droid`, `opencode`, or `claude` to instead spawn that agent CLI directly as a subprocess (no queue, no waiting for a separate agent to claim). Recognized by the compass and memory commands. |
 
 ## Parsing
 
 | Variable | Type / Default | Effect |
 |----------|----------------|--------|
-| `CAIRN_CHUNK_VARIANT` | `A`/`B`, default `B` | How source is chunked before embedding. Variant `B` is the current default; override to `A` for the legacy chunker if you need to reproduce older embeddings. Changing this invalidates existing embeddings on the next `cairn embed`. |
+| `CAIRN_CHUNK_VARIANT` | string, default `B` | How source is chunked before embedding (case-insensitive). The ablation ladder: `A` (legacy: kind + name + first signature line), `B` (default: A + docstring + parameters + return type + full signature), `C` (B + body + context), plus field-dropout variants of B for retrieval-quality ablations — `B_NO_SCOPE` (no enclosing scope/imports), `B_NO_SIG` (no parameters/return type), `B_IDENTITIES` (only the identity floor: qualified name + file path + signature + docstring), `C_TRIM` (B + body truncated to half the chunk budget). Changing this invalidates existing embeddings on the next `cairn embed`. |
 
 ## Workspace config file (`cairn.json`)
 

--- a/docs/contribution-workflow.md
+++ b/docs/contribution-workflow.md
@@ -121,9 +121,11 @@ updated (`cairn update`), memory recorded, tests, CHANGELOG.
 
 ## 7. Watch CI; fix on the SAME branch
 
-Seven checks run on PR open (and on each later push). Use the gate-failure table
-below. Push fixes to the branch — CI re-runs automatically; do **not**
-close/reopen the PR.
+Nine CI jobs run on PR open (and on each later push): pre-commit, Security,
+Type check, PR title, Dependency review, the Test matrix (Python 3.10–3.14,
+one check per version), DS-v2 seal, Build, and the advisory Bench comparison.
+Use the gate-failure table below. Push fixes to the branch — CI re-runs
+automatically; do **not** close/reopen the PR.
 
 ## 8. After merge — post-task (binding, see AGENTS.md §"After completing a task")
 
@@ -148,11 +150,14 @@ Map the failed check to its fix. Check names match the CI job `name:` fields.
 | `PR title (conventional commits)` | title isn't `type: subject` | rename the PR title (no code change) |
 | `Dependency review (PR)` | a NEW dep in the PR is vulnerable/unlicensed | pick a different version/package |
 | `Test (Python X)` | a test failed | fix code or update the test; run `pytest -m core` locally first |
+| `Verify DS-v2 seal` | the vendored eval dataset drifted from its pinned tree-hashes / expectations | never hand-edit `benchmarks/datasource/`; regenerate via the dataset's own verifier (`benchmarks/datasource/ds2/verify_dataset.py`) |
 | `Build wheel + sdist` | wheel won't build or import | fix the packaging/import error |
+| `Bench (advisory baseline comparison)` | perf moved >15% past the rolling baseline | advisory only (never reddens CI); inspect `bench-comment.md` on the PR before merging |
 
-`Security / bandit` and `Type check (mypy, advisory)` are **advisory**: they show
-green even with findings (`continue-on-error`). Open their job logs and review any
-*new* finding — don't ignore them just because the check is green.
+`Security / bandit`, `Type check (mypy, advisory)`, and `Bench` are
+**advisory**: they show green even with findings (`continue-on-error`). Open
+their job logs and review any *new* finding — don't ignore them just because
+the check is green.
 
 ---
 

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -42,7 +42,7 @@ into specific relationships.
 | `get_callers(name, fuzzy?, limit?, structured?)` | Who calls this symbol. Precise by default; `fuzzy=True` adds name-only call sites. |
 | `get_callees(name, fuzzy?, limit?, structured?)` | What this symbol calls. Precise by default; `fuzzy=True` includes unresolved/external calls. |
 | `impact_analysis(name, depth?, fuzzy?, cached?, limit?, structured?)` | Recursive blast radius (callers up to `depth`). Reports total + by-depth + affected tests + cross-repo consumers. |
-| `semantic_search(query, limit?, include_callers?, structured?)` | Concept search — finds code by meaning. Requires the `semantic` extra. |
+| `semantic_search(query, limit?, include_callers?, structured?, rerank?)` | Concept search — finds code by meaning. Requires the `semantic` extra. |
 | `search_symbols(pattern, kind?, structured?)` | Lexical symbol search (`*` wildcards, BM25-ranked). The default discovery entry point. |
 | `cross_repo_deps(repo, limit?)` | Cross-repo dependency map: what `repo` depends on, what depends on it. |
 | `visualize_graph(scope?, symbol?, module?, repo?, depth?, format?)` | Generate a diagram (Mermaid/DOT/JSON) of a graph scope. |
@@ -70,9 +70,14 @@ into specific relationships.
   `fused(bm25+semantic)`) is shown. Rank order is meaningful either way; set
   `CAIRN_FUSION=0` for true 0..1 cosine scores. Rerank runs when enabled
   (auto-on after `cairn download-reranker`, or `CAIRN_RERANK=1`); each reranked
-  result is labelled `[rerank X.XX]`. If the configured rerank model is
-  missing/evicted from the cache, it falls back to the hybrid order rather than
-  failing. Set `CAIRN_RERANK=0` to force it off.
+  result is labelled `[rerank X.XX]`. In auto mode (default) the rerank stage
+  is skipped when the fused ranking is already decisive (margin over the RRF
+  scores ≥ `CAIRN_RERANK_MIN_MARGIN` and the top hit is an exact name match);
+  the per-call `rerank` parameter overrides that — `None`/omitted = auto (the
+  gate decides), `True` = force the rerank stage when enabled (bypasses the
+  confidence gate; `CAIRN_RERANK=0` still wins), `False` = never rerank. If the
+  configured rerank model is missing/evicted from the cache, it falls back to
+  the hybrid order rather than failing. Set `CAIRN_RERANK=0` to force it off.
 - **`search_symbols`**: FTS5 + phrase splitting handles underscored tokens,
   and unions in a LIKE-based substring pass for non-prefix patterns, so
   wildcards and substring queries both work on underscored and camelCase names.
@@ -236,9 +241,16 @@ area):
 
 ### Freshness
 
-The server reconciles freshness **once at boot** (diffing the files table
-against disk). Tool calls do **not** re-check freshness per query — edits
-made while a `cairn serve` process is up require a server restart (or `cairn build`)
-to show up in results. Per-query staleness banners surface when a result set
-touches files with unindexed edits pending in `pending_sync`. Use the
-`cairn://status` resource for the aggregate freshness picture.
+Freshness is maintained two ways. At boot, the server runs a one-time
+catch-up (diffing the files table against disk) to absorb edits made while it
+was down. Then — with the `[watch]` extra installed and `CAIRN_WATCH` not
+disabled — it starts a **live file watcher** so source edits made while the
+server runs are reindexed within a ~2s debounce window, without a restart or
+an explicit `cairn update`. Each changed file is first marked in
+`pending_sync`, so concurrent MCP readers immediately see a staleness banner
+on results touching that file until the reindex lands. Without the `[watch]`
+extra (or with `CAIRN_WATCH=0`, or in read-only mode), freshness falls back to
+boot catch-up + explicit `cairn update` — in that degraded mode, edits made
+while the server is up require a server restart (or `cairn build`) to show up
+in results. Use the `cairn://status` resource for the aggregate freshness
+picture.

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -4,7 +4,7 @@
 
 The `cairn` MCP server (started by `cairn serve`) exposes the codebase
 intelligence graph to AI agents. It is a FastMCP server implemented in
-`src/cairn/mcp_server/` and registers **27 tools** across 5 layers,
+`src/cairn/mcp_server/` and registers **27 tools** across 4 layers,
 plus an index-status resource.
 Read it when deciding which tool to call for a question, or when a tool's
 parameters or output shape need checking.
@@ -108,8 +108,8 @@ Bundle/OKF-read and cross-layer routing.
 
 ### Behavioral notes (knowledge base + compass)
 
-- **`ask_compass`** is the router (the L4 "router" tool in `AGENTS.md`'s layer
-  accounting). It routes correctly but can return thin body skeletons when
+- **`ask_compass`** is the router (the cross-layer router; it lives in Layer
+  2). It routes correctly but can return thin body skeletons when
   wiki/compass coverage is thin — **don't treat an empty response as "no info
   exists"**; drill down with the specific layer tool. It explicitly flags when
   every layer came up empty. With `file_path` set and no query, it runs in
@@ -130,6 +130,9 @@ Bundle/OKF-read and cross-layer routing.
 > which the live `mcp` instance enforces via an assertion in `server.py`.
 > `explore` is registered in the graph layer (1 of its 9) but acts as the
 > aggregator/front-door; `ask_compass` is the cross-layer router.
+> Layer numbering runs 1, 2, 4, 5: it follows the router's L1–L5 taxonomy
+> (L1 graph, L2 wiki, L3 compass, L4 memory, L5 knowledge), and wiki (L2) +
+> compass (L3) share one tool group — so there is no Layer 3 section.
 
 ---
 
@@ -191,7 +194,7 @@ procedural workflows.
 ### Behavioral notes (knowledge)
 
 - **`knowledge_search`** is the business-docs layer (different from the
-  Layer 2/3 bundle-level `search_knowledge`). It bridges to the code graph:
+  Layer 2 bundle-level `search_knowledge`). It bridges to the code graph:
   documents tagged with `affects_repos` get `cross_repo_deps` results
   appended. Lexical search works without the semantic extra; semantic adds
   recall. If the corpus isn't embedded, run `cairn knowledge embed`.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -147,7 +147,7 @@ Desktop, Cursor, or ZCode, add it to the client's MCP config:
 }
 ```
 
-The server exposes 27 tools across 5 layers (graph, compass + knowledge base +
+The server exposes 27 tools across 4 layers (graph, compass + knowledge base +
 router, memory, knowledge). The aggregator tool `explore` is the recommended
 first call for almost any question — it fans a query across the graph layer and
 returns one consolidated answer in a single round trip.

--- a/src/cairn/agent_install/_common.py
+++ b/src/cairn/agent_install/_common.py
@@ -345,7 +345,7 @@ def _agents_instructions(transport: str = "stdio", sse_url: str | None = None) -
         "## MCP Server\n"
         "- Name: `cairn` (auto-connected at session start)\n"
         f"{_transport_note(transport, sse_url)}\n"
-        "- 27 tools across 5 layers: graph (9), knowledge base + compass (5), memory (8), knowledge (5)\n"
+        "- 27 tools across 4 layers: graph (9), knowledge base + compass (5), memory (8), knowledge (5)\n"
         "  (`explore` is the recommended first call -- it aggregates the graph layer)\n"
         "\n"
     ) + _INSTRUCTIONS_BODY

--- a/src/cairn/agent_integration/skill/references/tools.md
+++ b/src/cairn/agent_integration/skill/references/tools.md
@@ -14,7 +14,7 @@ server. SKILL.md keeps only a name index — come here for the details.
 - `cross_repo_deps(repo, limit=50)` -- Cross-repo dependency map
 - `visualize_graph(scope, symbol?, module?, repo?, depth=3, format="mermaid")` -- Mermaid/DOT/JSON diagram of a symbol/module/impact/repo/deps scope
 
-## Layer 2/3: Knowledge Base + Compass
+## Layer 2: Knowledge Base + Compass
 - `search_knowledge(query, type_filter="", limit=10, full_body=False)` -- Search wiki, compass, patterns, memory. Use `type_filter="Wiki"` for wiki articles, `type_filter="Pattern"` for non-obvious patterns, `type_filter="Compass"` for module guides, or leave empty for all.
 - `get_compass(module)` -- Get navigation guide for a module
 - `trace_flow(entry, max_depth=8)` -- Trace the downward call chain from an entry-point symbol. Returns ordered call sequence, branch points (fan-out), and terminal calls (side effects). Read-only.

--- a/src/cairn/cli/core.py
+++ b/src/cairn/cli/core.py
@@ -149,10 +149,16 @@ def init(ws_arg, legacy_dir, no_build, import_docs):
 @main.command()
 @click.option("--list", "list_all", is_flag=True, help="List all registered workspaces.")
 @click.option("--mcp-config", is_flag=True, help="Print a path-free .mcp.json snippet for agents.")
-def config(list_all, mcp_config):
+@click.option("--db", "db_only", is_flag=True,
+              help="Print only the resolved graph DB path (machine-readable; for scripting).")
+def config(list_all, mcp_config, db_only):
     """Show resolved store paths for this workspace (or all registered ones)."""
 
     from ..paths import REGISTRY_FILE, resolve_store, resolve_workspace
+
+    if db_only:
+        click.echo(str(resolve_store().db))
+        return
 
     if mcp_config:
         snippet = {

--- a/src/cairn/graph/resolver.py
+++ b/src/cairn/graph/resolver.py
@@ -3,7 +3,8 @@
 Resolves an edge to exactly one candidate across priority tiers, leaving
 otherwise-unresolved edges as ``resolution='ambiguous'`` (precise by default).
 
-Tiers: SAME-FILE -> IMPORT-AWARE -> SAME-REPO -> GLOBAL -> AMBIGUOUS.
+Tiers: TYPE-AWARE (receiver dispatch) -> SAME-FILE -> IMPORT-AWARE ->
+SAME-REPO -> GLOBAL -> AMBIGUOUS.
 Resolution is decided per tier: one candidate -> answer; many -> mark
 ambiguous and stop; zero -> try the next broader tier.
 """

--- a/src/cairn/mcp_server/server.py
+++ b/src/cairn/mcp_server/server.py
@@ -1,7 +1,7 @@
 """cairn MCP server: exposes graph query tools to AI agents.
 
-Implements 27 tools across 5 layers (graph, knowledge base, memory/router,
-knowledge). Transport: stdio (default) or SSE, via the mcp SDK (FastMCP).
+Implements 27 tools across 4 layers (graph, knowledge base + compass,
+memory, knowledge). Transport: stdio (default) or SSE, via the mcp SDK (FastMCP).
 
 This file owns boot (sys.path bootstrap shim, boot catch-up, parent-pid
 watchdog) and the run() entry point; tool implementations live in the

--- a/tests/test_agent_surface.py
+++ b/tests/test_agent_surface.py
@@ -230,7 +230,7 @@ def _render_agents_instructions_from_source() -> str:
             if (isinstance(node, ast.FunctionDef) and node.name == "_agents_instructions"):
                 for inner in ast.walk(node):
                     if (isinstance(inner, ast.Constant) and isinstance(inner.value, str)
-                            and "tools across 5 layers" in inner.value):
+                            and "tools across 4 layers" in inner.value):
                         agents_value = inner.value
                         break
                 break
@@ -417,7 +417,7 @@ def test_tool_count_string_matches_server():
             f"could not import _agents_instructions ({exc!r}) and the source "
             "fallback also failed to render the instruction text"
         )
-    expected_phrase = f"{expected} tools across 5 layers"
+    expected_phrase = f"{expected} tools across 4 layers"
     assert expected_phrase in instructions, (
         f"_agents_instructions() output does not contain {expected_phrase!r}; "
         f"the installer blurb drifted from _EXPECTED_TOOL_COUNT={expected}"

--- a/tests/test_cli_init_rail.py
+++ b/tests/test_cli_init_rail.py
@@ -47,6 +47,28 @@ def test_init_no_build_renders_rail_open_and_close():
         assert "`cairn config`" in out
 
 
+def test_config_db_flag_prints_bare_path():
+    """`cairn config --db` prints exactly the resolved .kg path (one line,
+    machine-readable) — the form the README self-demo pipes into sqlite3."""
+    runner = CliRunner()
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
+        ws = _fixture_workspace(tmp_path)
+        result = runner.invoke(
+            main,
+            ["config", "--db"],
+            env={
+                "CAIRN_HOME": str(tmp_path / "cairn_home"),
+                "CAIRN_WORKSPACE": str(ws),
+            },
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0
+        out = result.output.strip()
+        assert out.endswith(".kg")
+        assert "\n" not in out, "must be a single machine-readable line"
+
+
 def test_init_piped_output_has_no_ansi_escapes():
     runner = CliRunner()
     with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
## Summary

Two strict docs-vs-code audits of all 18 doc surfaces (mechanical cross-checks
of env vars / CLI tree / MCP tool inventory, four parallel verification agents,
then line-level grounding of every candidate finding — one agent finding was
rejected as a false positive during grounding). This PR fixes everything that
survived grounding:

- **`cairn config --db`** (00d1889) — the README self-demo piped
  `$(cairn config --db)` into sqlite3, but the flag never existed. Now prints
  only the resolved .kg path for scripts.
- **Round-1 drift fixes** (701837c) — 10 stale claims: mcp-tools freshness
  section rewritten for the live watcher + `semantic_search` rerank param;
  cli-reference's 15 memory subcommands, `config --db`, build flag exclusion;
  configuration's `CAIRN_WORKERS` clamp, LLM backends, all 7 chunk variants,
  and 3 previously undocumented env vars; contribution-workflow's nine CI jobs.
- **Round-2 drift fixes** (46f4557) — "27 tools across **5** layers" → **4**
  (the phrase conflated the MCP tool grouping with the router's genuine L1–L5
  routing taxonomy, where wiki L2 + compass L3 share one tool group); fixed
  across 12 surfaces incl. the agent-install template and its two sync-test
  assertions. `architecture-overview.md`'s closure depth corrected to
  "materialised to distance 4" (`CLOSURE_MAX_DEPTH`). `resolver.py` docstring
  now lists its type-aware Tier 0.

## Change type

- [x] Feature / improvement
- [x] Docs / chore / CI

## Audit checklist

- [x] **Blast radius checked** — only code-behavior change is the additive
      `--db` flag on `cairn config`; all other edits are docs, docstrings,
      template strings, and test assertion strings (no runtime effect)
- [x] **Layering respected** — CLI presentation layer + docs only; no
      documented-boundary crossings
- [x] **Graph updated** — `cairn update` ran (0 files reindexed; doc-only)
- [x] **Memory recorded** — pattern "Layer-count drift: tool groups (4) vs
      routing layers (5)" → tribal
- [x] **Fallback/perf paths** — N/A: no fallback or perf path altered
- [x] **Tests** — `tests/test_agent_surface.py` 7 passed (updated sync
      assertions); full suite via CI
- [x] **CHANGELOG** — `[Unreleased]` Added + Changed entries present
- [x] **Gates green** — pre-commit passed on all 13 changed files; pip-audit /
      bandit / mypy confirmed via CI

## Blast-radius note

`cairn config --db` — additive optional flag, no existing consumer changes
("none — new surface"). `server.py` / `resolver.py` / `_common.py` are
docstring/template-string-only edits.

## Verification

- `uv run pytest tests/test_agent_surface.py -q` → **7 passed**
- `uv run pre-commit run --files <13 changed files>` → **all passed**
- compile checks (`ast.parse`) on the two touched modules → OK
- straggler greps (`5 layers`, `five layers`, `Layer 2/3`) → clean outside
  generated `egg-info`

**Reviewer note:** `router.py`'s "route across all 5 layers" is intentionally
unchanged — the router genuinely routes across L1–L5; the **tool grouping**
is 4. Both taxonomies are now stated explicitly in `mcp-tools.md`'s grouping
note so the seam can't trip the next audit.