### PR TITLE
feat(dashboard): GitNexus-inspired UI overhaul, live symbol-search typeahead, asset-cache fix, workspace stickiness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Dashboard visual overhaul — a sidebar app shell with GitNexus-inspired
+  design tokens across every view: restyled tables, badges, cards, window
+  controls, and chain pills; stat tiles, export chips, and segmented
+  window controls; a landing launcher; a reworked graph view (kind colors,
+  communities, label discipline, spiral layout, kind filters, counts
+  legend, canvas controls). The graph's symbol search becomes a live
+  typeahead: matching symbols appear in a dropdown while typing
+  (prefix-match `/graph/suggest` endpoint, case-insensitive, shortest
+  first, kind/file context), navigable by arrow keys, Enter, or click —
+  the old type-blind confirm flow remains as the Enter fallback.
+
+### Fixed
+- Stale dashboard assets across upgrades — static responses now send
+  `Cache-Control: no-cache` and asset URLs carry a mtime version, so a
+  browser holding an old cached `app.js` never renders it against new
+  HTML. The last selected workspace is remembered per browser
+  (localStorage), so bare visits return to it instead of the launch
+  store.
+
+### Changed
+- The dashboard subsystem is now documented: `cairn dashboard` entry in
+  the CLI reference, a Local dashboard section in the architecture guide
+  (read-only and loopback-only invariants, store selection, estimate
+  provenance), and README coverage.
+
 ## [0.13.0] - 2026-08-20
 
 > **Focus:** the dashboard-v2 train — `cairn dashboard` grows from a

--- a/README.md
+++ b/README.md
@@ -183,6 +183,11 @@ dispatch hops — polymorphism that grep fundamentally cannot see.
   telemetry egress (OTLP export is opt-in and best-effort).
 - **Agent-first surfaces** — the same store backs 27 MCP tools and the CLI;
   `cairn install-agents` wires every detected client in one command.
+- **Local dashboard** — `cairn dashboard` opens a read-only web console at
+  `127.0.0.1:8765`: interactive graph with symbol search, recorded
+  tool-call history and token usage (MCP + CLI, mode-labeled estimates),
+  session chains, health/memory panels, machine-wide workspace switching,
+  and CSV/JSON export of any filtered view.
 
 ## How It Works
 
@@ -257,6 +262,7 @@ Full harness, scaling runs, and the k-fold retrieval-quality campaign:
 | Command | What it does |
 |---------|--------------|
 | `cairn serve` | Run the stdio MCP server |
