### PR TITLE
ci(release): drop musllinux and Intel-macOS legs from wheel matrix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,8 +36,8 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      # Linux aarch64 + musllinux legs build under QEMU emulation inside
-      # cibuildwheel's docker containers (D-008).
+      # Linux aarch64 legs build under QEMU emulation inside cibuildwheel's
+      # docker containers (D-008).
       - name: Set up QEMU
         if: runner.os == 'Linux'
         uses: docker/setup-qemu-action@v3
@@ -61,18 +61,23 @@ jobs:
         run: uv build --sdist
 
       # cp310-* + setup.py's py_limited_api -> one cp310-abi3 wheel per
-      # platform (cibuildwheel auto-runs abi3audit on it). Linux x86_64 +
-      # aarch64 covers manylinux AND musllinux for both arches. Pinned
-      # exactly: cibuildwheel minor releases add/remove platforms (their
-      # FAQ mandates exact pins).
+      # platform (cibuildwheel auto-runs abi3audit on it). Supported: macOS
+      # Apple Silicon, manylinux x86_64 + aarch64, Windows AMD64. musllinux
+      # is skipped: sqlite-vec (core dep) ships no musl wheels, so an Alpine
+      # install can never resolve. Intel macOS is skipped: cryptography
+      # (transitive via mcp -> pyjwt[crypto]) dropped Intel-macOS wheels and
+      # fresh resolution there falls to a Rust sdist build. Pinned exactly:
+      # cibuildwheel minor releases add/remove platforms (their FAQ mandates
+      # exact pins).
       - name: Build wheels
         uses: pypa/cibuildwheel@v4.2.0
         with:
           output-dir: wheelhouse
         env:
           CIBW_BUILD: "cp310-*"
+          CIBW_SKIP: "*musllinux*"
           CIBW_ARCHS_LINUX: "x86_64 aarch64"
-          CIBW_ARCHS_MACOS: "x86_64 arm64"
+          CIBW_ARCHS_MACOS: "arm64"
           CIBW_ARCHS_WINDOWS: "AMD64"
           CIBW_TEST_REQUIRES: tree_sitter
           # Smoke-test the compiled grammar in every wheel (supersedes the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,9 +56,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   inheritance, imports, the `operator fun invoke` rewrite) is unchanged:
   the golden corpus stays byte-identical and the scip-java hybrid merge
   joins against the new parses unchanged. With the in-tree extension,
-  `cairn-intel` wheels are now per-platform (cp310-abi3; macOS arm64/x64,
-  manylinux x86_64/aarch64, musllinux, Windows) built by a pinned
-  cibuildwheel matrix — `pip install cairn-intel` stays toolchain-free.
+  `cairn-intel` wheels are now per-platform (cp310-abi3; macOS Apple
+  Silicon, manylinux x86_64/aarch64, Windows) built by a pinned
+  cibuildwheel matrix, with every wheel smoke-testing its own grammar at
+  build time — `pip install cairn-intel` stays toolchain-free. Two
+  platforms are deliberately not shipped: musllinux (sqlite-vec, a core
+  dependency, publishes no musl wheels, so an Alpine install can never
+  resolve) and Intel macOS (cryptography — pulled transitively via
+  mcp's `pyjwt[crypto]` — has dropped Intel-macOS wheels; the first
+  per-wheel install test is what surfaced both limits).
 - The dashboard subsystem is now documented: `cairn dashboard` entry in
   the CLI reference, a Local dashboard section in the architecture guide
   (read-only and loopback-only invariants, store selection, estimate


### PR DESCRIPTION
## Summary

The first v0.14.0 wheel-matrix run failed on two legs — not the Kotlin
extension (it built, repaired, and passed the grammar smoke test on every
leg), but dependency resolution in the new per-wheel install test:
musllinux (sqlite-vec, a core dep, publishes no musl wheels — Alpine
installs can never resolve) and macOS x86_64 (cryptography, transitive
via mcp → pyjwt[crypto], dropped Intel-macOS wheels; sdist fallback needs
Rust). Every other leg passed: manylinux x86_64/aarch64, macOS arm64,
Windows AMD64. Nothing was published (PyPI/release jobs skipped), so
v0.14.0 remains unshipped and movable.

Platform decisions: drop both legs and document the limits (matches the
ecosystem direction — Tahoe is the last Intel macOS; torch went
arm64-only before cryptography did).

## Change type

- [ ] Feature / improvement
- [ ] Bugfix
- [ ] Refactor (no behavior change)
- [x] Docs / chore / CI

## Audit checklist

- [x] **Blast radius checked** — workflow selectors + changelog text only; no code or dependency metadata touched.
- [x] **Layering respected** — release pipeline only.
- [x] **Graph updated** — no indexed code changed.
- [x] **Memory recorded** — platform limits captured in the workflow comments and changelog (the durable record for users).
- [x] **Fallback/perf paths** — N/A.
- [x] **Tests** — no test surface changed; the next tagged run IS the test for this fix.
- [x] **CHANGELOG** — 0.14.0 entry amended pre-publication (section never shipped).
- [x] **Gates green** — pre-commit clean on the changed files; conventional title.

## Blast-radius note

None beyond the release workflow; supported platforms narrow to macOS
Apple Silicon, manylinux x86_64/aarch64, Windows AMD64.

## Verification

- Diagnosis from run 32827303035 logs: `sqlite-vec … from versions: none` (musllinux x86_64) and `Failed building wheel for cryptography` (macOS x86_64, via `pyjwt[crypto]>=2.10.1->mcp->cairn-intel`); Windows job conclusion: success.
- Local: `uv.lock` wheel inventory confirms cryptography 50.0.0 is arm64-only on macOS.
- Post-merge: tag v0.14.0 will be re-cut at the merge commit and re-run.