### PR TITLE
chore(release): bump version 0.12.1 → 0.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,51 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.13.0] - 2026-08-20
+
+> **Focus:** the dashboard-v2 train — `cairn dashboard` grows from a
+> read-only window into the graph into a complete operational console for
+> months of recorded agent traffic: scale, liveness, navigation, machine-wide
+> store switching, CLI-side usage recording, and an operational-polish pass.
+
 ### Added
+- `cairn dashboard` — a local, read-only web dashboard (127.0.0.1:8765,
+  zero new runtime deps): projects overview with index/embedding status,
+  interactive project graph (vendored vis-network, scope/depth controls),
+  tool-call history with filters, per-tool estimated token usage ranked by
+  cost, session-grouped tool call chains split at inactivity gaps, plus
+  health / memory / task-queue panels. A missing DB renders guidance
+  ("run `cairn build`"), never an error page.
+- MCP tool-call recording — `tool_metrics` gains `req_chars`, `resp_chars`,
+  and a redacted `args_summary` (additive migration; buffered off the hot
+  path, flushed on clean shutdown), and the server stamps a per-process
+  `CAIRN_SESSION` id so history and chains group per session.
+- Traffic views at months of scale — history/tokens/chains gain time
+  windows (24h / 7d / 30d / all) and keyset pagination over a new
+  `(invoked_at, id)` index, so a store with 10.5k+ recorded calls renders
+  within its budget; chains are bounded with per-session expand.
+- Live traffic views — poll-based auto-refresh on history/chains/tokens
+  (a re-arming loop gated on tab visibility) with pause/resume, a
+  disconnected banner, and filter/scroll preservation across refreshes;
+  proven by a 30-cycle soak asserting row-set equality.
+- Cross-view links — every entity drills down in one click: tokens→history
+  and history→chains row links that carry the active window, a chains
+  session filter, `/graph` linked from both navs, and node inspection via
+  select (single click) with doubleClick reserved for expansion.
+- Graph navigation — symbol search-to-focus with a disambiguation
+  candidates endpoint, doubleClick node expansion via `/graph/neighbors`,
+  and a force/hierarchical layout toggle that preserves the camera and
+  persists in the URL.
+- Workspaces launcher — `/workspaces` gives a machine-wide overview of
+  every known store (registry ∪ directories, four-state enumeration,
+  stat-first budgeted probes) and `?store=` switches every view to another
+  workspace without a server restart, with full filter/link carry.
+- CLI usage recording — `cli:*` command invocations are recorded beside
+  MCP tool calls into `tool_metrics` with a `source` column (`mcp`/`cli`,
+  additive migration, buffered like the MCP path): the history view
+  displays and filters by source, the tokens view includes CLI usage under
+  `cli:*` names, and terminal/tmux/CLI session ids never render as
+  "unknown".
 - Dashboard operational polish — warm health: probe results (reranker/ANN
   checks) prewarm on a background thread at server start and serve from a
   stale-while-revalidate cache, so the first `/health` never pays the
@@ -20,7 +64,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   showing the policy in force and current store size. Token estimates
   become mode-aware: an exact tokenizer (via the optional `[semantic]`
   extra, no new deps) calibrates the chars-per-token divisor per window
-  from the store's own summaries, with the active mode always labeled and
+  from the store's summaries, with the active mode always labeled and
   `heuristic (chars/4)` as the zero-dependency fallback. Truncation
   observability: `tool_metrics` gains `truncated_from_chars`/
   `truncated_to_chars` recorded per truncated call (durable past the
@@ -34,24 +78,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   RFC-4180-correct CSV). Dark theme: `[data-theme=dark]` palette with a
   pre-paint, localStorage-persisted toggle defaulting to
   `prefers-color-scheme`.
-- `cairn dashboard` — a local, read-only web dashboard (127.0.0.1:8765,
-  zero new runtime deps): projects overview with index/embedding status,
-  interactive project graph (vendored vis-network, scope/depth controls),
-  tool-call history with filters, per-tool estimated token usage ranked by
-  cost, session-grouped tool call chains split at inactivity gaps, plus
-  health / memory / task-queue panels. A missing DB renders guidance
-  ("run `cairn build`"), never an error page.
-- MCP tool-call recording — `tool_metrics` gains `req_chars`, `resp_chars`,
-  and a redacted `args_summary` (additive migration; buffered off the hot
-  path, flushed on clean shutdown), and the server stamps a per-process
-  `CAIRN_SESSION` id so history and chains group per session.
 
 ### Changed
 - `cairn config --db` — prints only the resolved graph DB path (machine-readable,
   for scripting). The README self-demo already piped this into `sqlite3`; the
   flag now exists to match.