+| `cairn dashboard` | Local read-only web console (127.0.0.1:8765) |
 | `cairn build` / `cairn update` | Full build (first run) / incremental reindex |
 | `cairn def <symbol>` | Find a symbol's definition |
 | `cairn impact <symbol>` | Within-repo blast radius (precise default; `--fuzzy` to audit) |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -17,6 +17,7 @@ the per-topic pages, or when deciding which layer a question belongs to.
 | [`## Resolution model`](#resolution-model) | The `exact` / `ambiguous` / `unresolved` edge labels, precise vs fuzzy query modes, and when to use which. |
 | [`## The LLM boundary`](#the-llm-boundary) | How synthesis work is queued for an external agent and fact-checked by the deterministic critic. |
 | [`## Storage`](#storage) | What lives in the SQLite store vs the `.knowledge/` markdown bundle, and how the store root is resolved. |
+| [`## Local dashboard`](#local-dashboard) | The read-only web console over the same store — its invariants (read-only, loopback-only) and where its numbers come from. |
 
 ## What cairn is
 
@@ -274,3 +275,31 @@ The store root resolves to `~/.cairn/<workspace-key>/` by default, where
 finds the right store by walking up from cwd (like git), with `CAIRN_WORKSPACE`
 as an explicit override. See [configuration.md](configuration.md) for the full
 set of path variables and `cairn config --list` to print the resolved locations.
+
+## Local dashboard
+
+`cairn dashboard` is the human-facing read surface over the same store: a
+Starlette app (vendored vis-network for the graph; zero new runtime
+dependencies) bound to `127.0.0.1:8765`. It sits **beside** the layer map,
+not inside it — every view reads through plain SQL over the graph DB and
+`.knowledge/` bundle, never through the MCP tools.
+
+Two invariants hold by construction:
+
+1. **Read-only.** Every handler opens the store with a read-only SQLite
+   connection. Retention (`CAIRN_TOOL_METRICS_MAX_ROWS`/`_MAX_AGE_SECONDS`)
+   ages `tool_metrics` rows in the recording pipeline's flush transaction —
+   the dashboard only displays the policy and current size on its health
+   panel.
+2. **Loopback-only.** Non-loopback bind hosts are refused at startup; the
+   dashboard is a local operator console, not a service.
+
+Store selection is per-request (`?store=` names a registry key from the
+`/workspaces` launcher), so one server process can view every store on the
+machine without restarts. Traffic views (history/tokens/chains) read the
+`tool_metrics`/`events` telemetry the MCP server and CLI record; token
+estimates are mode-labeled (exact tokenizer via the `[semantic]` extra when
+importable, else the documented chars÷4 heuristic) and truncation stats
+come from the durable per-call magnitude columns. Asset URLs carry a
+mtime version and static responses send `Cache-Control: no-cache`, so a
+dashboard upgrade never serves stale JS against new HTML.

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -348,7 +348,14 @@ and wiring them into `cairn.json` for build-time hybrid indexing.
 | `cairn status` | System status and health across all layers. |
 | `cairn eval` | Run retrieval evaluation harness across L1/L5 corpora (`--corpus`, `--json`; `--sweep`/`--kfold` for lever sweeps). |
 | `cairn bench` | Run performance, scalability, or agent-effort benchmarks. |
+| `cairn dashboard` | Launch the local read-only web dashboard (127.0.0.1:8765): projects, interactive graph (symbol typeahead search, node expansion, layouts), tool-call history with filters, per-tool token estimates with truncation stats, session chains, health/memory/task panels, machine-wide `/workspaces` launcher with restart-free `?store=` switching, and CSV/JSON export of the filtered history/tokens views. Loopback-only; every connection is read-only — retention ages rows in the recording pipeline, never here. |
 
+`dashboard` options: `--db PATH` (serve a specific store; default: the
+central store for this workspace), `--host` (loopback only — non-loopback
+binds are refused), `--port` (default 8765). Heavy probes (reranker/ANN)
+prewarm in a background thread at startup, so the first `/health` render
+doesn't pay the import. See [configuration.md](configuration.md) for the
+retention policy env vars surfaced on the health panel.
 `metrics` options: `--db`, `--tool NAME` (default aggregation only), `--json`,
 plus the telemetry-trend flags `--builds`, `--quality`, `--contention`, `--tasks`.
 `doctor` options: `--db`, `--json`.

--- a/src/cairn/dashboard/app.py
+++ b/src/cairn/dashboard/app.py
@@ -208,6 +208,7 @@ def create_app(
         list_projects,
         prewarm_probes,
         symbol_candidates,
+        symbol_suggest,
     )
     from .workspaces import enumerate_stores, probe_stores
     from .. import paths
@@ -328,6 +329,16 @@ def create_app(
         conn = get_read_only_db(selected_db)
         try:
             result = symbol_candidates(conn, name)
+        finally:
+            conn.close()
+        return JSONResponse(result)
+
+    def graph_suggest(request: Request) -> Response:
+        prefix = request.query_params.get("name", "").strip()
+        selected_db, _, _ = resolve_selection(request, db_path, knowledge_dir)
+        conn = get_read_only_db(selected_db)
+        try:
+            result = symbol_suggest(conn, prefix)
         finally:
             conn.close()
         return JSONResponse(result)
@@ -575,6 +586,7 @@ def create_app(
         Route("/projects", projects, name="projects"),
         Route("/graph", graph, name="graph"),
         Route("/graph/candidates", graph_candidates, name="graph_candidates"),
+        Route("/graph/suggest", graph_suggest, name="graph_suggest"),
         Route("/graph/neighbors", graph_neighbors, name="graph_neighbors"),
         Route("/history", history, name="history"),
         Route("/history.csv", history_csv, name="history_csv"),

--- a/src/cairn/dashboard/app.py
+++ b/src/cairn/dashboard/app.py
@@ -164,7 +164,16 @@ def create_app(
     from starlette.staticfiles import StaticFiles
     from starlette.templating import Jinja2Templates
 
+    static_dir = _PACKAGE_DIR / "static"
     templates = Jinja2Templates(directory=str(_PACKAGE_DIR / "templates"))
+    # Asset version = newest static-file mtime, so template URLs carry
+    # ?v=<version> and any browser holding a stale cached app.js/app.css
+    # (heuristic caching predating the no-cache header, or an old
+    # install) fetches fresh the moment the files change.
+    templates.env.globals["asset_version"] = max(
+        (p.stat().st_mtime_ns for p in static_dir.rglob("*") if p.is_file()),
+        default=0,
+    )
     templates.env.filters["filesize"] = _human_size
     templates.env.filters["epoch"] = _human_ts
     templates.env.filters["duration"] = _human_duration
@@ -172,7 +181,17 @@ def create_app(
     templates.env.filters["span"] = _human_span
     templates.env.filters["offset"] = _rel_offset
     templates.env.filters["mean"] = _fmt_mean
-    static_dir = _PACKAGE_DIR / "static"
+
+    class _RevalidatingStaticFiles(StaticFiles):
+        """Browsers heuristic-cache uncontrolled responses for a lazy
+        freshness lifetime, so an upgraded dashboard keeps serving the
+        OLD app.js/app.css (stale UI, new HTML) until the cache evicts.
+        The assets are local and tiny — always revalidate instead."""
+
+        def file_response(self, *args, **kwargs):
+            response = super().file_response(*args, **kwargs)
+            response.headers["Cache-Control"] = "no-cache"
+            return response
 
     from .data import (
         GRAPH_SCOPES,
@@ -569,7 +588,7 @@ def create_app(
         Route("/tasks", tasks, name="tasks"),
         Mount(
             "/static",
-            app=StaticFiles(directory=str(static_dir)),
+            app=_RevalidatingStaticFiles(directory=str(static_dir)),
             name="static",
         ),
     ]

--- a/src/cairn/dashboard/data.py
+++ b/src/cairn/dashboard/data.py
@@ -185,6 +185,59 @@ def symbol_candidates(
     return {"matches": matches, "truncated": len(fetched) > limit}
 
 
+SUGGEST_LIMIT = 10
+
+
+def symbol_suggest(
+    conn: sqlite3.Connection, prefix: str, limit: int = SUGGEST_LIMIT
+) -> Dict:
+    """Symbols whose name starts with ``prefix``, for search typeahead.
+
+    Complements :func:`symbol_candidates` (exact-name disambiguation)
+    with a prefix scan so the search box can show matching options
+    while typing instead of demanding a full name first. The pattern is
+    ``prefix%`` with LIKE wildcards in the typed text escaped (a name
+    is data, never SQL), matched ASCII-case-insensitively as LIKE is.
+    Matches carry the same context (``kind``, ``file``, ``repo_id``)
+    and are ordered shortest-name-first — the closest completions
+    surface before longer names — then name/file/repo for stable
+    lists. Capping and the ``truncated`` flag follow the candidates
+    contract; an empty or whitespace-only ``prefix`` short-circuits
+    empty without touching the database.
+    """
+    if not prefix or not prefix.strip():
+        return {"matches": [], "truncated": False}
+    if limit < 1:
+        limit = 1
+    escaped = (
+        prefix.strip()
+        .replace("\\", "\\\\")
+        .replace("%", "\\%")
+        .replace("_", "\\_")
+    )
+    fetched = conn.execute(
+        """
+        SELECT s.name AS name, s.kind AS kind, f.path AS file, f.repo_id AS repo_id
+        FROM symbols s
+        LEFT JOIN files f ON s.file_id = f.id
+        WHERE s.name LIKE ? ESCAPE '\\'
+        ORDER BY LENGTH(s.name) ASC, s.name ASC, f.path ASC, f.repo_id ASC, s.id ASC
+        LIMIT ?
+        """,
+        [escaped + "%", limit + 1],
+    ).fetchall()
+    matches = [
+        {
+            "name": row["name"],
+            "kind": row["kind"],
+            "file": row["file"],
+            "repo_id": row["repo_id"],
+        }
+        for row in fetched[:limit]
+    ]
+    return {"matches": matches, "truncated": len(fetched) > limit}
+
+
 def _parse_ts(value) -> Optional[datetime]:
     """Parse an ISO-8601 timestamp (concept or ``build_runs``) to an aware
     UTC datetime, or None when missing/unparseable."""

--- a/src/cairn/dashboard/static/app.css
+++ b/src/cairn/dashboard/static/app.css
@@ -1,20 +1,65 @@
+/* Cairn dashboard — GitNexus-inspired design system.
+   Theme contract (pinned by tests/test_dashboard_theme.py — note that
+   test locates blocks by first substring match, so keep selector
+   spellings OUT of comments):
+   - The first root-variable block below holds every theme-varying
+     variable and NOTHING else; the dark-theme block that follows must
+     redefine each of them to a different value plus color-scheme. New
+     theme-dependent tokens go into BOTH blocks, never the constants one.
+   - Theme resolution lives in base.html's inline head script — no
+     system-color-scheme media query may appear in this file. */
+
 :root {
-  --bg: #f6f7f9;
+  --bg: #eef1f6;
   --surface: #ffffff;
-  --text: #1f2430;
-  --muted: #6b7280;
-  --border: #d9dde3;
-  --accent: #2563eb;
+  --surface-2: #f4f6fa;
+  --sidebar: #f7f9fc;
+  --canvas: #fbfcfe;
+  --text: #182230;
+  --muted: #5f6d81;
+  --border: #dbe2ec;
+  --accent: #0d9488;
+  --accent-2: #7c5cf6;
+  --accent-contrast: #ffffff;
+  --accent-soft: rgba(13, 148, 136, 0.12);
+  --ok: #15803d;
+  --warn: #b45309;
+  --err: #b91c1c;
+  --shadow: rgba(23, 31, 46, 0.1);
 }
 
 [data-theme="dark"] {
-  --bg: #12151c;
-  --surface: #1b202a;
-  --text: #e5e9f0;
-  --muted: #96a0af;
-  --border: #2d3542;
-  --accent: #7aa2f7;
+  --bg: #0b0f16;
+  --surface: #131a26;
+  --surface-2: #18202e;
+  --sidebar: #0e131d;
+  --canvas: #0a0d13;
+  --text: #e6edf5;
+  --muted: #8d9aae;
+  --border: #232d3f;
+  --accent: #2dd4bf;
+  --accent-2: #a78bfa;
+  --accent-contrast: #04211d;
+  --accent-soft: rgba(45, 212, 191, 0.14);
+  --ok: #34d399;
+  --warn: #fbbf24;
+  --err: #f87171;
+  --shadow: rgba(0, 0, 0, 0.45);
   color-scheme: dark;
+}
+
+/* Theme-invariant design constants (NOT scanned by the theme test —
+   keep them out of the first :root block above). */
+:root {
+  --radius-s: 6px;
+  --radius: 10px;
+  --radius-l: 14px;
+  --shadow-1: 0 1px 2px var(--shadow);
+  --shadow-2: 0 12px 32px -16px var(--shadow);
+  --sidebar-w: 220px;
+  --topbar-h: 56px;
+  --font-sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+    "Helvetica Neue", Arial, sans-serif;
 }
 
 * {
@@ -23,77 +68,165 @@
 
 body {
   margin: 0;
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
-    "Helvetica Neue", Arial, sans-serif;
+  font-family: var(--font-sans);
   background: var(--bg);
   color: var(--text);
   line-height: 1.55;
 }
 
-.site-header {
-  background: var(--surface);
+a {
+  color: var(--accent);
+}
+
+a:hover,
+a:focus {
+  color: var(--accent-2);
+}
+
+:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+  border-radius: 2px;
+}
+
+/* ---- App shell: sidebar + topbar + main ---- */
+
+body.app-shell {
+  display: grid;
+  grid-template-columns: var(--sidebar-w) minmax(0, 1fr);
+  min-height: 100vh;
+}
+
+.sidebar {
+  position: sticky;
+  top: 0;
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  padding: 1rem 0.75rem;
+  background: var(--sidebar);
+  border-right: 1px solid var(--border);
+  overflow-y: auto;
+}
+
+.brand {
+  display: flex;
+  align-items: center;
+  gap: 0.55rem;
+  padding: 0.35rem 0.6rem 0.9rem;
+  color: var(--text);
+  text-decoration: none;
+  font-weight: 700;
+  font-size: 1.1rem;
+  letter-spacing: -0.01em;
+}
+
+.brand svg {
+  color: var(--accent);
+}
+
+.brand:hover,
+.brand:focus {
+  color: var(--text);
+}
+
+.side-nav {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+}
+
+.side-nav a {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  padding: 0.48rem 0.65rem;
+  border-radius: var(--radius-s);
+  color: var(--muted);
+  text-decoration: none;
+  font-size: 0.92rem;
+  transition: background 120ms ease, color 120ms ease;
+}
+
+.side-nav a svg {
+  flex: none;
+  opacity: 0.85;
+}
+
+.side-nav a:hover,
+.side-nav a:focus {
+  color: var(--text);
+  background: var(--accent-soft);
+}
+
+.side-nav a.active {
+  color: var(--accent);
+  background: var(--accent-soft);
+  font-weight: 600;
+}
+
+.side-nav a.active svg {
+  opacity: 1;
+}
+
+.sidebar-foot {
+  margin-top: auto;
+  padding-top: 0.75rem;
+  border-top: 1px solid var(--border);
+}
+
+.app-body {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.topbar {
+  position: sticky;
+  top: 0;
+  z-index: 20;
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  min-height: var(--topbar-h);
+  padding: 0 1.5rem;
+  background: var(--bg);
+  background: color-mix(in srgb, var(--bg) 78%, transparent);
+  backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
   border-bottom: 1px solid var(--border);
 }
 
-.site-nav {
-  max-width: 960px;
-  margin: 0 auto;
-  padding: 0.65rem 1rem;
-  display: flex;
-  gap: 1.1rem;
-  align-items: baseline;
-}
-
-.site-nav a {
+.topbar-title {
+  font-size: 0.82rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
   color: var(--muted);
-  text-decoration: none;
-  font-size: 0.95rem;
-}
-
-.site-nav a:hover,
-.site-nav a:focus {
-  color: var(--text);
-}
-
-.site-nav .brand {
-  font-weight: 700;
-  color: var(--accent);
-  font-size: 1.05rem;
-}
-
-.theme-toggle {
-  margin-left: auto;
-  padding: 0.1rem 0.65rem;
-  border: 1px solid var(--border);
-  border-radius: 6px;
-  background: transparent;
-  color: var(--muted);
-  font: inherit;
-  font-size: 0.95rem;
-  cursor: pointer;
-}
-
-.theme-toggle:hover,
-.theme-toggle:focus {
-  color: var(--text);
 }
 
 .site-main {
-  max-width: 960px;
+  width: 100%;
+  max-width: 1280px;
   margin: 0 auto;
-  padding: 1.5rem 1rem;
+  padding: 1.75rem 1.5rem 3.5rem;
 }
+
+/* ---- Panels (the per-view card container) ---- */
 
 .panel {
   background: var(--surface);
   border: 1px solid var(--border);
-  border-radius: 8px;
-  padding: 1.25rem 1.5rem;
+  border-radius: var(--radius-l);
+  box-shadow: var(--shadow-1);
+  padding: 1.4rem 1.6rem;
 }
 
 .panel h1 {
-  margin: 0 0 0.5rem;
+  margin: 0 0 0.6rem;
   font-size: 1.4rem;
+  letter-spacing: -0.01em;
 }
 
 .muted {
@@ -109,26 +242,147 @@ body {
   margin: 0.2rem 0;
 }
 
-a {
-  color: var(--accent);
+/* ---- Theme toggle ---- */
+
+.theme-toggle {
+  width: 100%;
+  padding: 0.42rem 0.65rem;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-s);
+  background: transparent;
+  color: var(--muted);
+  font: inherit;
+  font-size: 0.9rem;
+  cursor: pointer;
+  transition: background 120ms ease, color 120ms ease;
 }
+
+.theme-toggle:hover,
+.theme-toggle:focus {
+  color: var(--text);
+  background: var(--accent-soft);
+}
+
+/* ---- Live refresh chrome (topbar-mounted) ---- */
 
 #live-controls {
-  max-width: 960px;
-  margin: 0 auto;
-  padding: 0 1rem;
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  margin-left: auto;
+  font-size: 0.85rem;
 }
 
-#live-banner:not(:empty) {
-  margin-left: 0.5rem;
+#live-controls:not([hidden])::before {
+  content: "";
+  width: 8px;
+  height: 8px;
+  border-radius: 999px;
+  background: var(--accent);
+  animation: live-pulse 2s ease-in-out infinite;
 }
 
 #live-controls[data-state="disconnected"] {
-  color: var(--text);
-  border-top: 1px solid var(--border);
-  padding-top: 0.35rem;
+  color: var(--err);
+}
+
+#live-controls[data-state="disconnected"]::before {
+  background: var(--err);
+  animation: none;
 }
 
 #live-controls[data-state="paused"] {
   opacity: 0.6;
+}
+
+#live-controls[data-state="paused"]::before {
+  animation: none;
+}
+
+#live-controls:not([hidden]) #live-banner:not(:empty) {
+  color: var(--err);
+}
+
+#live-controls:not([hidden]) #live-pause {
+  padding: 0.18rem 0.7rem;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: var(--surface);
+  color: var(--muted);
+  font: inherit;
+  font-size: 0.8rem;
+  cursor: pointer;
+}
+
+#live-controls:not([hidden]) #live-pause:hover,
+#live-controls:not([hidden]) #live-pause:focus {
+  color: var(--text);
+  border-color: var(--accent);
+}
+
+@keyframes live-pulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.35;
+  }
+}
+
+/* ---- Responsive: sidebar collapses to a horizontal bar ---- */
+
+@media (max-width: 920px) {
+  body.app-shell {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .sidebar {
+    height: auto;
+    flex-direction: row;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.6rem 0.9rem;
+    border-right: 0;
+    border-bottom: 1px solid var(--border);
+    overflow-x: auto;
+    overflow-y: hidden;
+  }
+
+  .brand {
+    padding: 0 0.75rem 0 0.2rem;
+    white-space: nowrap;
+  }
+
+  .side-nav {
+    flex-direction: row;
+    gap: 0.25rem;
+  }
+
+  .side-nav a {
+    white-space: nowrap;
+    padding: 0.4rem 0.55rem;
+  }
+
+  .sidebar-foot {
+    margin-top: 0;
+    margin-left: auto;
+    padding-top: 0;
+    padding-left: 0.75rem;
+    border-top: 0;
+    border-left: 1px solid var(--border);
+  }
+
+  .theme-toggle {
+    width: auto;
+    white-space: nowrap;
+  }
+
+  .topbar {
+    padding: 0 1rem;
+  }
+
+  .site-main {
+    padding: 1.25rem 1rem 2.5rem;
+  }
 }

--- a/src/cairn/dashboard/static/app.css
+++ b/src/cairn/dashboard/static/app.css
@@ -403,6 +403,10 @@ body.app-shell {
   min-width: 240px;
 }
 
+.graph-stage {
+  position: relative;
+}
+
 .graph-canvas {
   height: min(72vh, 780px);
   min-height: 480px;
@@ -411,10 +415,43 @@ body.app-shell {
   border-radius: var(--radius);
 }
 
+.graph-overlay {
+  position: absolute;
+  left: 0.8rem;
+  bottom: 0.8rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  pointer-events: none;
+}
+
+.graph-overlay button {
+  pointer-events: auto;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-s);
+  background: color-mix(in srgb, var(--surface) 82%, transparent);
+  backdrop-filter: blur(6px);
+  -webkit-backdrop-filter: blur(6px);
+  color: var(--muted);
+  cursor: pointer;
+  transition: color 120ms ease, border-color 120ms ease;
+}
+
+.graph-overlay button:hover,
+.graph-overlay button:focus {
+  color: var(--accent);
+  border-color: var(--accent);
+}
+
 .graph-legend {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.4rem 1rem;
+  gap: 0.35rem;
   margin: 0.5rem 0 0;
   font-size: 0.84rem;
 }
@@ -424,13 +461,34 @@ body.app-shell {
   align-items: center;
   gap: 0.42rem;
   min-width: 0;
+  padding: 0.14rem 0.55rem;
+  border: 1px solid transparent;
+  border-radius: 999px;
+  background: none;
+  color: inherit;
+  font: inherit;
+  cursor: pointer;
+  transition: background 120ms ease, border-color 120ms ease;
 }
 
-.legend-name {
-  max-width: 200px;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+.legend-item:hover,
+.legend-item:focus {
+  background: var(--accent-soft);
+  border-color: color-mix(in srgb, var(--accent) 30%, transparent);
+}
+
+.legend-item.off {
+  opacity: 0.45;
+}
+
+.legend-item.off .legend-name {
+  text-decoration: line-through;
+}
+
+.legend-count {
+  color: var(--muted);
+  font-size: 0.76rem;
+  font-variant-numeric: tabular-nums;
 }
 
 .legend-dot {

--- a/src/cairn/dashboard/static/app.css
+++ b/src/cairn/dashboard/static/app.css
@@ -26,6 +26,13 @@
   --warn: #b45309;
   --err: #b91c1c;
   --shadow: rgba(23, 31, 46, 0.1);
+  --kind-function: #0d9488;
+  --kind-method: #16a34a;
+  --kind-class: #7c3aed;
+  --kind-interface: #2563eb;
+  --kind-enum: #db2777;
+  --kind-module: #b45309;
+  --kind-external: #6b7280;
 }
 
 [data-theme="dark"] {
@@ -45,6 +52,13 @@
   --warn: #fbbf24;
   --err: #f87171;
   --shadow: rgba(0, 0, 0, 0.45);
+  --kind-function: #2dd4bf;
+  --kind-method: #4ade80;
+  --kind-class: #a78bfa;
+  --kind-interface: #60a5fa;
+  --kind-enum: #f472b6;
+  --kind-module: #fbbf24;
+  --kind-external: #8b9bb4;
   color-scheme: dark;
 }
 
@@ -328,6 +342,147 @@ body.app-shell {
   50% {
     opacity: 0.35;
   }
+}
+
+/* ---- Graph view ---- */
+
+.graph-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-end;
+  gap: 0.9rem;
+}
+
+.graph-controls {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-end;
+  gap: 0.9rem;
+  margin: 0.6rem 0;
+}
+
+.graph-controls label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+  font-size: 0.74rem;
+  font-weight: 600;
+  color: var(--muted);
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+}
+
+.graph-controls input[type="text"],
+.graph-controls input[type="number"],
+.graph-controls select {
+  min-width: 0;
+  padding: 0.42rem 0.65rem;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-s);
+  background: var(--surface-2);
+  color: var(--text);
+  font: inherit;
+  font-size: 0.9rem;
+  letter-spacing: normal;
+  transition: border-color 120ms ease;
+}
+
+.graph-controls input:focus,
+.graph-controls select:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px var(--accent-soft);
+}
+
+.graph-controls button[type="submit"] {
+  padding: 0.45rem 1rem;
+  border: 0;
+  border-radius: var(--radius-s);
+  background: var(--accent);
+  color: var(--accent-contrast);
+  font: inherit;
+  font-size: 0.88rem;
+  font-weight: 600;
+  letter-spacing: normal;
+  cursor: pointer;
+  transition: filter 120ms ease;
+}
+
+.graph-controls button[type="submit"]:hover {
+  filter: brightness(1.08);
+}
+
+#symbol-search {
+  min-width: 240px;
+}
+
+.graph-canvas {
+  height: min(72vh, 780px);
+  min-height: 480px;
+  background: var(--canvas);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+}
+
+.graph-legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem 1rem;
+  margin: 0.5rem 0 0;
+  font-size: 0.84rem;
+}
+
+.legend-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.42rem;
+}
+
+.legend-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 999px;
+  flex: none;
+}
+
+.legend-dot[data-kind="function"] {
+  background: var(--kind-function);
+}
+
+.legend-dot[data-kind="method"] {
+  background: var(--kind-method);
+}
+
+.legend-dot[data-kind="class"] {
+  background: var(--kind-class);
+}
+
+.legend-dot[data-kind="interface"] {
+  background: var(--kind-interface);
+}
+
+.legend-dot[data-kind="enum"] {
+  background: var(--kind-enum);
+}
+
+.legend-dot[data-kind="module"] {
+  background: var(--kind-module);
+}
+
+.legend-dot[data-kind="external"] {
+  background: var(--kind-external);
+}
+
+#graph-counts strong {
+  color: var(--accent);
+}
+
+.empty-state {
+  padding: 2.4rem 1rem;
+  border: 1px dashed var(--border);
+  border-radius: var(--radius);
+  color: var(--muted);
+  text-align: center;
 }
 
 /* ---- Responsive: sidebar collapses to a horizontal bar ---- */

