### PR TITLE
chore: sync main with v0.14.0 release commits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 > `0.4.0` entry below is the inaugural documented release; entries from future
 > releases will be appended here incrementally.
 
-## [Unreleased]
+## [0.14.0] - 2026-08-25
+
+> **Focus:** a two-train release — Kotlin support moves to the
+> actively-maintained fwcd tree-sitter grammar (vendored in-tree as a compiled
+> extension, modern syntax parses clean, per-platform wheels), and the
+> dashboard gets its GitNexus-inspired visual overhaul with live typeahead
+> graph search.
 
 ### Added
 - Modern Kotlin parses cleanly — files using recent Kotlin syntax (KEEP-0438

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "cairn-intel"
-version = "0.13.0"
+version = "0.14.0"
 description = "Local codebase intelligence system: structural graph + compass + wiki + agent memory"
 readme = "README.md"
 license = "MIT"
@@ -211,7 +211,7 @@ select = ["F"]
 # The custom template (.cz_templates/keepachangelog.j2) renders that draft in
 # the existing `## [X.Y.Z] - YYYY-MM-DD` format rather than commitizen's
 # default `## X.Y.Z (YYYY-MM-DD)`.
-version = "0.13.0"
+version = "0.14.0"
 version_scheme = "pep440"
 tag_format = "v$version"
 update_changelog_on_bump = false

--- a/src/cairn/__init__.py
+++ b/src/cairn/__init__.py
@@ -1,3 +1,3 @@
 """Cairn: local codebase intelligence system."""
-__version__ = "0.13.0"
+__version__ = "0.14.0"
 __package_name__ = "cairn-intel"

--- a/uv.lock
+++ b/uv.lock
@@ -189,7 +189,7 @@ filecache = [
 
 [[package]]
 name = "cairn-intel"
-version = "0.13.0"
+version = "0.14.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

Brings the v0.14.0 release commits to `main`: the finalized changelog section
(`## [0.14.0] - 2026-08-25`, covering both release trains — the fwcd Kotlin
grammar adoption and the dashboard visual overhaul) and the commitizen version
bump (0.13.0 → 0.14.0 in `pyproject.toml` and `src/cairn/__init__.py`),
matching tag `v0.14.0`. PyPI publishes from the tag; this PR keeps `main` in
sync per `docs/release-checklist.md` (tag-first path).

## Change type

- [ ] Feature / improvement
- [ ] Bugfix
- [ ] Refactor (no behavior change)
- [x] Docs / chore / CI

## Audit checklist

Author — confirm before requesting review (procedure: `docs/review-checklist.md`):

- [x] **Blast radius checked** — no symbol, signature, or behavior change; the
  only executable-adjacent edits are the two version constants. `impact` N/A.
- [x] **Layering respected** — no module changes.
- [x] **Graph updated** — `cairn update` ran post-bump (0 files reindexed;
  only a version literal changed since the last full build).
- [x] **Memory recorded** — release mechanics captured for future cuts.
- [x] **Fallback/perf paths** — N/A, none touched.
- [x] **Tests** — `pytest -m core -q` green on this branch (26 passed); the
  full suite was green at the tag's content (2137 passed, 1 skipped, clean-room
  matrix 3.10–3.14) — the bump changes no logic.
- [x] **CHANGELOG** — this PR *is* the changelog step (`[Unreleased]` →
  `[0.14.0]`, committed before the bump per the changelog-first rule).
- [x] **Gates green** — pre-commit clean; conventional title (`chore:` — the
  checklist's literal `release:` example would fail the PR-title gate).

## Blast-radius note

None — consumers of the changed values are release tooling (`cz` version
files) and the tag pipeline; no runtime code path reads them differently.

## Verification

- `uv run --extra dev --extra test cz bump --dry-run` → `increment detected:
  MINOR`, 0.13.0 → 0.14.0, tag `v0.14.0` (driven by the `feat:` history since
  v0.13.0).
- Tag `v0.14.0` → `e45b879`; both version files read `0.14.0`; `git status`
  clean.
- `pytest -m core -q` → 26 passed on `release/0.14.0-sync`.
- The `release.yml` run triggered by the tag push is the live proof of the
  new cibuildwheel wheel matrix (first execution — Windows/musllinux legs
  are the ones to watch).