-
-### Changed
 - Code-vs-docs drift fixes from a full docs audit. `docs/mcp-tools.md`: the
   freshness section now describes the live file watcher (`[watch]` extra, ~2s
   debounce, `pending_sync` staleness banners) instead of the pre-watcher

--- a/README.md
+++ b/README.md
@@ -346,7 +346,7 @@ time; the `BAAI/bge-m3` embedding model (MIT) downloads on demand to
 
 ## Status
 
-**Beta — pre-1.0 (v0.12.1).** Public surfaces (CLI flags, MCP tool shapes,
+**Beta — pre-1.0 (v0.13.0).** Public surfaces (CLI flags, MCP tool shapes,
 knowledge-file layout) may still shift before 1.0. Feedback welcome via
 [GitHub issues](https://github.com/tanlnm512/cairn/issues).
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "cairn-intel"
-version = "0.12.1"
+version = "0.13.0"
 description = "Local codebase intelligence system: structural graph + compass + wiki + agent memory"
 readme = "README.md"
 license = "MIT"
@@ -212,7 +212,7 @@ select = ["F"]
 # The custom template (.cz_templates/keepachangelog.j2) renders that draft in
 # the existing `## [X.Y.Z] - YYYY-MM-DD` format rather than commitizen's
 # default `## X.Y.Z (YYYY-MM-DD)`.
-version = "0.12.1"
+version = "0.13.0"
 version_scheme = "pep440"
 tag_format = "v$version"
 update_changelog_on_bump = false

--- a/src/cairn/__init__.py
+++ b/src/cairn/__init__.py
@@ -1,3 +1,3 @@
 """Cairn: local codebase intelligence system."""
-__version__ = "0.12.1"
+__version__ = "0.13.0"
 __package_name__ = "cairn-intel"


### PR DESCRIPTION
## Summary

Minor release 0.13.0 — the dashboard-v2 train (base dashboard + seven specs: traffic-scale, live-updates, cross-links, graph-nav, workspace-launcher, cli-usage-recording, operational polish), shipped via PRs #45–#47. This PR finalizes the hand-maintained CHANGELOG ([Unreleased] → [0.13.0], adding entries for the six middle specs that land at release time), updates the README beta line, and carries the `cz bump` commit (pyproject + `__version__` → 0.13.0, tag `v0.13.0` pushed after merge per the main-protection flow).

## Change type

- [ ] Feature / improvement
- [ ] Bugfix
- [ ] Refactor (no behavior change)
- [x] Docs / chore / CI

## Audit checklist

- [x] **Blast radius checked** — version-string changes only (pyproject, `__init__.__version__`); no API/signature changes; fixtures stamp from `__version__` (grep verified: no hardcoded 0.12.1 in tests/).
- [x] **Layering respected** — n/a.
- [x] **Graph updated** — no source logic changes.
- [x] **Memory recorded** — n/a (release bookkeeping).
- [x] **Fallback/perf paths** — n/a.
- [x] **Tests** — full suite green at 8646a49 (2123 passed, 1 skipped; local Apple-container matrix 5/5 + CI 14/14 on PR #47); `cz bump --dry-run` verified MINOR.
- [x] **CHANGELOG** — [0.13.0] - 2026-08-00 section finalized by hand (`update_changelog_on_bump=false` by design).
- [x] **Gates green** — pre-commit ran via cz; CI rides this PR; tag push after merge triggers release.yml (Trusted Publishing → PyPI + GitHub Release).

## Blast-radius note

None — version metadata + docs.

## Verification

`cz bump --dry-run` → `0.12.1 → 0.13.0`, tag `v0.13.0`; diff = CHANGELOG.md, README.md (one line), pyproject.toml (version), src/cairn/__init__.py (`__version__`).