### PR TITLE
ci(release): unique artifact names per upload, pattern-download with merge

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,19 +86,20 @@ jobs:
             python -c "import cairn._tree_sitter_kotlin as m; from tree_sitter import Language, Parser;
             assert not Parser(Language(m.language())).parse(b'class Foo').root_node.has_error"
 
-      # Same artifact name across legs -- upload-artifact merges same-named
-      # artifacts, so publish-pypi / github-release below download the full
-      # set (all wheels + sdist) unchanged.
+      # Unique artifact name per upload -- upload-artifact rejects a
+      # duplicate name within one job (409), and same-name merging across
+      # jobs is not a v4+ guarantee. Both consumers below pattern-download
+      # dist-* with merge-multiple.
       - uses: actions/upload-artifact@v6
         with:
-          name: dist
+          name: dist-wheels-${{ matrix.os }}
           path: wheelhouse/
 
       - name: Upload sdist
         if: runner.os == 'Linux'
         uses: actions/upload-artifact@v6
         with:
-          name: dist
+          name: dist-sdist
           path: dist/
 
   publish-pypi:
@@ -113,7 +114,8 @@ jobs:
     steps:
       - uses: actions/download-artifact@v6
         with:
-          name: dist
+          pattern: dist-*
+          merge-multiple: true
           path: dist/
 
       # PyPA's official action. With Trusted Publishing it exchanges the
@@ -135,7 +137,8 @@ jobs:
 
       - uses: actions/download-artifact@v6
         with:
-          name: dist
+          pattern: dist-*
+          merge-multiple: true
           path: dist/
 
       - name: Extract version from tag


### PR DESCRIPTION
## Summary

Second v0.14.0 run failed at the ubuntu job's sdist upload: 409 Conflict —
upload-artifact forbids a duplicate artifact name within one job, and both
the wheels and sdist steps used `dist`. The first run never reached this
step (it failed earlier in the wheel matrix), so the bug was latent until
now. Wheels now upload as `dist-wheels-<os>`, the sdist as `dist-sdist`;
both consumers (`publish-pypi`, `github-release`) download `pattern: dist-*`
with `merge-multiple: true`.

## Change type
- [x] Docs / chore / CI

## Audit checklist
- [x] Blast radius — release workflow artifact plumbing only
- [x] Layering — release pipeline only
- [x] Graph — no indexed code changed
- [x] Memory — fix rationale lives in the workflow comment
- [x] Fallback/perf — N/A
- [x] Tests — the next tagged run is the test
- [x] CHANGELOG — N/A (CI plumbing)
- [x] Gates — pre-commit clean; conventional title

## Verification
- Run 32829483496: all three build jobs green (matrix fix held); failure is
  solely the 409 at `Upload sdist`; artifacts API shows three same-named
  `dist` uploads from the wheels steps.
- After merge: tag v0.14.0 re-cut at the merge commit (still unpublished).