### PR TITLE
fix(dashboard): make _human_size fall-through return explicit for mypy

### DIFF
--- a/src/cairn/dashboard/app.py
+++ b/src/cairn/dashboard/app.py
@@ -33,10 +33,11 @@ TASK_STATUSES = ("pending", "in-progress", "done", "failed")
 def _human_size(num_bytes) -> str:
     """Byte count as B / KiB / MiB / GiB / TiB, one decimal above 1024."""
     size = float(num_bytes or 0)
-    for unit in ("B", "KiB", "MiB", "GiB", "TiB"):
-        if size < 1024 or unit == "TiB":
+    for unit in ("B", "KiB", "MiB", "GiB"):
+        if size < 1024:
             return f"{int(size)} {unit}" if unit == "B" else f"{size:.1f} {unit}"
         size /= 1024
+    return f"{size:.1f} TiB"
 
 
 def _human_ts(value) -> str:


### PR DESCRIPTION
## Summary

One-line follow-up to #45 found by the local Apple-container CI run: mypy (advisory job) flagged `dashboard/app.py` `Missing return statement` — the TiB escape was inside the loop condition, which mypy can't prove exhausts. Hoisted to a terminal return; formatting behavior verified identical at all unit boundaries (0 B / 512 B / 2.0 KiB / 5.0 MiB / 3.0 TiB), `tests/test_dashboard_app.py` 23 passed, `mypy src/cairn/dashboard/` clean.

## Change type

- [x] Bugfix

## Audit checklist

- [x] **Blast radius checked** — single pure formatting helper used by templates via the `filesize` Jinja filter; no signature change.
- [x] **Layering respected** — dashboard package only.
- [x] **Graph updated** — trivial change; `cairn update` ran post-merge of #45.
- [x] **Memory recorded** — no new learning (advisory-typing hygiene).
- [x] **Fallback/perf paths** — none touched.
- [x] **Tests** — 23 dashboard-app tests green; mypy clean on the package.
- [x] **CHANGELOG** — not needed (no user-visible behavior change).
- [x] **Gates green** — pre-commit on the file passed; conventional title.

## Blast-radius note

none — behavior-identical refactor of a pure function.

## Verification

`uv run pytest tests/test_dashboard_app.py -q` → 23 passed; `uv run --extra dev mypy --ignore-missing-imports src/cairn/dashboard/` → Success: no issues found in 3 source files; boundary outputs unchanged.