--- a/src/cairn/dashboard/static/app.css
+++ b/src/cairn/dashboard/static/app.css
@@ -235,6 +235,7 @@ body.app-shell {
   border-radius: var(--radius-l);
   box-shadow: var(--shadow-1);
   padding: 1.4rem 1.6rem;
+  overflow-x: auto;
 }
 
 .panel h1 {
@@ -483,6 +484,270 @@ body.app-shell {
   border-radius: var(--radius);
   color: var(--muted);
   text-align: center;
+}
+
+/* ---- Data tables ---- */
+
+.data-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.92rem;
+}
+
+.data-table th {
+  padding: 0.55rem 0.75rem;
+  border-bottom: 1px solid var(--border);
+  background: var(--surface-2);
+  text-align: left;
+  font-size: 0.72rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  color: var(--muted);
+  white-space: nowrap;
+}
+
+.data-table td {
+  padding: 0.55rem 0.75rem;
+  border-bottom: 1px solid var(--border);
+  vertical-align: top;
+}
+
+.data-table tbody tr:hover {
+  background: var(--accent-soft);
+}
+
+.data-table .num,
+td.num {
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+
+code {
+  padding: 0.08rem 0.42rem;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-s);
+  background: var(--canvas);
+  font-size: 0.84em;
+  word-break: break-all;
+}
+
+/* ---- Badges ---- */
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.38rem;
+  padding: 0.08rem 0.6rem;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: var(--surface-2);
+  color: var(--muted);
+  font-size: 0.76rem;
+  font-weight: 600;
+  line-height: 1.55;
+  white-space: nowrap;
+}
+
+.badge::before {
+  content: "";
+  width: 6px;
+  height: 6px;
+  border-radius: 999px;
+  background: currentColor;
+  flex: none;
+}
+
+.badge-ok,
+.badge-done {
+  color: var(--ok);
+  border-color: color-mix(in srgb, var(--ok) 32%, transparent);
+  background: color-mix(in srgb, var(--ok) 12%, transparent);
+}
+
+.badge-warn,
+.badge-partial {
+  color: var(--warn);
+  border-color: color-mix(in srgb, var(--warn) 32%, transparent);
+  background: color-mix(in srgb, var(--warn) 12%, transparent);
+}
+
+.badge-error,
+.badge-failed {
+  color: var(--err);
+  border-color: color-mix(in srgb, var(--err) 32%, transparent);
+  background: color-mix(in srgb, var(--err) 12%, transparent);
+}
+
+.badge-embedded,
+.badge-in-progress {
+  color: var(--accent);
+  border-color: color-mix(in srgb, var(--accent) 32%, transparent);
+  background: var(--accent-soft);
+}
+
+/* ---- Cards & stat tiles ---- */
+
+.card-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 0.9rem;
+  margin-top: 1rem;
+}
+
+.card {
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 1rem 1.1rem;
+}
+
+.card h2 {
+  margin: 0 0 0.35rem;
+  font-size: 0.76rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  color: var(--muted);
+}
+
+.card-value {
+  margin: 0.1rem 0 0.35rem;
+  font-size: 1.35rem;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+  font-variant-numeric: tabular-nums;
+}
+
+.card .muted {
+  font-size: 0.84rem;
+}
+
+.stat-row {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 0.9rem;
+  margin: 0.9rem 0 1.2rem;
+}
+
+.stat-tile {
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 0.8rem 1rem;
+}
+
+.stat-value {
+  font-size: 1.45rem;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+  font-variant-numeric: tabular-nums;
+}
+
+.stat-label {
+  margin-top: 0.15rem;
+  font-size: 0.74rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  color: var(--muted);
+}
+
+/* ---- Secondary button / export chips ---- */
+
+.btn-secondary {
+  display: inline-block;
+  padding: 0.3rem 0.85rem;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: var(--surface-2);
+  color: var(--muted);
+  font-size: 0.84rem;
+  text-decoration: none;
+  transition: color 120ms ease, border-color 120ms ease;
+}
+
+.btn-secondary:hover,
+.btn-secondary:focus {
+  color: var(--accent);
+  border-color: var(--accent);
+}
+
+/* ---- Window control (segmented) ---- */
+
+.window-control {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  font-size: 0.85rem;
+}
+
+.window-control strong {
+  padding: 0.16rem 0.72rem;
+  border-radius: 999px;
+  background: var(--accent-soft);
+  color: var(--accent);
+  font-size: 0.82rem;
+}
+
+.window-control a {
+  padding: 0.16rem 0.72rem;
+  border: 1px solid transparent;
+  border-radius: 999px;
+  color: var(--muted);
+  text-decoration: none;
+}
+
+.window-control a:hover,
+.window-control a:focus {
+  color: var(--text);
+  border-color: var(--border);
+  background: var(--surface-2);
+}
+
+/* ---- Launcher (landing page) ---- */
+
+.launcher-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(215px, 1fr));
+  gap: 0.9rem;
+  margin-top: 1.2rem;
+}
+
+.launcher-card {
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+  padding: 1rem 1.05rem;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--surface-2);
+  color: var(--text);
+  text-decoration: none;
+  transition: border-color 120ms ease, transform 120ms ease;
+}
+
+.launcher-card svg {
+  color: var(--accent);
+}
+
+.launcher-card:hover,
+.launcher-card:focus {
+  border-color: var(--accent);
+  transform: translateY(-2px);
+  color: var(--text);
+}
+
+.launcher-title {
+  font-weight: 700;
+  font-size: 0.95rem;
+}
+
+.launcher-blurb {
+  font-size: 0.82rem;
+  color: var(--muted);
 }
 
 /* ---- Responsive: sidebar collapses to a horizontal bar ---- */

--- a/src/cairn/dashboard/static/app.css
+++ b/src/cairn/dashboard/static/app.css
@@ -587,6 +587,17 @@ code {
   background: var(--accent-soft);
 }
 
+/* Memory/knowledge types (decision, pattern, mistake, workaround):
+   purple distinguishes them from operational statuses. */
+.badge-decision,
+.badge-pattern,
+.badge-mistake,
+.badge-workaround {
+  color: var(--accent-2);
+  border-color: color-mix(in srgb, var(--accent-2) 32%, transparent);
+  background: color-mix(in srgb, var(--accent-2) 12%, transparent);
+}
+
 /* ---- Cards & stat tiles ---- */
 
 .card-grid {

--- a/src/cairn/dashboard/static/app.css
+++ b/src/cairn/dashboard/static/app.css
@@ -841,3 +841,58 @@ code {
     padding: 1.25rem 1rem 2.5rem;
   }
 }
+
+/* ---- Symbol-search typeahead dropdown ---- */
+.suggest-wrap {
+  position: relative;
+  display: block;
+}
+
+.suggest-box {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  right: 0;
+  z-index: 40;
+  margin-top: 4px;
+  max-height: 18rem;
+  overflow-y: auto;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  box-shadow: 0 12px 32px rgba(15, 23, 42, 0.18);
+  padding: 4px 0;
+}
+
+.suggest-item {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  padding: 6px 12px;
+  font-size: 0.85rem;
+  cursor: pointer;
+}
+
+.suggest-item:hover,
+.suggest-item.active {
+  background: var(--accent-soft);
+}
+
+.suggest-name {
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+.suggest-ctx {
+  color: var(--muted);
+  font-size: 0.75rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.suggest-empty {
+  padding: 6px 12px;
+  color: var(--muted);
+  font-size: 0.8rem;
+}

--- a/src/cairn/dashboard/static/app.css
+++ b/src/cairn/dashboard/static/app.css
@@ -26,13 +26,6 @@
   --warn: #b45309;
   --err: #b91c1c;
   --shadow: rgba(23, 31, 46, 0.1);
-  --kind-function: #0d9488;
-  --kind-method: #16a34a;
-  --kind-class: #7c3aed;
-  --kind-interface: #2563eb;
-  --kind-enum: #db2777;
-  --kind-module: #b45309;
-  --kind-external: #6b7280;
 }
 
 [data-theme="dark"] {
@@ -52,13 +45,6 @@
   --warn: #fbbf24;
   --err: #f87171;
   --shadow: rgba(0, 0, 0, 0.45);
-  --kind-function: #2dd4bf;
-  --kind-method: #4ade80;
-  --kind-class: #a78bfa;
-  --kind-interface: #60a5fa;
-  --kind-enum: #f472b6;
-  --kind-module: #fbbf24;
-  --kind-external: #8b9bb4;
   color-scheme: dark;
 }
 
@@ -437,6 +423,14 @@ body.app-shell {
   display: inline-flex;
   align-items: center;
   gap: 0.42rem;
+  min-width: 0;
+}
+
+.legend-name {
+  max-width: 200px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .legend-dot {
@@ -444,34 +438,6 @@ body.app-shell {
   height: 10px;
   border-radius: 999px;
   flex: none;
-}
-
-.legend-dot[data-kind="function"] {
-  background: var(--kind-function);
-}
-
-.legend-dot[data-kind="method"] {
-  background: var(--kind-method);
-}
-
-.legend-dot[data-kind="class"] {
-  background: var(--kind-class);
-}
-
-.legend-dot[data-kind="interface"] {
-  background: var(--kind-interface);
-}
-
-.legend-dot[data-kind="enum"] {
-  background: var(--kind-enum);
-}
-
-.legend-dot[data-kind="module"] {
-  background: var(--kind-module);
-}
-
-.legend-dot[data-kind="external"] {
-  background: var(--kind-external);
 }
 
 #graph-counts strong {

--- a/src/cairn/dashboard/static/app.js
+++ b/src/cairn/dashboard/static/app.js
@@ -10,11 +10,11 @@
    — vis-network is vendored.
 
    Rendering model (GitNexus-inspired, ported to vis-network):
-   - Communities: nodes are colored by their natural cluster — the
-     file's directory (symbol/module scopes) or the leading path segment
-     of aggregated ids like "src (36)" (repo scope). Largest community
-     takes palette slot 0; new communities from expansions take the next
-     free slot, so existing colors never shift under a merge.
+   - Kind coloring & filters: nodes color by symbol kind (function,
+     method, class, interface, enum, module, external) from the same
+     palette the legend renders; legend items are clickable filters
+     that hide/show every node of that kind — vis hides connected
+     edges with their endpoints.
    - Label discipline: dense graphs (>30 nodes with edges) label only
      the top quarter by degree; edgeless or small graphs label
      everything. Zooming out past 0.45 strips labels graph-wide (the
@@ -55,58 +55,50 @@
     return document.documentElement.dataset.theme !== "light";
   }
 
-  /* ---- Communities ---- */
+  /* ---- Kind coloring & filters ---- */
 
-  var PALETTE_DARK = [
-    "#2dd4bf", "#a78bfa", "#60a5fa", "#f472b6", "#fbbf24",
-    "#4ade80", "#f87171", "#22d3ee", "#fb923c", "#a3e635",
-    "#e879f9", "#38bdf8"
-  ];
-  var PALETTE_LIGHT = [
-    "#0d9488", "#7c3aed", "#2563eb", "#db2777", "#b45309",
-    "#16a34a", "#b91c1c", "#0891b2", "#c2410c", "#4d7c0f",
-    "#c026d3", "#0284c7"
-  ];
-  function palette() {
-    return isDark() ? PALETTE_DARK : PALETTE_LIGHT;
+  var KIND_DARK = {
+    function: "#2dd4bf",
+    method: "#4ade80",
+    class: "#a78bfa",
+    interface: "#60a5fa",
+    enum: "#f472b6",
+    module: "#fbbf24",
+    external: "#8b9bb4"
+  };
+  var KIND_LIGHT = {
+    function: "#0d9488",
+    method: "#16a34a",
+    class: "#7c3aed",
+    interface: "#2563eb",
+    enum: "#db2777",
+    module: "#b45309",
+    external: "#6b7280"
+  };
+  function kindPalette() {
+    return isDark() ? KIND_DARK : KIND_LIGHT;
+  }
+  function kindOf(n) {
+    return n.kind && kindPalette()[n.kind] ? n.kind : "other";
   }
 
-  function communityKey(n) {
-    if (n.file) {
-      var i = n.file.lastIndexOf("/");
-      return i > 0 ? n.file.slice(0, i) : "(root)";
-    }
-    var id = (n.id || "").replace(/\s+\(\d+\)\s*$/, "");
-    var seg = id.split("/")[0];
-    return seg || "(root)";
-  }
+  var idKind = {};
+  var kindCounts = {};
+  var hiddenKinds = {};
 
-  var communityIndex = {};
-  var communityCounts = {};
-  var communityCursor = 0;
-  var idCommunity = {};
-
-  function communityOf(n) {
+  function registerKind(n) {
     /* merge() re-runs nodeView over already-known nodes (id-keyed
-       updates); a node's community is assigned and counted once. */
-    if (idCommunity[n.id] !== undefined) {
-      return idCommunity[n.id];
+       updates); a node's kind is counted once. */
+    if (idKind[n.id] !== undefined) {
+      return idKind[n.id];
     }
-    var k = communityKey(n);
-    if (communityIndex[k] === undefined) {
-      communityIndex[k] = communityCursor % PALETTE_DARK.length;
-      communityCursor += 1;
-      communityCounts[k] = communityCounts[k] || 0;
-    }
-    communityCounts[k] += 1;
-    idCommunity[n.id] = k;
+    var k = kindOf(n);
+    kindCounts[k] = (kindCounts[k] || 0) + 1;
+    idKind[n.id] = k;
     return k;
   }
-  function slotColor(slot) {
-    return palette()[slot];
-  }
   function colorForKey(k) {
-    var c = slotColor(communityIndex[k]);
+    var c = kindPalette()[k] || cssVar("--muted");
     return {
       background: c,
       border: c,
@@ -115,24 +107,20 @@
     };
   }
 
-  /* Initial assignment is largest-community-first so the biggest
-     cluster reads as the primary hue; id order breaks ties. */
-  (function assignInitialCommunities() {
-    var counts = {};
-    data.nodes.forEach(function (n) {
-      var k = communityKey(n);
-      counts[k] = (counts[k] || 0) + 1;
+  /* Legend items double as filters: toggling a kind hides every node
+     of that kind — vis hides the connected edges with them. */
+  function setKindHidden(kind, hidden) {
+    hiddenKinds[kind] = hidden;
+    var updates = [];
+    nodes.get().forEach(function (node) {
+      if (idKind[node.id] === kind) {
+        updates.push({ id: node.id, hidden: hidden });
+      }
     });
-    Object.keys(counts)
-      .sort(function (a, b) {
-        return counts[b] - counts[a] || (a < b ? -1 : 1);
-      })
-      .forEach(function (k) {
-        communityIndex[k] = communityCursor % PALETTE_DARK.length;
-        communityCursor += 1;
-        communityCounts[k] = 0;
-      });
-  })();
+    if (updates.length) {
+      nodes.update(updates);
+    }
+  }
 
   /* ---- Degree / labels / positions ---- */
 
@@ -174,13 +162,15 @@
   var edgeless = !data.edges.length;
 
   function nodeView(n) {
-    communityOf(n);
+    var kind = registerKind(n);
     var view = {
       id: n.id,
       label: labelEligible[n.id] ? n.id : "",
       title: [n.kind, n.file].filter(Boolean).join("\n"),
       value: (degree[n.id] || 0) + 1,
-      color: colorForKey(idCommunity[n.id])
+      color: colorForKey(kind),
+      /* merged nodes of an already-filtered kind arrive hidden */
+      hidden: !!hiddenKinds[kind]
     };
     if (edgeless) {
       var p = spiralPosition();
@@ -349,7 +339,39 @@
     }
   });
 
-  /* ---- Legend (communities, rendered from the same palette) ---- */
+  /* Canvas overlay controls (GitNexus-style zoom/fit cluster at the
+     canvas's bottom-left); the overlay markup lives in graph.html. */
+  var overlay = canvas.parentNode
+    ? canvas.parentNode.querySelector(".graph-overlay")
+    : null;
+  if (overlay) {
+    overlay.addEventListener("click", function (event) {
+      var btn =
+        event.target && event.target.closest
+          ? event.target.closest("button[data-graph-action]")
+          : null;
+      if (!btn || !overlay.contains(btn)) {
+        return;
+      }
+      var action = btn.getAttribute("data-graph-action");
+      var animation = { duration: 250, easingFunction: "easeInOutQuad" };
+      if (action === "zoom-in") {
+        network.moveTo({
+          scale: network.getScale() * 1.35,
+          animation: animation
+        });
+      } else if (action === "zoom-out") {
+        network.moveTo({
+          scale: Math.max(network.getScale() / 1.35, 0.05),
+          animation: animation
+        });
+      } else if (action === "fit") {
+        network.fit({ animation: animation });
+      }
+    });
+  }
+
+  /* ---- Legend: kind swatches with counts, doubling as filters ---- */
 
   function renderLegend() {
     var el = document.getElementById("graph-legend");
@@ -357,29 +379,50 @@
       return;
     }
     el.textContent = "";
-    var keys = Object.keys(communityCounts).sort(function (a, b) {
-      return communityCounts[b] - communityCounts[a] || (a < b ? -1 : 1);
-    });
-    keys.slice(0, 8).forEach(function (k) {
-      var item = document.createElement("span");
-      item.className = "legend-item";
-      var dot = document.createElement("span");
-      dot.className = "legend-dot";
-      dot.style.background = slotColor(communityIndex[k]);
-      var name = document.createElement("span");
-      name.className = "legend-name";
-      name.textContent = k;
-      item.appendChild(dot);
-      item.appendChild(name);
-      el.appendChild(item);
-    });
-    if (keys.length > 8) {
-      var more = document.createElement("span");
-      more.className = "legend-item";
-      more.textContent = "+" + (keys.length - 8) + " more";
-      el.appendChild(more);
-    }
+    Object.keys(kindCounts)
+      .sort(function (a, b) {
+        return kindCounts[b] - kindCounts[a] || (a < b ? -1 : 1);
+      })
+      .forEach(function (k) {
+        var item = document.createElement("button");
+        item.type = "button";
+        item.className = "legend-item" + (hiddenKinds[k] ? " off" : "");
+        item.setAttribute("data-kind", k);
+        item.title = "toggle " + k + " nodes";
+        var dot = document.createElement("span");
+        dot.className = "legend-dot";
+        dot.style.background = kindPalette()[k] || cssVar("--muted");
+        var name = document.createElement("span");
+        name.className = "legend-name";
+        name.textContent = k;
+        var count = document.createElement("span");
+        count.className = "legend-count";
+        count.textContent = kindCounts[k];
+        item.appendChild(dot);
+        item.appendChild(name);
+        item.appendChild(count);
+        el.appendChild(item);
+      });
     el.hidden = false;
+  }
+
+  var legendBar = document.getElementById("graph-legend");
+  if (legendBar) {
+    legendBar.addEventListener("click", function (event) {
+      var item =
+        event.target && event.target.closest
+          ? event.target.closest(".legend-item")
+          : null;
+      if (!item || !legendBar.contains(item)) {
+        return;
+      }
+      var kind = item.getAttribute("data-kind");
+      if (!kind || !(kind in kindCounts)) {
+        return;
+      }
+      setKindHidden(kind, !hiddenKinds[kind]);
+      renderLegend();
+    });
   }
   renderLegend();
 
@@ -391,7 +434,7 @@
     network.setOptions(themeOptions());
     var updates = [];
     nodes.get().forEach(function (n) {
-      var k = idCommunity[n.id];
+      var k = idKind[n.id];
       if (k !== undefined) {
         updates.push({ id: n.id, color: colorForKey(k) });
       }

--- a/src/cairn/dashboard/static/app.js
+++ b/src/cairn/dashboard/static/app.js
@@ -7,7 +7,14 @@
    hierarchical (top-down) on the live network, camera preserved.
    Selecting a node (single click) swaps the #inspect-action hint for a
    plain anchor into that symbol's neighborhood view. No CDN
-   — vis-network is vendored. */
+   — vis-network is vendored.
+
+   Theming: node colors come from the stylesheet's --kind-* variables
+   (the same tokens the HTML legend uses), read at network build time;
+   a MutationObserver on <html data-theme> re-applies the color options
+   when the theme toggle flips, without touching layout or physics.
+   Node size scales with degree (vis `value` scaling) so hubs read as
+   hubs, GitNexus-style. */
 (function () {
   "use strict";
   var block = document.getElementById("graph-data");
@@ -24,12 +31,26 @@
   if (!data.nodes || !data.nodes.length) {
     return;
   }
+  function cssVar(name) {
+    var v = getComputedStyle(document.documentElement).getPropertyValue(
+      name
+    );
+    return v ? v.trim() : "";
+  }
+  /* Node degree over the initial edge set — vis `value` scaling turns
+     it into hub sizing. Fetched-merge nodes later get degree 0 + 1. */
+  var degree = {};
+  data.edges.forEach(function (e) {
+    degree[e.source] = (degree[e.source] || 0) + 1;
+    degree[e.target] = (degree[e.target] || 0) + 1;
+  });
   function nodeView(n) {
     return {
       id: n.id,
       label: n.id,
       title: [n.kind, n.file].filter(Boolean).join("\n"),
-      group: n.kind || "other"
+      group: n.kind || "other",
+      value: (degree[n.id] || 0) + 1
     };
   }
   function edgeKey(source, target, kind) {
@@ -78,18 +99,118 @@
     };
   }
 
-  var networkOptions = {
-    autoResize: true,
-    interaction: { dragNodes: true, dragView: true, zoomView: true }
-  };
-  if (layout === "hier") {
-    networkOptions.layout = layoutOptions(layout);
+  /* Color/typography options derived from the active theme's CSS
+     variables — safe to re-apply on a theme flip because they carry no
+     layout or physics state. */
+  function themeOptions() {
+    var groups = {};
+    ["function", "method", "class", "interface", "enum", "module",
+      "external"].forEach(function (kind) {
+      var c = cssVar("--kind-" + kind);
+      if (!c) {
+        return;
+      }
+      groups[kind] = {
+        color: {
+          background: c,
+          border: c,
+          highlight: { background: c, border: cssVar("--text") },
+          hover: { background: c, border: cssVar("--text") }
+        }
+      };
+    });
+    return {
+      groups: groups,
+      nodes: {
+        shape: "dot",
+        size: 9,
+        borderWidth: 2,
+        scaling: { min: 7, max: 22 },
+        color: {
+          background: cssVar("--muted"),
+          border: cssVar("--muted"),
+          highlight: {
+            background: cssVar("--accent"),
+            border: cssVar("--text")
+          },
+          hover: { background: cssVar("--accent"), border: cssVar("--text") }
+        },
+        font: {
+          face: cssVar("--font-sans"),
+          size: 12,
+          color: cssVar("--muted"),
+          strokeColor: cssVar("--canvas"),
+          strokeWidth: 3
+        }
+      },
+      edges: {
+        color: {
+          color: cssVar("--border"),
+          highlight: cssVar("--accent"),
+          hover: cssVar("--accent")
+        },
+        width: 0.75,
+        selectionWidth: 1.5,
+        hoverWidth: 1.5,
+        arrows: { to: { enabled: true, scaleFactor: 0.4 } },
+        smooth: { enabled: true, type: "continuous", roundness: 0.35 }
+      }
+    };
   }
+
+  function optionsFor(kind) {
+    var options = {
+      autoResize: true,
+      interaction: {
+        dragNodes: true,
+        dragView: true,
+        zoomView: true,
+        hover: true,
+        tooltipDelay: 120,
+        selectConnectedEdges: true,
+        hoverConnectedEdges: true
+      }
+    };
+    var themed = themeOptions();
+    Object.keys(themed).forEach(function (key) {
+      options[key] = themed[key];
+    });
+    if (kind === "hier") {
+      options.layout = layoutOptions(kind);
+      options.physics = { enabled: false };
+    } else {
+      options.physics = {
+        enabled: true,
+        solver: "barnesHut",
+        barnesHut: {
+          gravitationalConstant: -6000,
+          springLength: 140,
+          springConstant: 0.04,
+          damping: 0.45,
+          avoidOverlap: 0.35
+        },
+        stabilization: { enabled: true, iterations: 350, fit: true }
+      };
+    }
+    return options;
+  }
+
   var network = new vis.Network(
     canvas,
     { nodes: nodes, edges: edges },
-    networkOptions
+    optionsFor(layout)
   );
+
+  /* Theme toggle re-colors the live network: only the theme-derived
+     options are re-applied, so layout/physics/camera state survives. */
+  if (typeof MutationObserver !== "undefined") {
+    new MutationObserver(function () {
+      network.setOptions(themeOptions());
+    }).observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ["data-theme"]
+    });
+  }
   var pending = {};
 
   function refreshCounts(truncated) {
@@ -260,7 +381,10 @@
       layout = kind;
       var position = network.getViewPosition();
       var scale = network.getScale();
-      network.setOptions({ layout: layoutOptions(kind) });
+      /* Full option swap: the layout change rides the physics change it
+         implies (hier disables physics, force re-enables barnesHut with
+         a fresh stabilization). */
+      network.setOptions(optionsFor(kind));
       network.once("afterDrawing", function () {
         network.moveTo({ position: position, scale: scale });
       });

--- a/src/cairn/dashboard/static/app.js
+++ b/src/cairn/dashboard/static/app.js
@@ -9,12 +9,26 @@
    plain anchor into that symbol's neighborhood view. No CDN
    — vis-network is vendored.
 
-   Theming: node colors come from the stylesheet's --kind-* variables
-   (the same tokens the HTML legend uses), read at network build time;
-   a MutationObserver on <html data-theme> re-applies the color options
-   when the theme toggle flips, without touching layout or physics.
-   Node size scales with degree (vis `value` scaling) so hubs read as
-   hubs, GitNexus-style. */
+   Rendering model (GitNexus-inspired, ported to vis-network):
+   - Communities: nodes are colored by their natural cluster — the
+     file's directory (symbol/module scopes) or the leading path segment
+     of aggregated ids like "src (36)" (repo scope). Largest community
+     takes palette slot 0; new communities from expansions take the next
+     free slot, so existing colors never shift under a merge.
+   - Label discipline: dense graphs (>30 nodes with edges) label only
+     the top quarter by degree; edgeless or small graphs label
+     everything. Zooming out past 0.45 strips labels graph-wide (the
+     sigma labelRenderThreshold equivalent); zooming back in restores.
+   - Edgeless graphs (repo/module overviews) skip physics: nodes take
+     deterministic golden-angle spiral positions — a spread
+     constellation instead of a center clump.
+   - Node size scales with degree (vis `value` scaling) so hubs read as
+     hubs.
+   - Theming: edge/font options derive from the stylesheet's CSS
+     variables; a MutationObserver on <html data-theme> re-applies them
+     and re-colors every node from the active palette (light palettes
+     are the dark hues' saturated-dark counterparts). Layout and physics
+     state are never touched by a theme flip. */
 (function () {
   "use strict";
   var block = document.getElementById("graph-data");
@@ -37,21 +51,143 @@
     );
     return v ? v.trim() : "";
   }
-  /* Node degree over the initial edge set — vis `value` scaling turns
-     it into hub sizing. Fetched-merge nodes later get degree 0 + 1. */
+  function isDark() {
+    return document.documentElement.dataset.theme !== "light";
+  }
+
+  /* ---- Communities ---- */
+
+  var PALETTE_DARK = [
+    "#2dd4bf", "#a78bfa", "#60a5fa", "#f472b6", "#fbbf24",
+    "#4ade80", "#f87171", "#22d3ee", "#fb923c", "#a3e635",
+    "#e879f9", "#38bdf8"
+  ];
+  var PALETTE_LIGHT = [
+    "#0d9488", "#7c3aed", "#2563eb", "#db2777", "#b45309",
+    "#16a34a", "#b91c1c", "#0891b2", "#c2410c", "#4d7c0f",
+    "#c026d3", "#0284c7"
+  ];
+  function palette() {
+    return isDark() ? PALETTE_DARK : PALETTE_LIGHT;
+  }
+
+  function communityKey(n) {
+    if (n.file) {
+      var i = n.file.lastIndexOf("/");
+      return i > 0 ? n.file.slice(0, i) : "(root)";
+    }
+    var id = (n.id || "").replace(/\s+\(\d+\)\s*$/, "");
+    var seg = id.split("/")[0];
+    return seg || "(root)";
+  }
+
+  var communityIndex = {};
+  var communityCounts = {};
+  var communityCursor = 0;
+  var idCommunity = {};
+
+  function communityOf(n) {
+    /* merge() re-runs nodeView over already-known nodes (id-keyed
+       updates); a node's community is assigned and counted once. */
+    if (idCommunity[n.id] !== undefined) {
+      return idCommunity[n.id];
+    }
+    var k = communityKey(n);
+    if (communityIndex[k] === undefined) {
+      communityIndex[k] = communityCursor % PALETTE_DARK.length;
+      communityCursor += 1;
+      communityCounts[k] = communityCounts[k] || 0;
+    }
+    communityCounts[k] += 1;
+    idCommunity[n.id] = k;
+    return k;
+  }
+  function slotColor(slot) {
+    return palette()[slot];
+  }
+  function colorForKey(k) {
+    var c = slotColor(communityIndex[k]);
+    return {
+      background: c,
+      border: c,
+      highlight: { background: c, border: cssVar("--text") },
+      hover: { background: c, border: cssVar("--text") }
+    };
+  }
+
+  /* Initial assignment is largest-community-first so the biggest
+     cluster reads as the primary hue; id order breaks ties. */
+  (function assignInitialCommunities() {
+    var counts = {};
+    data.nodes.forEach(function (n) {
+      var k = communityKey(n);
+      counts[k] = (counts[k] || 0) + 1;
+    });
+    Object.keys(counts)
+      .sort(function (a, b) {
+        return counts[b] - counts[a] || (a < b ? -1 : 1);
+      })
+      .forEach(function (k) {
+        communityIndex[k] = communityCursor % PALETTE_DARK.length;
+        communityCursor += 1;
+        communityCounts[k] = 0;
+      });
+  })();
+
+  /* ---- Degree / labels / positions ---- */
+
   var degree = {};
   data.edges.forEach(function (e) {
     degree[e.source] = (degree[e.source] || 0) + 1;
     degree[e.target] = (degree[e.target] || 0) + 1;
   });
+
+  var labelEligible = {};
+  (function computeEligibility() {
+    var ns = data.nodes;
+    if (!data.edges.length || ns.length <= 30) {
+      ns.forEach(function (n) {
+        labelEligible[n.id] = true;
+      });
+      return;
+    }
+    var sorted = ns.slice().sort(function (a, b) {
+      return (degree[b.id] || 0) - (degree[a.id] || 0);
+    });
+    var take = Math.max(10, Math.floor(ns.length * 0.25));
+    sorted.forEach(function (n, i) {
+      labelEligible[n.id] = i < take && (degree[n.id] || 0) >= 1;
+    });
+  })();
+
+  var labelsShown = true;
+
+  var GOLDEN = Math.PI * (3 - Math.sqrt(5));
+  var spiralCursor = 0;
+  function spiralPosition() {
+    var i = spiralCursor;
+    spiralCursor += 1;
+    var r = 100 * Math.sqrt(i + 0.6);
+    var a = i * GOLDEN;
+    return { x: Math.round(r * Math.cos(a)), y: Math.round(r * Math.sin(a)) };
+  }
+  var edgeless = !data.edges.length;
+
   function nodeView(n) {
-    return {
+    communityOf(n);
+    var view = {
       id: n.id,
-      label: n.id,
+      label: labelEligible[n.id] ? n.id : "",
       title: [n.kind, n.file].filter(Boolean).join("\n"),
-      group: n.kind || "other",
-      value: (degree[n.id] || 0) + 1
+      value: (degree[n.id] || 0) + 1,
+      color: colorForKey(idCommunity[n.id])
     };
+    if (edgeless) {
+      var p = spiralPosition();
+      view.x = p.x;
+      view.y = p.y;
+    }
+    return view;
   }
   function edgeKey(source, target, kind) {
     return source + "\u0000" + target + "\u0000" + (kind || "");
@@ -101,39 +237,24 @@
 
   /* Color/typography options derived from the active theme's CSS
      variables — safe to re-apply on a theme flip because they carry no
-     layout or physics state. */
+     layout or physics state. Node colors live on the nodes themselves
+     (community palette), not here. */
   function themeOptions() {
-    var groups = {};
-    ["function", "method", "class", "interface", "enum", "module",
-      "external"].forEach(function (kind) {
-      var c = cssVar("--kind-" + kind);
-      if (!c) {
-        return;
-      }
-      groups[kind] = {
-        color: {
-          background: c,
-          border: c,
-          highlight: { background: c, border: cssVar("--text") },
-          hover: { background: c, border: cssVar("--text") }
-        }
-      };
-    });
+    var accent = cssVar("--accent");
     return {
-      groups: groups,
       nodes: {
         shape: "dot",
         size: 9,
         borderWidth: 2,
-        scaling: { min: 7, max: 22 },
+        scaling: { min: 7, max: 24 },
         color: {
-          background: cssVar("--muted"),
-          border: cssVar("--muted"),
+          background: accent,
+          border: accent,
           highlight: {
-            background: cssVar("--accent"),
+            background: accent,
             border: cssVar("--text")
           },
-          hover: { background: cssVar("--accent"), border: cssVar("--text") }
+          hover: { background: accent, border: cssVar("--text") }
         },
         font: {
           face: cssVar("--font-sans"),
@@ -178,16 +299,20 @@
     if (kind === "hier") {
       options.layout = layoutOptions(kind);
       options.physics = { enabled: false };
+    } else if (edgeless) {
+      /* Spiral positions are final; physics would only drag the
+         constellation back into a clump. */
+      options.physics = { enabled: false };
     } else {
       options.physics = {
         enabled: true,
         solver: "barnesHut",
         barnesHut: {
           gravitationalConstant: -6000,
-          springLength: 140,
+          springLength: 160,
           springConstant: 0.04,
           damping: 0.45,
-          avoidOverlap: 0.35
+          avoidOverlap: 0.4
         },
         stabilization: { enabled: true, iterations: 350, fit: true }
       };
@@ -201,11 +326,84 @@
     optionsFor(layout)
   );
 
-  /* Theme toggle re-colors the live network: only the theme-derived
-     options are re-applied, so layout/physics/camera state survives. */
+  /* Zoom label discipline (sigma's labelRenderThreshold equivalent):
+     crossing the scale threshold flips the graph-wide label state once,
+     never per-zoom-tick. */
+  function applyLabels() {
+    var updates = [];
+    nodes.get().forEach(function (n) {
+      updates.push({
+        id: n.id,
+        label: labelsShown && labelEligible[n.id] ? n.id : ""
+      });
+    });
+    if (updates.length) {
+      nodes.update(updates);
+    }
+  }
+  network.on("zoom", function () {
+    var want = network.getScale() >= 0.45;
+    if (want !== labelsShown) {
+      labelsShown = want;
+      applyLabels();
+    }
+  });
+
+  /* ---- Legend (communities, rendered from the same palette) ---- */
+
+  function renderLegend() {
+    var el = document.getElementById("graph-legend");
+    if (!el) {
+      return;
+    }
+    el.textContent = "";
+    var keys = Object.keys(communityCounts).sort(function (a, b) {
+      return communityCounts[b] - communityCounts[a] || (a < b ? -1 : 1);
+    });
+    keys.slice(0, 8).forEach(function (k) {
+      var item = document.createElement("span");
+      item.className = "legend-item";
+      var dot = document.createElement("span");
+      dot.className = "legend-dot";
+      dot.style.background = slotColor(communityIndex[k]);
+      var name = document.createElement("span");
+      name.className = "legend-name";
+      name.textContent = k;
+      item.appendChild(dot);
+      item.appendChild(name);
+      el.appendChild(item);
+    });
+    if (keys.length > 8) {
+      var more = document.createElement("span");
+      more.className = "legend-item";
+      more.textContent = "+" + (keys.length - 8) + " more";
+      el.appendChild(more);
+    }
+    el.hidden = false;
+  }
+  renderLegend();
+
+  /* Theme toggle re-colors the live network: theme-derived options via
+     setOptions, node colors via a single batched update, then the
+     legend re-renders from the new palette. Layout/physics/camera
+     state survives untouched. */
+  function applyTheme() {
+    network.setOptions(themeOptions());
+    var updates = [];
+    nodes.get().forEach(function (n) {
+      var k = idCommunity[n.id];
+      if (k !== undefined) {
+        updates.push({ id: n.id, color: colorForKey(k) });
+      }
+    });
+    if (updates.length) {
+      nodes.update(updates);
+    }
+    renderLegend();
+  }
   if (typeof MutationObserver !== "undefined") {
     new MutationObserver(function () {
-      network.setOptions(themeOptions());
+      applyTheme();
     }).observe(document.documentElement, {
       attributes: true,
       attributeFilter: ["data-theme"]
@@ -257,6 +455,7 @@
     if (added.length) {
       edges.add(added);
     }
+    renderLegend();
     refreshCounts(!!(result && result.metadata && result.metadata.truncated));
   }
 
@@ -383,7 +582,8 @@
       var scale = network.getScale();
       /* Full option swap: the layout change rides the physics change it
          implies (hier disables physics, force re-enables barnesHut with
-         a fresh stabilization). */
+         a fresh stabilization — unless the graph is edgeless, where
+         force stays physics-off on spiral positions). */
       network.setOptions(optionsFor(kind));
       network.once("afterDrawing", function () {
         network.moveTo({ position: position, scale: scale });

--- a/src/cairn/dashboard/static/app.js
+++ b/src/cairn/dashboard/static/app.js
@@ -637,16 +637,19 @@
   }
 })();
 
-/* Symbol search (confirm-to-focus): Enter in #symbol-search fetches
-   /graph/candidates. One untruncated hit navigates straight to the
-   symbol-focused graph; several hits render an inline candidate list
-   where each entry focuses its symbol. Truncation, zero matches, and
-   a failed request each leave one muted hint line. */
+/* Symbol search (typeahead): typing fetches /graph/suggest and shows
+   a live dropdown of matching symbols — the options are visible while
+   typing; ArrowUp/Down move, Enter or click picks, Escape closes.
+   Enter with no dropdown open keeps the confirm-to-focus flow (exact
+   /graph/candidates: one untruncated hit navigates straight to the
+   symbol-focused graph; several render the inline disambiguation list
+   below). */
 (function () {
   "use strict";
   var input = document.getElementById("symbol-search");
   var box = document.getElementById("symbol-candidates");
-  if (!input || !box) {
+  var dd = document.getElementById("symbol-suggest");
+  if (!input || !box || !dd) {
     return;
   }
 
@@ -658,6 +661,14 @@
   var storeKey = graphData
     ? (graphData.getAttribute("data-store") || "").trim()
     : "";
+
+  function suggestUrl(prefix) {
+    return (
+      "/graph/suggest?name=" +
+      encodeURIComponent(prefix) +
+      (storeKey ? "&store=" + encodeURIComponent(storeKey) : "")
+    );
+  }
 
   function focusUrl(name) {
     return (
@@ -674,6 +685,7 @@
     box.appendChild(line);
   }
 
+  /* ---- Confirm-to-focus (Enter with no dropdown open) ---- */
   function render(name, result) {
     var matches = result.matches || [];
     if (matches.length === 1 && !result.truncated) {
@@ -707,11 +719,7 @@
     }
   }
 
-  input.addEventListener("keydown", function (event) {
-    if (event.key !== "Enter") {
-      return;
-    }
-    event.preventDefault();
+  function confirmFocus() {
     box.textContent = "";
     var name = input.value.trim();
     if (!name) {
@@ -735,6 +743,168 @@
         box.textContent = "";
         note("search unavailable");
       });
+  }
+
+  /* ---- Typeahead dropdown ---- */
+  var items = [];
+  var active = -1;
+  var timer = null;
+  var seq = 0;
+  var SUGGEST_DEBOUNCE_MS = 160;
+
+  function close() {
+    dd.hidden = true;
+    dd.textContent = "";
+    items = [];
+    active = -1;
+    input.setAttribute("aria-expanded", "false");
+    input.removeAttribute("aria-activedescendant");
+  }
+
+  function highlight(i) {
+    var rows = dd.querySelectorAll(".suggest-item");
+    for (var r = 0; r < rows.length; r++) {
+      rows[r].classList.toggle("active", r === i);
+    }
+    active = i;
+    if (i >= 0 && rows[i]) {
+      rows[i].scrollIntoView({ block: "nearest" });
+      input.setAttribute("aria-activedescendant", rows[i].id);
+    } else {
+      input.removeAttribute("aria-activedescendant");
+    }
+  }
+
+  function entry(m, idx) {
+    var el = document.createElement("div");
+    el.className = "suggest-item";
+    el.id = "suggest-opt-" + idx;
+    el.setAttribute("role", "option");
+    var main = document.createElement("span");
+    main.className = "suggest-name";
+    main.textContent = m.name;
+    el.appendChild(main);
+    var ctx = [];
+    if (m.kind) {
+      ctx.push(m.kind);
+    }
+    if (m.file) {
+      ctx.push(m.file);
+    }
+    if (ctx.length) {
+      var sub = document.createElement("span");
+      sub.className = "suggest-ctx";
+      sub.textContent = ctx.join(" — ");
+      el.appendChild(sub);
+    }
+    /* mousedown beats the document closer and the input blur — the
+       pick runs before anything can dismiss the dropdown. */
+    el.addEventListener("mousedown", function (event) {
+      event.preventDefault();
+      pick(m.name);
+    });
+    return el;
+  }
+
+  function open(result) {
+    var matches = result.matches || [];
+    dd.textContent = "";
+    items = matches;
+    active = -1;
+    if (!matches.length) {
+      var empty = document.createElement("div");
+      empty.className = "suggest-empty";
+      empty.textContent = "no matching symbol";
+      dd.appendChild(empty);
+    } else {
+      matches.forEach(function (m, idx) {
+        dd.appendChild(entry(m, idx));
+      });
+      if (result.truncated) {
+        var more = document.createElement("div");
+        more.className = "suggest-empty";
+        more.textContent =
+          "more than " + matches.length + " — keep typing to refine";
+        dd.appendChild(more);
+      }
+      highlight(0);
+    }
+    dd.hidden = false;
+    input.setAttribute("aria-expanded", "true");
+  }
+
+  function pick(name) {
+    close();
+    input.value = name;
+    box.textContent = "";
+    window.location.assign(focusUrl(name));
+  }
+
+  function refresh() {
+    var prefix = input.value.trim();
+    if (!prefix) {
+      close();
+      return;
+    }
+    var my = ++seq;
+    fetch(suggestUrl(prefix))
+      .then(function (resp) {
+        if (!resp.ok) {
+          throw new Error("suggest request failed");
+        }
+        return resp.json();
+      })
+      .then(function (result) {
+        if (my === seq) {
+          open(result);
+        }
+      })
+      .catch(function () {
+        if (my === seq) {
+          close();
+        }
+      });
+  }
+
+  input.addEventListener("input", function () {
+    clearTimeout(timer);
+    timer = setTimeout(refresh, SUGGEST_DEBOUNCE_MS);
+  });
+
+  input.addEventListener("keydown", function (event) {
+    if (event.key === "ArrowDown" && !dd.hidden && items.length) {
+      event.preventDefault();
+      highlight((active + 1) % items.length);
+      return;
+    }
+    if (event.key === "ArrowUp" && !dd.hidden && items.length) {
+      event.preventDefault();
+      highlight((active - 1 + items.length) % items.length);
+      return;
+    }
+    if (event.key === "Escape" && !dd.hidden) {
+      event.preventDefault();
+      close();
+      return;
+    }
+    if (event.key !== "Enter") {
+      return;
+    }
+    event.preventDefault();
+    if (!dd.hidden && items.length) {
+      pick(items[active >= 0 ? active : 0].name);
+      return;
+    }
+    close();
+    confirmFocus();
+  });
+
+  /* A click outside the search wrapper closes the dropdown; a click on
+     the input itself keeps it open. */
+  document.addEventListener("mousedown", function (event) {
+    if (!dd.hidden && !dd.parentNode.contains(event.target)) {
+      close();
+    }
   });
 })();
 

--- a/src/cairn/dashboard/templates/base.html
+++ b/src/cairn/dashboard/templates/base.html
@@ -18,8 +18,12 @@
         }
         var prefersDark = window.matchMedia
           ? window.matchMedia("(prefers-color-scheme: dark)").matches
-          : false;
-        var dark = stored === "dark" || (stored === null && prefersDark);
+          : null;
+        /* Resolution order: stored choice, then system preference, then
+           dark — dark is the dashboard's default look. */
+        var dark =
+          stored === "dark" ||
+          (stored === null && (prefersDark === null || prefersDark));
         document.documentElement.dataset.theme = dark ? "dark" : "light";
         var toggle = document.getElementById("theme-toggle");
         if (toggle) {
@@ -53,31 +57,71 @@
     })();
   </script>
 </head>
-<body>
-  <header class="site-header">
-    <nav class="site-nav">
-      {#- FR-003: keep the selected store on every nav hop; empty when the
-          launch store is served (byte-identical plain hrefs). -#}
-      {% set nav_query = '' if not store_key else '?store=' + (store_key | urlencode) %}
-      <a class="brand" href="/{{ nav_query }}">cairn</a>
-      <a href="/workspaces{{ nav_query }}">Workspaces</a>
-      <a href="/projects{{ nav_query }}">Projects</a>
-      <a href="/graph{{ nav_query }}">Graph</a>
-      <a href="/history{{ nav_query }}">History</a>
-      <a href="/tokens{{ nav_query }}">Tokens</a>
-      <a href="/chains{{ nav_query }}">Chains</a>
-      <a href="/health{{ nav_query }}">Health</a>
-      <a href="/memory{{ nav_query }}">Memory</a>
-      <a href="/tasks{{ nav_query }}">Tasks</a>
-      <button type="button" id="theme-toggle" class="theme-toggle">Theme</button>
+<body class="app-shell">
+  <aside class="sidebar">
+    {#- FR-003: keep the selected store on every nav hop; empty when the
+        launch store is served (byte-identical plain hrefs). -#}
+    {% set nav_query = '' if not store_key else '?store=' + (store_key | urlencode) %}
+    {% set path = request.url.path %}
+    <a class="brand" href="/{{ nav_query }}">
+      <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linejoin="round" aria-hidden="true"><path d="m12 3.5 4.5 5.5h-9L12 3.5z"/><path d="m12 12 4.5 5.5h-9L12 12z"/><path d="M12 21.5v-1"/></svg>
+      <span>cairn</span>
+    </a>
+    <nav class="side-nav">
+      <a href="/workspaces{{ nav_query }}"{% if path.startswith('/workspaces') %} class="active" aria-current="page"{% endif %}>
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 2 2 7l10 5 10-5-10-5z"/><path d="m2 17 10 5 10-5"/><path d="m2 12 10 5 10-5"/></svg>
+        <span>Workspaces</span>
+      </a>
+      <a href="/projects{{ nav_query }}"{% if path.startswith('/projects') %} class="active" aria-current="page"{% endif %}>
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"/></svg>
+        <span>Projects</span>
+      </a>
+      <a href="/graph{{ nav_query }}"{% if path.startswith('/graph') %} class="active" aria-current="page"{% endif %}>
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="18" cy="5" r="3"/><circle cx="6" cy="12" r="3"/><circle cx="18" cy="19" r="3"/><path d="M8.6 13.5l6.8 4M15.4 6.5l-6.8 4"/></svg>
+        <span>Graph</span>
+      </a>
+      <a href="/history{{ nav_query }}"{% if path.startswith('/history') %} class="active" aria-current="page"{% endif %}>
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><path d="M12 7v5l3 3"/></svg>
+        <span>History</span>
+      </a>
+      <a href="/tokens{{ nav_query }}"{% if path.startswith('/tokens') %} class="active" aria-current="page"{% endif %}>
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M13 2 3 14h7l-1 8 10-12h-7l1-8z"/></svg>
+        <span>Tokens</span>
+      </a>
+      <a href="/chains{{ nav_query }}"{% if path.startswith('/chains') %} class="active" aria-current="page"{% endif %}>
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M10 13a5 5 0 0 0 7.5.5l3-3a5 5 0 0 0-7-7l-1.7 1.7"/><path d="M14 11a5 5 0 0 0-7.5-.5l-3 3a5 5 0 0 0 7 7l1.7-1.7"/></svg>
+        <span>Chains</span>
+      </a>
+      <a href="/health{{ nav_query }}"{% if path.startswith('/health') %} class="active" aria-current="page"{% endif %}>
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M22 12h-4l-3 9L9 3l-3 9H2"/></svg>
+        <span>Health</span>
+      </a>
+      <a href="/memory{{ nav_query }}"{% if path.startswith('/memory') %} class="active" aria-current="page"{% endif %}>
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><ellipse cx="12" cy="5" rx="9" ry="3"/><path d="M21 12c0 1.7-4 3-9 3s-9-1.3-9-3"/><path d="M3 5v14c0 1.7 4 3 9 3s9-1.3 9-3V5"/></svg>
+        <span>Memory</span>
+      </a>
+      <a href="/tasks{{ nav_query }}"{% if path.startswith('/tasks') %} class="active" aria-current="page"{% endif %}>
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M9 11l3 3L22 4"/><path d="M21 12v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11"/></svg>
+        <span>Tasks</span>
+      </a>
     </nav>
-  </header>
-  <main class="site-main">
-    {% block content %}{% endblock %}
-  </main>
-  <div id="live-controls" class="muted" data-state="running" hidden>
-    <span id="live-state"></span>
-    <button type="button" id="live-pause">Pause</button>
+    <div class="sidebar-foot">
+      <button type="button" id="theme-toggle" class="theme-toggle">Theme</button>
+    </div>
+  </aside>
+  <div class="app-body">
+    <header class="topbar">
+      {#- The topbar label derives from the path segment ("/" -> Overview);
+          views may override via the view_title block. -#}
+      <div class="topbar-title">{% block view_title %}{{ 'Overview' if path == '/' else (path.strip('/').split('/')[0] | capitalize) }}{% endblock %}</div>
+      <div id="live-controls" class="muted" data-state="running" hidden>
+        <span id="live-state"></span>
+        <button type="button" id="live-pause">Pause</button>
+      </div>
+    </header>
+    <main class="site-main">
+      {% block content %}{% endblock %}
+    </main>
   </div>
   {% block scripts %}{% endblock %}
 </body>

--- a/src/cairn/dashboard/templates/base.html
+++ b/src/cairn/dashboard/templates/base.html
@@ -56,6 +56,37 @@
       });
     })();
   </script>
+  <script>
+    /* Workspace stickiness: the store selection rides the URL
+       (?store=<key>, the FR-003 seam), which a typed URL or new tab
+       drops — so, like the theme, the last explicit selection is
+       remembered (localStorage "cairn-store") and a bare visit
+       redirects to it. Until the user picks a workspace, nothing is
+       stored and bare URLs keep the launch store, byte-identical. A
+       remembered-but-since-deleted store lands on the friendly
+       missing-DB page, where Workspaces is one click away. */
+    (function () {
+      "use strict";
+      var STORAGE_KEY = "cairn-store";
+      var url = new URL(window.location.href);
+      var selected = (url.searchParams.get("store") || "").trim();
+      try {
+        if (selected) {
+          window.localStorage.setItem(STORAGE_KEY, selected);
+        } else {
+          var remembered = window.localStorage.getItem(STORAGE_KEY);
+          if (remembered) {
+            url.searchParams.set("store", remembered);
+            window.location.replace(
+              url.pathname + url.search + url.hash
+            );
+          }
+        }
+      } catch (err) {
+        /* storage unavailable: the selection stays URL-only */
+      }
+    })();
+  </script>
 </head>
 <body class="app-shell">
   <aside class="sidebar">

--- a/src/cairn/dashboard/templates/base.html
+++ b/src/cairn/dashboard/templates/base.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>{% block title %}Cairn Dashboard{% endblock %}</title>
-  <link rel="stylesheet" href="{{ url_for('static', path='/app.css') }}">
+  <link rel="stylesheet" href="{{ url_for('static', path='/app.css') }}?v={{ asset_version }}">
   <script>
     (function () {
       "use strict";

--- a/src/cairn/dashboard/templates/chains.html
+++ b/src/cairn/dashboard/templates/chains.html
@@ -99,4 +99,4 @@
   }
 </style>
 {% endblock %}
-{% block scripts %}<script src="{{ url_for('static', path='/app.js') }}"></script>{% endblock %}
+{% block scripts %}<script src="{{ url_for('static', path='/app.js') }}?v={{ asset_version }}"></script>{% endblock %}

--- a/src/cairn/dashboard/templates/chains.html
+++ b/src/cairn/dashboard/templates/chains.html
@@ -58,9 +58,10 @@
      only drives the shared live-refresh region swap. */
   .chain {
     border: 1px solid var(--border);
-    border-radius: 8px;
+    border-radius: var(--radius);
     padding: 0.6rem 1rem;
     margin: 0.7rem 0;
+    background: var(--surface);
   }
   .chain-head {
     margin-bottom: 0.4rem;
@@ -79,7 +80,7 @@
   }
   .chain-call:not(:last-child)::after {
     content: "→";
-    color: var(--muted);
+    color: var(--accent);
     margin: 0 0.45rem;
     font-weight: 700;
   }
@@ -87,10 +88,14 @@
     display: inline-flex;
     align-items: center;
     gap: 0.45rem;
-    background: var(--bg);
+    background: var(--surface-2);
     border: 1px solid var(--border);
     border-radius: 999px;
     padding: 0.12rem 0.7rem;
+  }
+  .call-tool {
+    font-weight: 600;
+    font-size: 0.88rem;
   }
 </style>
 {% endblock %}

--- a/src/cairn/dashboard/templates/graph.html
+++ b/src/cairn/dashboard/templates/graph.html
@@ -1,6 +1,7 @@
 {% extends "base.html" %}
 {% import "_links.html" as links with context %}
 {% block title %}Graph — Cairn Dashboard{% endblock %}
+{% block view_title %}Graph{% endblock %}
 {% block content %}
 <section class="panel">
   <h1>Graph</h1>
@@ -10,7 +11,7 @@
     </label>
   </form>
   <div id="symbol-candidates"></div>
-  <form class="graph-controls" method="get" action="/graph">
+  <form class="graph-controls graph-toolbar" method="get" action="/graph">
     <label>Scope
       <select name="scope">
         {% for s in scopes %}
@@ -30,11 +31,11 @@
     <button type="submit">Apply</button>
   </form>
   {#- Layout toggle (FR-004): links swap only the layout param, keeping
-    scope/focus/repo/depth (window_control link conventions); the active
-    layout renders as <strong>. app.js intercepts clicks on the anchors
-    to toggle the live network without a reload. FR-003: links.url keeps
-    the selected store riding the href; empty selection keeps the bare
-    hrefs, byte-identical. -#}
+      scope/focus/repo/depth (window_control link conventions); the active
+      layout renders as <strong>. app.js intercepts clicks on the anchors
+      to toggle the live network without a reload. FR-003: links.url keeps
+      the selected store riding the href; empty selection keeps the bare
+      hrefs, byte-identical. -#}
   {% macro layout_href(kind) -%}
   {% set q = {"layout": kind, "scope": scope} %}
   {%- if focus %}{% set _ = q.update({"focus": focus}) %}{% endif %}
@@ -48,10 +49,20 @@
     {%- endfor %}
   </p>
   {#- Node inspect (FR-004, D-004): selecting a node on the canvas swaps
-    this hint for an anchor to that symbol's neighborhood graph
-    (scope=symbol&focus=...); deselecting restores the hint. Distinct from
-    double-click, which expands in place. -#}
+      this hint for an anchor to that symbol's neighborhood graph
+      (scope=symbol&focus=...); deselecting restores the hint. Distinct from
+      double-click, which expands in place. -#}
   <p class="muted"><span id="inspect-action" class="muted">select a node to inspect</span></p>
+  {#- Kind legend: only the kinds present in the current result set, so
+      the swatch row stays honest for module- or symbol-scoped graphs.
+      The --kind-* tokens are the single color source — app.js reads the
+      same variables when coloring vis groups. -#}
+  {% set kinds = graph.nodes | map(attribute='kind') | reject('none') | unique | list | sort %}
+  {% if kinds %}
+  <p class="graph-legend muted">
+    {% for k in kinds %}<span class="legend-item"><span class="legend-dot" data-kind="{{ k }}"></span>{{ k }}</span>{% endfor %}
+  </p>
+  {% endif %}
   <p class="muted" id="graph-counts">
     scope <strong>{{ scope }}</strong> —
     {{ graph.metadata.get("node_count", graph.nodes | length) }} nodes,
@@ -62,7 +73,7 @@
     scope queries are capped, so a count at the cap means the graph was truncated.
   </p>
   {% if graph.nodes %}
-  <div id="graph-canvas" data-layout="{{ layout }}" style="height: 480px; border: 1px solid #d9dde3; border-radius: 8px; background: #ffffff;"></div>
+  <div id="graph-canvas" data-layout="{{ layout }}" class="graph-canvas"></div>
   {% else %}
   <p class="empty-state">No nodes for this scope — adjust the controls above.</p>
   {% endif %}

--- a/src/cairn/dashboard/templates/graph.html
+++ b/src/cairn/dashboard/templates/graph.html
@@ -70,7 +70,22 @@
     scope queries are capped, so a count at the cap means the graph was truncated.
   </p>
   {% if graph.nodes %}
-  <div id="graph-canvas" data-layout="{{ layout }}" class="graph-canvas"></div>
+  <div class="graph-stage">
+    <div id="graph-canvas" data-layout="{{ layout }}" class="graph-canvas"></div>
+    {#- Overlay controls float over the canvas's bottom-left; app.js
+        wires the data-graph-action buttons to vis zoom/fit. -#}
+    <div class="graph-overlay">
+      <button type="button" data-graph-action="zoom-in" title="Zoom in" aria-label="Zoom in">
+        <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" aria-hidden="true"><path d="M12 5v14M5 12h14"/></svg>
+      </button>
+      <button type="button" data-graph-action="zoom-out" title="Zoom out" aria-label="Zoom out">
+        <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" aria-hidden="true"><path d="M5 12h14"/></svg>
+      </button>
+      <button type="button" data-graph-action="fit" title="Fit view" aria-label="Fit view">
+        <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M8 3H5a2 2 0 0 0-2 2v3M16 3h3a2 2 0 0 1 2 2v3M8 21H5a2 2 0 0 1-2-2v-3M16 21h3a2 2 0 0 0 2-2v-3"/></svg>
+      </button>
+    </div>
+  </div>
   {% else %}
   <p class="empty-state">No nodes for this scope — adjust the controls above.</p>
   {% endif %}
@@ -81,6 +96,6 @@
 </section>
 {% endblock %}
 {% block scripts %}
-<script src="{{ url_for('static', path='/vis-network.min.js') }}"></script>
-<script src="{{ url_for('static', path='/app.js') }}"></script>
+<script src="{{ url_for('static', path='/vis-network.min.js') }}?v={{ asset_version }}"></script>
+<script src="{{ url_for('static', path='/app.js') }}?v={{ asset_version }}"></script>
 {% endblock %}

--- a/src/cairn/dashboard/templates/graph.html
+++ b/src/cairn/dashboard/templates/graph.html
@@ -53,15 +53,12 @@
       (scope=symbol&focus=...); deselecting restores the hint. Distinct from
       double-click, which expands in place. -#}
   <p class="muted"><span id="inspect-action" class="muted">select a node to inspect</span></p>
-  {#- Kind legend: only the kinds present in the current result set, so
-      the swatch row stays honest for module- or symbol-scoped graphs.
-      The --kind-* tokens are the single color source — app.js reads the
-      same variables when coloring vis groups. -#}
-  {% set kinds = graph.nodes | map(attribute='kind') | reject('none') | unique | list | sort %}
-  {% if kinds %}
-  <p class="graph-legend muted">
-    {% for k in kinds %}<span class="legend-item"><span class="legend-dot" data-kind="{{ k }}"></span>{{ k }}</span>{% endfor %}
-  </p>
+  {#- Community legend: app.js renders it from the same palette it
+      colored the nodes with (top 8 communities + overflow), so the
+      swatches can never drift from the canvas. Hidden until filled;
+      absent when the graph is empty. -#}
+  {% if graph.nodes %}
+  <p class="graph-legend muted" id="graph-legend" hidden></p>
   {% endif %}
   <p class="muted" id="graph-counts">
     scope <strong>{{ scope }}</strong> —

--- a/src/cairn/dashboard/templates/graph.html
+++ b/src/cairn/dashboard/templates/graph.html
@@ -7,7 +7,12 @@
   <h1>Graph</h1>
   <form class="graph-controls">
     <label>Symbol
-      <input type="text" id="symbol-search" placeholder="symbol name" autocomplete="off">
+      <span class="suggest-wrap">
+        <input type="text" id="symbol-search" placeholder="type to search symbols"
+               autocomplete="off" role="combobox" aria-expanded="false"
+               aria-controls="symbol-suggest" aria-autocomplete="list">
+        <div id="symbol-suggest" class="suggest-box" role="listbox" hidden></div>
+      </span>
     </label>
   </form>
   <div id="symbol-candidates"></div>

--- a/src/cairn/dashboard/templates/history.html
+++ b/src/cairn/dashboard/templates/history.html
@@ -5,6 +5,20 @@
 <section class="panel">
   <div id="refresh-region">
   <h1>History</h1>
+  <div class="stat-row">
+    <div class="stat-tile">
+      <div class="stat-value">{{ calls | length }}</div>
+      <div class="stat-label">calls shown</div>
+    </div>
+    <div class="stat-tile">
+      <div class="stat-value">{{ window }}</div>
+      <div class="stat-label">time window</div>
+    </div>
+    <div class="stat-tile">
+      <div class="stat-value">{{ calls | selectattr('status', 'equalto', 'error') | list | length }}</div>
+      <div class="stat-label">error calls</div>
+    </div>
+  </div>
   <form class="graph-controls" method="get" action="/history">
     <label>Tool
       <input type="text" name="tool" value="{{ tool }}">
@@ -28,8 +42,8 @@
   {%- if window != "all" %}{% set _ = export_q.update({'window': window}) %}{% endif %}
   <p class="muted">
     Export:
-    <a href="{{ links.url('/history.csv', export_q) }}">CSV</a> ·
-    <a href="{{ links.url('/history.json', export_q) }}">JSON</a>
+    <a class="btn-secondary" href="{{ links.url('/history.csv', export_q) }}">CSV</a>
+    <a class="btn-secondary" href="{{ links.url('/history.json', export_q) }}">JSON</a>
   </p>
   {% if calls %}
   <table class="data-table">

--- a/src/cairn/dashboard/templates/history.html
+++ b/src/cairn/dashboard/templates/history.html
@@ -103,4 +103,4 @@
   </div>
 </section>
 {% endblock %}
-{% block scripts %}<script src="{{ url_for('static', path='/app.js') }}"></script>{% endblock %}
+{% block scripts %}<script src="{{ url_for('static', path='/app.js') }}?v={{ asset_version }}"></script>{% endblock %}

--- a/src/cairn/dashboard/templates/index.html
+++ b/src/cairn/dashboard/templates/index.html
@@ -1,6 +1,7 @@
 {% extends "base.html" %}
 {% import "_links.html" as links with context %}
 {% block title %}Cairn Dashboard{% endblock %}
+{% block view_title %}Overview{% endblock %}
 {% block content %}
 <section class="panel">
   <h1>Cairn Dashboard</h1>
@@ -8,17 +9,54 @@
     Read-only view over the graph DB:
     <code>{{ db_path }}</code>
   </p>
-  <ul class="link-list">
-    {#- FR-003: a selected store rides every landing-list link (links.url);
-        empty selection keeps the bare hrefs, byte-identical. -#}
-    <li><a href="{{ links.url('/projects') }}">Projects &amp; index status</a></li>
-    <li><a href="{{ links.url('/graph') }}">Graph explorer</a></li>
-    <li><a href="{{ links.url('/history') }}">Tool-call history</a></li>
-    <li><a href="{{ links.url('/tokens') }}">Token usage</a></li>
-    <li><a href="{{ links.url('/chains') }}">Session chains</a></li>
-    <li><a href="{{ links.url('/health') }}">Health</a></li>
-    <li><a href="{{ links.url('/memory') }}">Memory</a></li>
-    <li><a href="{{ links.url('/tasks') }}">Task queue</a></li>
-  </ul>
+  {#- FR-003: a selected store rides every landing-card link (links.url);
+      empty selection keeps the bare hrefs, byte-identical. -#}
+  <div class="launcher-grid">
+    <a class="launcher-card" href="{{ links.url('/workspaces') }}">
+      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 2 2 7l10 5 10-5-10-5z"/><path d="m2 17 10 5 10-5"/><path d="m2 12 10 5 10-5"/></svg>
+      <span class="launcher-title">Workspaces</span>
+      <span class="launcher-blurb">Local stores, one click away</span>
+    </a>
+    <a class="launcher-card" href="{{ links.url('/projects') }}">
+      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"/></svg>
+      <span class="launcher-title">Projects &amp; index status</span>
+      <span class="launcher-blurb">Indexed repos and embeddings</span>
+    </a>
+    <a class="launcher-card" href="{{ links.url('/graph') }}">
+      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="18" cy="5" r="3"/><circle cx="6" cy="12" r="3"/><circle cx="18" cy="19" r="3"/><path d="M8.6 13.5l6.8 4M15.4 6.5l-6.8 4"/></svg>
+      <span class="launcher-title">Graph explorer</span>
+      <span class="launcher-blurb">Interactive symbol graph</span>
+    </a>
+    <a class="launcher-card" href="{{ links.url('/history') }}">
+      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><path d="M12 7v5l3 3"/></svg>
+      <span class="launcher-title">Tool-call history</span>
+      <span class="launcher-blurb">Every recorded invocation</span>
+    </a>
+    <a class="launcher-card" href="{{ links.url('/tokens') }}">
+      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M13 2 3 14h7l-1 8 10-12h-7l1-8z"/></svg>
+      <span class="launcher-title">Token usage</span>
+      <span class="launcher-blurb">Context cost per tool</span>
+    </a>
+    <a class="launcher-card" href="{{ links.url('/chains') }}">
+      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M10 13a5 5 0 0 0 7.5.5l3-3a5 5 0 0 0-7-7l-1.7 1.7"/><path d="M14 11a5 5 0 0 0-7.5-.5l-3 3a5 5 0 0 0 7 7l1.7-1.7"/></svg>
+      <span class="launcher-title">Session chains</span>
+      <span class="launcher-blurb">Calls grouped per session</span>
+    </a>
+    <a class="launcher-card" href="{{ links.url('/health') }}">
+      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M22 12h-4l-3 9L9 3l-3 9H2"/></svg>
+      <span class="launcher-title">Health</span>
+      <span class="launcher-blurb">Same checks as cairn doctor</span>
+    </a>
+    <a class="launcher-card" href="{{ links.url('/memory') }}">
+      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><ellipse cx="12" cy="5" rx="9" ry="3"/><path d="M21 12c0 1.7-4 3-9 3s-9-1.3-9-3"/><path d="M3 5v14c0 1.7 4 3 9 3s9-1.3 9-3V5"/></svg>
+      <span class="launcher-title">Memory</span>
+      <span class="launcher-blurb">Recent tribal knowledge</span>
+    </a>
+    <a class="launcher-card" href="{{ links.url('/tasks') }}">
+      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M9 11l3 3L22 4"/><path d="M21 12v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11"/></svg>
+      <span class="launcher-title">Task queue</span>
+      <span class="launcher-blurb">LLM synthesis jobs</span>
+    </a>
+  </div>
 </section>
 {% endblock %}

--- a/src/cairn/dashboard/templates/projects.html
+++ b/src/cairn/dashboard/templates/projects.html
@@ -5,6 +5,24 @@
 <section class="panel">
   <h1>Projects</h1>
   {% if projects %}
+  <div class="stat-row">
+    <div class="stat-tile">
+      <div class="stat-value">{{ projects | length }}</div>
+      <div class="stat-label">projects</div>
+    </div>
+    <div class="stat-tile">
+      <div class="stat-value">{{ projects | sum(attribute='file_count') }}</div>
+      <div class="stat-label">files</div>
+    </div>
+    <div class="stat-tile">
+      <div class="stat-value">{{ projects | sum(attribute='symbol_count') }}</div>
+      <div class="stat-label">symbols</div>
+    </div>
+    <div class="stat-tile">
+      <div class="stat-value">{{ projects | sum(attribute='edge_count') }}</div>
+      <div class="stat-label">edges</div>
+    </div>
+  </div>
   <table class="data-table">
     <thead>
       <tr>

--- a/src/cairn/dashboard/templates/tokens.html
+++ b/src/cairn/dashboard/templates/tokens.html
@@ -26,10 +26,24 @@
   {%- if window != "all" %}{% set _ = export_q.update({'window': window}) %}{% endif %}
   <p class="muted">
     Export:
-    <a href="{{ links.url('/tokens.csv', export_q) }}">CSV</a> ·
-    <a href="{{ links.url('/tokens.json', export_q) }}">JSON</a>
+    <a class="btn-secondary" href="{{ links.url('/tokens.csv', export_q) }}">CSV</a>
+    <a class="btn-secondary" href="{{ links.url('/tokens.json', export_q) }}">JSON</a>
   </p>
   {% if tools %}
+  <div class="stat-row">
+    <div class="stat-tile">
+      <div class="stat-value">{{ tools | length }}</div>
+      <div class="stat-label">tools</div>
+    </div>
+    <div class="stat-tile">
+      <div class="stat-value">{{ tools | sum(attribute='calls') }}</div>
+      <div class="stat-label">calls</div>
+    </div>
+    <div class="stat-tile">
+      <div class="stat-value">~{{ tools | sum(attribute='total_tokens') }}</div>
+      <div class="stat-label">est. tokens total</div>
+    </div>
+  </div>
   <table class="data-table">
     <thead>
       <tr>

--- a/src/cairn/dashboard/templates/tokens.html
+++ b/src/cairn/dashboard/templates/tokens.html
@@ -79,4 +79,4 @@
   </div>
 </section>
 {% endblock %}
-{% block scripts %}<script src="{{ url_for('static', path='/app.js') }}"></script>{% endblock %}
+{% block scripts %}<script src="{{ url_for('static', path='/app.js') }}?v={{ asset_version }}"></script>{% endblock %}

--- a/src/cairn/dashboard/templates/window_control.html
+++ b/src/cairn/dashboard/templates/window_control.html
@@ -15,7 +15,7 @@
 {%- if after %}{% set _ = q.update({'after': after}) %}{% endif %}
 {{- links.url(request.url.path, q) }}
 {%- endmacro %}
-<p class="muted">
+<p class="muted window-control">
   Window:
   {%- for preset in ["24h", "7d", "30d", "all"] %} {% if not loop.first %} · {% endif %}{% if preset == window %}<strong>{{ preset }}</strong>{% else %}<a href="{{ window_href(preset) }}">{{ preset }}</a>{% endif %}
   {%- endfor %}

--- a/tests/test_dashboard_app.py
+++ b/tests/test_dashboard_app.py
@@ -1431,7 +1431,7 @@ def test_tokens_and_chains_wrap_their_content_in_refresh_region(tmp_path):
         assert structure in region, path  # the view lives in the swap target
         assert seeded in region, path  # seeded content, not empty markup
         assert (
-            len(re.findall(r'<script[^>]*\ssrc="[^"]*app\.js"', resp.text))
+            len(re.findall(r'<script[^>]*\ssrc="[^"]*app\.js[?"]', resp.text))
             == 1
         ), path  # the loop module loads once, never twice
 
@@ -1670,7 +1670,7 @@ def test_history_live_chrome_hooks_render_and_app_js_loads_once(tmp_path):
     assert 'id="live-state"' in resp.text  # the visible state-word slot
     assert 'id="live-pause"' in resp.text  # the pause/resume toggle
 
-    loads = re.findall(r'<script[^>]*\ssrc="[^"]*app\.js"', resp.text)
+    loads = re.findall(r'<script[^>]*\ssrc="[^"]*app\.js[?"]', resp.text)
     assert len(loads) == 1  # the loop module loads once, never twice
 
 

--- a/tests/test_dashboard_app.py
+++ b/tests/test_dashboard_app.py
@@ -2002,19 +2002,26 @@ def test_inspect_target_url_renders_symbol_neighborhood(tmp_path):
 def test_nav_and_landing_page_each_link_to_graph(tmp_path):
     """FR-006 / US3 / TC-006: /graph is no orphan — the shared nav carries
     it on every page (base.html) and the landing page's link list repeats
-    it (index.html)."""
+    it (index.html). The sidebar nav anchors carry an inline svg icon, so
+    the label rides a <span> inside the anchor."""
     client = _client(tmp_path, seed=False)
+
+    def nav_anchor(html):
+        # base.html nav: the /graph anchor with its spanned label
+        return re.search(
+            r'<a href="/graph"[^>]*>.*?>Graph</span>', html, re.S
+        )
 
     landing = client.get("/")
     assert landing.status_code == 200
-    assert '<a href="/graph">Graph</a>' in landing.text  # base.html nav
+    assert nav_anchor(landing.text)
     assert '<a href="/graph">Graph explorer</a>' in landing.text  # list
 
     # The nav entry is base.html's, not landing-specific: another page
     # renders it too, so /graph is one click from anywhere.
     projects = client.get("/projects")
     assert projects.status_code == 200
-    assert '<a href="/graph">Graph</a>' in projects.text
+    assert nav_anchor(projects.text)
 
 
 def test_view_link_macro_carries_window_and_encodes_value():
@@ -2220,17 +2227,26 @@ def test_workspaces_route_renders_all_four_states_without_error(
 
 def test_base_nav_leads_with_the_workspaces_link(tmp_path, monkeypatch):
     """FR-001: the shared base nav (base.html) carries the overview as its
-    first entry, one click from every page."""
+    first entry, one click from every page. Sidebar nav anchors carry an
+    inline svg icon, so the label rides a <span> inside the anchor."""
     fixture = _four_state_home(tmp_path)
     resp = _workspaces_client(
         tmp_path, monkeypatch, fixture["home"]
     ).get("/workspaces")
     assert resp.status_code == 200
-    assert '<a href="/workspaces">Workspaces</a>' in resp.text
+
+    def anchor_pos(href, label):
+        return re.search(
+            r'<a href="' + href + r'"[^>]*>.*?>' + label + r"</span>",
+            resp.text,
+            re.S,
+        )
+
+    workspaces = anchor_pos("/workspaces", "Workspaces")
+    projects = anchor_pos("/projects", "Projects")
+    assert workspaces and projects
     # First entry: the overview anchor precedes every other nav view.
-    assert resp.text.index('<a href="/workspaces">Workspaces</a>') < (
-        resp.text.index('<a href="/projects">Projects</a>')
-    )
+    assert workspaces.start() < projects.start()
 
 
 def test_probe_cap_degrades_counts_visibly(tmp_path, monkeypatch):

--- a/tests/test_dashboard_app.py
+++ b/tests/test_dashboard_app.py
@@ -455,6 +455,53 @@ def test_candidates_route_whitespace_and_absent_name_are_empty_json(tmp_path):
         assert resp.json() == empty
 
 
+def test_suggest_route_returns_prefix_matches_as_json(tmp_path):
+    """/graph/suggest is application/json carrying the typeahead contract:
+    prefix matches (case-insensitive, mid-string fragments excluded),
+    shortest-first with file/kind context, empty-never-error."""
+    client = _panel_client(
+        tmp_path, _candidates_db_file(tmp_path, seed=True), str(tmp_path / "missing")
+    )
+
+    resp = client.get("/graph/suggest", params={"name": "dup"})
+    assert resp.status_code == 200
+    assert resp.headers["content-type"].startswith("application/json")
+    body = resp.json()
+    assert [m["name"] for m in body["matches"]] == ["dup_name", "dup_name"]
+    assert body["matches"][0]["kind"] == "class"
+    assert body["truncated"] is False
+
+    upper = client.get("/graph/suggest", params={"name": "SOLO"})
+    assert [m["name"] for m in upper.json()["matches"]] == ["solo_name"]
+
+    # a mid-string fragment and a blank prefix are the empty contract
+    for url in ("/graph/suggest?name=olo", "/graph/suggest?name=%20", "/graph/suggest"):
+        mid = client.get(url)
+        assert mid.status_code == 200
+        assert mid.json() == {"matches": [], "truncated": False}
+
+
+def test_graph_page_carries_typeahead_search_markup(tmp_path):
+    """The symbol search is a combobox wired to a live suggestion listbox
+    (#symbol-suggest) -- options render while typing instead of demanding
+    a full name first."""
+    client = _panel_client(
+        tmp_path, _candidates_db_file(tmp_path, seed=True), str(tmp_path / "missing")
+    )
+
+    resp = client.get("/graph")
+    assert resp.status_code == 200
+    for marker in (
+        'id="symbol-search"',
+        'role="combobox"',
+        'aria-controls="symbol-suggest"',
+        'id="symbol-suggest"',
+        'role="listbox"',
+        "suggest-wrap",
+    ):
+        assert marker in resp.text
+
+
 # ---------------------------------------------------------------------------
 # Node-expansion neighbors endpoint (graph-nav FR-003/FR-005 / US2): the
 # node/edge JSON the graph view's expand action fetches and merges.

--- a/tests/test_dashboard_app.py
+++ b/tests/test_dashboard_app.py
@@ -2015,7 +2015,13 @@ def test_nav_and_landing_page_each_link_to_graph(tmp_path):
     landing = client.get("/")
     assert landing.status_code == 200
     assert nav_anchor(landing.text)
-    assert '<a href="/graph">Graph explorer</a>' in landing.text  # list
+    # Landing launcher card: the anchor carries an svg + spanned title.
+    assert re.search(
+        r'<a class="launcher-card" href="/graph"[^>]*>.*?>Graph explorer'
+        r"</span>",
+        landing.text,
+        re.S,
+    )
 
     # The nav entry is base.html's, not landing-specific: another page
     # renders it too, so /graph is one click from anywhere.

--- a/tests/test_dashboard_data.py
+++ b/tests/test_dashboard_data.py
@@ -300,6 +300,96 @@ def test_symbol_candidates_miss_and_blank_are_empty_never_errors(fresh_db):
 
 
 # ---------------------------------------------------------------------------
+# Symbol-search typeahead suggestions: prefix matches (case-insensitive,
+# LIKE wildcards escaped), shortest-name-first, capped with the honest
+# truncated flag -- the dropdown's data contract.
+# ---------------------------------------------------------------------------
+
+
+def test_symbol_suggest_prefix_matches_shortest_first_with_context(fresh_db):
+    from cairn.dashboard.data import symbol_suggest
+
+    _seed(fresh_db)
+
+    result = symbol_suggest(fresh_db, "alpha")
+
+    assert result["truncated"] is False
+    # shortest first: alpha_main/alpha_util (10 chars) before
+    # alpha_helper (12), name ASC within a length tie
+    assert [m["name"] for m in result["matches"]] == [
+        "alpha_main",
+        "alpha_util",
+        "alpha_helper",
+    ]
+    first = result["matches"][0]
+    assert (first["kind"], first["file"], first["repo_id"]) == (
+        "function",
+        "src/alpha/core.py",
+        "alpha",
+    )
+
+
+def test_symbol_suggest_is_case_insensitive_and_prefix_only(fresh_db):
+    from cairn.dashboard.data import symbol_suggest
+
+    _seed(fresh_db)
+    empty = {"matches": [], "truncated": False}
+
+    assert [
+        m["name"] for m in symbol_suggest(fresh_db, "ALPHA")["matches"]
+    ] == ["alpha_main", "alpha_util", "alpha_helper"]
+    # a mid-string fragment is not a prefix
+    assert symbol_suggest(fresh_db, "lpha") == empty
+    for blank in ("", "   "):
+        assert symbol_suggest(fresh_db, blank) == empty
+
+
+def test_symbol_suggest_escapes_like_wildcards_in_the_query(fresh_db):
+    """% and _ in the typed text match literally -- the query is data,
+    never a pattern (unescaped, 'pct_' would wildcard-match 'pctX')."""
+    from cairn.dashboard.data import symbol_suggest
+
+    fresh_db.execute(
+        "INSERT INTO files (id, repo_id, path, language) "
+        "VALUES ('f_w', 'alpha', 'w.py', 'python')"
+    )
+    fresh_db.executemany(
+        "INSERT INTO symbols (id, file_id, name, qualified_name, kind) "
+        "VALUES (?, ?, ?, ?, ?)",
+        [
+            ("s_w1", "f_w", "pct_100", "w.pct_100", "function"),
+            ("s_w2", "f_w", "pctX100", "w.pctX100", "function"),
+        ],
+    )
+    fresh_db.commit()
+
+    # length tie (7 chars each): name ASC puts 'X' (0x58) before '_'
+    assert [m["name"] for m in symbol_suggest(fresh_db, "pct")["matches"]] == [
+        "pctX100",
+        "pct_100",
+    ]
+    assert [m["name"] for m in symbol_suggest(fresh_db, "pct_1")["matches"]] == [
+        "pct_100"
+    ]
+    assert symbol_suggest(fresh_db, "pct%") == {"matches": [], "truncated": False}
+
+
+def test_symbol_suggest_caps_at_limit_with_honest_truncation(fresh_db):
+    """The cap mirrors the candidates contract: over-cap returns exactly
+    the cap with truncated True; exactly-at-cap is not truncation."""
+    from cairn.dashboard.data import symbol_suggest
+
+    _seed(fresh_db)
+
+    over = symbol_suggest(fresh_db, "alpha", limit=2)
+    assert [m["name"] for m in over["matches"]] == ["alpha_main", "alpha_util"]
+    assert over["truncated"] is True
+
+    at_cap = symbol_suggest(fresh_db, "alpha", limit=3)
+    assert at_cap["truncated"] is False
+
+
+# ---------------------------------------------------------------------------
 # Node expansion (graph-nav FR-003/FR-005 / US2): the viz-layer neighbors
 # query, called directly -- the node/edge shape the dashboard's DataSet
 # merge consumes, duplicate-free, with honest counts at the per-direction

--- a/tests/test_dashboard_workspaces.py
+++ b/tests/test_dashboard_workspaces.py
@@ -320,3 +320,39 @@ def test_overview_first_render_budget(tmp_path, monkeypatch, scale_home):
 
     # Structural bounds hold regardless of the gate (CI-safe).
     _assert_overview_structure(resp.text, home)
+
+
+# ---------------------------------------------------------------------------
+# Workspace stickiness (store selection remembered across visits)
+# ---------------------------------------------------------------------------
+
+
+def test_base_template_carries_store_stickiness_script(tmp_path):
+    """A URL-carried ?store selection is remembered (localStorage
+    "cairn-store") and a bare visit redirects to the remembered store;
+    until the user picks a workspace nothing is stored, so bare URLs
+    keep the launch store. Pins the script's contract markers, mirroring
+    the theme-script tests: the storage key, both directions of the
+    localStorage round-trip, the param echo, and the restoring
+    redirect."""
+    pytest.importorskip("httpx")
+    from starlette.testclient import TestClient
+
+    from cairn.dashboard.app import create_app
+
+    client = TestClient(
+        create_app(
+            db_path=str(tmp_path / "dash.db"),
+            knowledge_dir=str(tmp_path / "missing"),
+        )
+    )
+    resp = client.get("/")
+    assert resp.status_code == 200
+
+    script_start = resp.text.index("cairn-store")
+    block = resp.text[script_start : resp.text.index("</script>", script_start)]
+    assert '"cairn-store"' in block  # the storage key
+    assert "searchParams.get" in block  # a present selection...
+    assert "localStorage.setItem" in block  # ...is remembered
+    assert "localStorage.getItem" in block  # a bare visit...
+    assert "location.replace" in block  # ...restores it

--- a/uv.lock
+++ b/uv.lock
@@ -189,7 +189,7 @@ filecache = [
 
 [[package]]
 name = "cairn-intel"
-version = "0.12.1"
+version = "0.13.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

The dashboard gets its visual and interaction pass on top of 0.13.0: a sidebar app shell with GitNexus-inspired design tokens across all views (restyled tables/badges/cards, stat tiles, export chips, segmented windows, landing launcher), a reworked graph view (kind colors, communities, label discipline, spiral layout, kind filters, counts legend), a **live typeahead for symbol search** (new prefix-match `/graph/suggest`; the old type-blind confirm flow stays as the Enter fallback), a **stale-asset fix** (mtime-versioned URLs + `Cache-Control: no-cache` on static), **workspace stickiness** (last selected store remembered per browser), and the previously-missing **dashboard documentation** (CLI reference entry, architecture section, README).

## Change type

- [x] Feature / improvement
- [ ] Bugfix
- [ ] Refactor (no behavior change)
- [ ] Docs / chore / CI

## Audit checklist

Author — confirm before requesting review (procedure: `docs/review-checklist.md`):

- [x] **Blast radius checked** — dashboard package + docs only; no public API, schema, or telemetry change; the one new SQL path (`symbol_suggest`) is a parameterized read-only SELECT; `/graph/suggest` rides `resolve_selection` + `get_read_only_db` like its siblings.
- [x] **Layering respected** — read-only discipline verified across the branch diff (no write paths added; retention still ages only in the recording pipeline); loopback-only bind unchanged.
- [x] **Graph updated** — `cairn update` ran after the final commit.
- [x] **Memory recorded** — mistake memory for the confirm-to-focus UX (discovery vs disambiguation are different data contracts).
- [x] **Fallback/perf paths** — no fallback/perf path changes; suggest endpoint is an indexed-prefix SELECT capped at 10 with a truncated flag.
- [x] **Tests** — full suite 2130 passed / 1 skipped locally AND in the Apple-container clean-room matrix (3.10–3.14, 5/5); +6 new tests (suggest data contract incl. LIKE-wildcard escaping, route JSON, combobox markup); the typeahead dropdown was additionally verified live in a real browser (typing → options, ArrowDown+Enter → focused graph).
- [x] **CHANGELOG** — `[Unreleased]` entries added (overhaul, typeahead, cache fix, stickiness, docs).
- [x] **Gates green** — pre-commit `--all-files` passed (ruff, secrets, yaml/toml, debug statements); local CI matrix green; PR rides the remote matrix.

## Blast-radius note

Additive UI surface: one new JSON route (`/graph/suggest`), one new data function (`symbol_suggest`), template/static restyling. `app.js` interactions (polling, expand, layout toggle) carry no automated coverage — verified live in-browser for the search path; the polling/expand surfaces regression-check via the Python-side data contracts.

## Verification

- `uv run pytest tests/ -q` → 2130 passed, 1 skipped
- `make ci-local-all` → clean-room matrix green 3.10–3.14 (2130 passed each)
- `uv run --extra dev pre-commit run --all-files` → all passed
- In-browser: typed `symb` → dropdown (Symbol/SymbolEntry/symbol_exists with kind+file); ArrowDown+Enter → `/graph?scope=symbol&focus=SymbolEntry`
- `scripts/check_doc_links.py` → 0 broken