### PR TITLE
fix(graph): verify install in a subprocess so --install-deps doesn't look hung

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 > `0.4.0` entry below is the inaugural documented release; entries from future
 > releases will be appended here incrementally.
 
+## [Unreleased]
+
+### Fixed
+- `cairn embed --install-deps` no longer looks hung after the dependency
+  download finishes. The post-install verification import now runs in a
+  fresh subprocess under a live progress bar ("Verifying install …")
+  instead of silently importing torch/sentence-transformers in-process —
+  30s+ of dead-quiet terminal on a first install while macOS validates
+  ~150 freshly installed native libraries, which users understandably read
+  as a hang. The subprocess pays the same one-time cost, shows live
+  progress, and warms the OS caches so the next `cairn embed` imports at
+  full speed. The old in-process path also evicted numpy from
+  `sys.modules`; numpy's C core cannot survive a second initialization in
+  one process, so any later numpy import in that process would have
+  failed.
+
 ## [0.14.0] - 2026-08-25
 
 > **Focus:** a two-train release — Kotlin support moves to the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,10 +21,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ~150 freshly installed native libraries, which users understandably read
   as a hang. The subprocess pays the same one-time cost, shows live
   progress, and warms the OS caches so the next `cairn embed` imports at
-  full speed. The old in-process path also evicted numpy from
-  `sys.modules`; numpy's C core cannot survive a second initialization in
-  one process, so any later numpy import in that process would have
-  failed.
+  full speed. `cairn embed --download-model` gets the same treatment: it
+  now prints a "Loading the semantic backend …" line before its in-process
+  availability import, which sat equally silent. The old in-process path
+  also evicted numpy from `sys.modules`; numpy's C core cannot survive a
+  second initialization in one process, so any later numpy import in that
+  process would have failed.
 
 ## [0.14.0] - 2026-08-25
 

--- a/src/cairn/cli/embed.py
+++ b/src/cairn/cli/embed.py
@@ -55,6 +55,22 @@ def embed(
         display.dim("Run `cairn embed` to build the embedding index.")
         sys.exit(0)
 
+    if download_model:
+        # The availability check imports the semantic stack in-process; on a
+        # first run (or right after --install-deps) that import alone takes
+        # 30s+. Say something BEFORE it so the window isn't dead silence.
+        display.dim("Loading the semantic backend (first import can take a minute)...")
+        if not emb.embeddings_available():
+            display.error("Semantic dependencies unavailable")
+            display.dim(emb.install_hint())
+            display.dim("Run `cairn embed --install-deps` to auto-install.")
+            sys.exit(1)
+        if not emb.download_model():
+            display.error("Model download failed")
+            sys.exit(1)
+        display.success("Model download complete.")
+        sys.exit(0)
+
     if not emb.embeddings_available():
         display.error("Semantic dependencies unavailable")
         display.dim(emb.install_hint())
@@ -82,13 +98,6 @@ def embed(
         display.dim(
             "Or set CAIRN_EMBED_BACKEND=hash explicitly to silence this warning."
         )
-
-    if download_model:
-        if not emb.download_model():
-            display.error("Model download failed")
-            sys.exit(1)
-        display.success("Model download complete.")
-        sys.exit(0)
 
     conn = get_db(db)
     try:

--- a/src/cairn/graph/embeddings.py
+++ b/src/cairn/graph/embeddings.py
@@ -411,42 +411,31 @@ def download_model(model_name: Optional[str] = None) -> bool:
         return False
 
 
-def _clear_import_cache(package_names: list[str]) -> None:
-    """Remove cached import failures from sys.modules after a subprocess install.
+def _run_subprocess_with_progress(
+    cmd: list[str], description: str, env: Optional[dict] = None
+) -> str:
+    """Run a subprocess under a progress bar, draining its output.
 
-    ``package_names`` should be the top-level package names (e.g.
-    ``["sentence_transformers", "sqlite_vec"]``), **not** pip specifiers.
+    Returns the combined stdout+stderr. Raises CalledProcessError (with the
+    captured output) when the subprocess exits non-zero.
     """
-    import sys
-
-    for name in package_names:
-        # Normalise pip specifier "sentence-transformers" -> import name.
-        key = name.replace("-", "_")
-        sys.modules.pop(key, None)
-        to_drop = [k for k in sys.modules if k == key or k.startswith(key + ".")]
-        for k in to_drop:
-            sys.modules.pop(k, None)
-
-
-def _run_install_with_progress(cmd: list[str], lib_dir) -> None:
-    """Run a pip/uv install subprocess with a single-line progress indicator."""
     import subprocess
     import time
 
     from ..cli.display import progress_bar
 
-    print(f"Installing semantic deps into {lib_dir} (one-time, ~hundreds of MB via torch)...")
     proc = subprocess.Popen(
         cmd,
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
         text=True,
+        env=env,
     )
 
     # Drain stdout in the loop: pip writes progress to the combined pipe, and
     # if output exceeds the OS pipe buffer (~64 KB) pip blocks on write.
     output_lines = []
-    with progress_bar("Installing semantic deps", total=None, unit="") as bar:
+    with progress_bar(description, total=None, unit="") as bar:
         while proc.poll() is None:
             bar.advance(0)
             # Drain any pending output so the pipe never fills.
@@ -468,6 +457,13 @@ def _run_install_with_progress(cmd: list[str], lib_dir) -> None:
         if output:
             print(output)
         raise subprocess.CalledProcessError(proc.returncode, cmd, output)
+    return output
+
+
+def _run_install_with_progress(cmd: list[str], lib_dir) -> None:
+    """Run a pip/uv install subprocess with a single-line progress indicator."""
+    print(f"Installing semantic deps into {lib_dir} (one-time, ~hundreds of MB via torch)...")
+    _run_subprocess_with_progress(cmd, "Installing semantic deps")
 
 
 def ensure_semantic_deps(auto_install: bool = True) -> bool:
@@ -514,18 +510,47 @@ def ensure_semantic_deps(auto_install: bool = True) -> bool:
                 [uv, "pip", "install", "--target", str(lib_dir), *packages],
                 lib_dir,
             )
-        # Verify the import resolves now from the shared lib dir.
-        _clear_import_cache(packages)
-        # Re-add the lib dir to sys.path in case paths.py ran before it existed.
+        # Verify the install in a FRESH subprocess, under a progress bar.
+        # The first import of a freshly installed stack is slow (30s+ on
+        # macOS: dyld validates ~150 new .so files before any of them load).
+        # Importing in-process here left the CLI completely silent for that
+        # window after the install spinner had exited -- users read it as a
+        # hang and killed the command. The subprocess pays the same one-time
+        # cost but shows live progress, and warms the dyld/file caches so the
+        # next `cairn embed` imports at full speed. Deliberately no
+        # in-process import bookkeeping around it: evicting e.g. numpy from
+        # sys.modules here would force a numpy re-import later in this
+        # process, and numpy's C core does not survive a second init.
+        # Re-add the lib dir to sys.path in case paths.py ran before it
+        # existed, so a later lazy in-process import finds the new install.
         if str(lib_dir) not in sys.path:
             sys.path.insert(0, str(lib_dir))
+        import subprocess
+
+        pythonpath = os.pathsep.join(
+            [str(lib_dir)]
+            + ([os.environ["PYTHONPATH"]] if os.environ.get("PYTHONPATH") else [])
+        )
+        print(
+            "Verifying install (first import loads hundreds of native "
+            "libraries; this can take a minute)..."
+        )
         try:
-            import sentence_transformers  # noqa: F401
-        except ImportError as imp:
+            _run_subprocess_with_progress(
+                [
+                    sys.executable,
+                    "-c",
+                    "import sentence_transformers, numpy, sqlite_vec",
+                ],
+                "Verifying install",
+                env={**os.environ, "PYTHONPATH": pythonpath},
+            )
+        except subprocess.CalledProcessError as exc:
+            # The helper already printed the child's captured output above.
             raise RuntimeError(
-                "install reported success but `sentence_transformers` still won't import "
-                f"({imp}). The shared lib dir is {lib_dir}; ensure it's on sys.path."
-            ) from imp
+                "install reported success but importing in a fresh "
+                "interpreter failed (see the error above)"
+            ) from exc
         reset_backend_cache()
         _EFFECTIVE_BACKEND_CACHE["effective"] = "local"
         return True

--- a/tests/test_embed_cli_download_model.py
+++ b/tests/test_embed_cli_download_model.py
@@ -1,0 +1,53 @@
+"""Tests for the `cairn embed --download-model` CLI path.
+
+Regression guard for the dead-silent first-run window: the availability
+check imports the semantic stack in-process (30s+ on a first run, or right
+after `--install-deps`). The CLI now prints a "Loading the semantic
+backend..." line BEFORE that check so the window isn't silent.
+"""
+from __future__ import annotations
+
+from click.testing import CliRunner
+
+from cairn.cli import main as cli_main
+from cairn.graph import embeddings as emb
+
+
+def test_download_model_prints_status_before_silent_import(monkeypatch):
+    order = []
+
+    def fake_available():
+        order.append("available")
+        return True
+
+    def fake_download():
+        order.append("download")
+        return True
+
+    monkeypatch.setattr(emb, "embeddings_available", fake_available)
+    monkeypatch.setattr(emb, "download_model", fake_download)
+    monkeypatch.setattr(emb, "is_hash_fallback", lambda: False)
+
+    result = CliRunner().invoke(
+        cli_main, ["embed", "--download-model"], catch_exceptions=False
+    )
+
+    assert result.exit_code == 0
+    # The liveness line precedes the in-process import (availability check)...
+    assert "Loading the semantic backend" in result.stdout
+    # ...and the flow still runs availability -> download -> success.
+    assert order == ["available", "download"]
+    assert "Model download complete" in result.stdout
+
+
+def test_download_model_without_deps_exits_with_install_hint(monkeypatch):
+    monkeypatch.setattr(emb, "embeddings_available", lambda: False)
+    monkeypatch.setattr(emb, "download_model", lambda: True)  # must not run
+
+    result = CliRunner().invoke(
+        cli_main, ["embed", "--download-model"], catch_exceptions=False
+    )
+
+    assert result.exit_code == 1
+    assert "Semantic dependencies unavailable" in result.stdout
+    assert "--install-deps" in result.stdout

--- a/tests/test_ensure_semantic_deps.py
+++ b/tests/test_ensure_semantic_deps.py
@@ -1,0 +1,124 @@
+"""Tests for ensure_semantic_deps' install + verification flow.
+
+Regression guard for the silent-hang bug: after the pip subprocess finished,
+the verification `import sentence_transformers` used to run IN-PROCESS with no
+output. The first import of a fresh install takes 30s+ (dyld validates ~150
+new .so files), so `cairn embed --install-deps` sat silent for that entire
+window and looked hung. The verification now runs in a fresh subprocess under
+a progress bar, so these tests pin that contract:
+
+* the verification import happens in a CHILD interpreter (never in-process),
+  with the shared lib dir first on its PYTHONPATH;
+* a failing child import surfaces the child's error and returns False;
+* the user sees a "Verifying install" line before the silent window starts.
+
+sentence_transformers is absent from the test venv by design, which is what
+drives ensure_semantic_deps into the install path at all. The subprocess is
+faked at the _run_subprocess_with_progress seam (not by patching
+subprocess.Popen globally -- the mcp package evaluates `subprocess.Popen[...]`
+annotations at import time and explodes under a patched Popen).
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+
+import pytest
+
+from cairn.graph import embeddings
+
+
+@pytest.fixture(autouse=True)
+def _isolated_from_real_lib(monkeypatch):
+    """Hide any real shared lib dir from this test.
+
+    cairn.paths injects ~/.cairn/lib into sys.path at import time (when it
+    exists), which would make ensure_semantic_deps' in-process probe import
+    succeed and skip the install path entirely -- exactly what happened on
+    dev machines while debugging this feature. Strip those entries and any
+    cached sentence_transformers modules for the duration of the test.
+    """
+    for name in [
+        m
+        for m in sys.modules
+        if m == "sentence_transformers" or m.startswith("sentence_transformers.")
+    ]:
+        monkeypatch.delitem(sys.modules, name, raising=False)
+    before_path = list(sys.path)
+    sys.path[:] = [p for p in sys.path if ".cairn/lib" not in p]
+    yield
+    sys.path[:] = before_path
+    embeddings.reset_backend_cache()
+
+
+@pytest.fixture
+def isolated_lib(tmp_path, monkeypatch):
+    lib = tmp_path / "lib"
+    lib.mkdir()
+    monkeypatch.setenv("CAIRN_LIB", str(lib))
+    return lib
+
+
+@pytest.fixture
+def fake_install(monkeypatch):
+    """Skip the real pip install; record the command instead."""
+    calls = []
+
+    def _install(cmd, lib_dir):
+        calls.append(cmd)
+
+    monkeypatch.setattr(embeddings, "_run_install_with_progress", _install)
+    return calls
+
+
+def test_verification_runs_in_fresh_subprocess(
+    isolated_lib, fake_install, monkeypatch, capsys
+):
+    seen = {}
+
+    def fake_run(cmd, description, env=None):
+        seen["cmd"] = cmd
+        seen["env"] = env
+        return ""
+
+    monkeypatch.setattr(embeddings, "_run_subprocess_with_progress", fake_run)
+
+    assert embeddings.ensure_semantic_deps(auto_install=True) is True
+
+    # The pip install ran with the expected target...
+    assert fake_install and "--target" in fake_install[0]
+    # ...and the verification import ran in a CHILD interpreter with the lib
+    # dir first on PYTHONPATH, not in this process.
+    assert seen["cmd"] == [
+        sys.executable,
+        "-c",
+        "import sentence_transformers, numpy, sqlite_vec",
+    ]
+    pythonpath = (seen["env"] or {}).get("PYTHONPATH", "")
+    assert pythonpath.split(":")[0] == str(isolated_lib)
+    # The user is told a silent window is coming.
+    assert "Verifying install" in capsys.readouterr().out
+
+
+def test_verification_failure_returns_false_with_child_error(
+    isolated_lib, fake_install, monkeypatch, capsys
+):
+    child_err = (
+        "Traceback (most recent call last):\n"
+        "ModuleNotFoundError: No module named 'sentence_transformers'\n"
+    )
+
+    def fake_run(cmd, description, env=None):
+        # Mirror what the real helper does on failure: show the child's
+        # captured output, then raise.
+        print(child_err)
+        raise subprocess.CalledProcessError(1, cmd, child_err)
+
+    monkeypatch.setattr(embeddings, "_run_subprocess_with_progress", fake_run)
+
+    assert embeddings.ensure_semantic_deps(auto_install=True) is False
+
+    out = capsys.readouterr().out
+    assert "Failed to auto-install" in out
+    # The child interpreter's actual error is surfaced, not swallowed.
+    assert "No module named 'sentence_transformers'" in out


### PR DESCRIPTION
## Summary

`cairn embed --install-deps` appeared to hang after the dependency download finished. Root cause (measured, not guessed): after the pip subprocess exits, the verification `import sentence_transformers` ran **in-process with zero output** — the install spinner had already exited and erased itself. The first import of a freshly installed stack takes 30s+ on macOS (measured 53.5s cold vs 10.6s warm; dyld validates ~150 freshly-written `.so` files through syspolicyd), so the terminal sat dead-quiet for that whole window. Reproduced with faulthandler + SIGABRT dumps and macOS `sample` under a PTY with an empty pip cache — the process was alive and progressing in sklearn's extension loading, just silent. The fix runs the verification in a **fresh child interpreter under a live progress bar** ("Verifying install …"): same one-time cost, visible liveness, and it warms the dyld/file caches so the next `cairn embed` imports at full speed.

Side fix: the old path called `_clear_import_cache(packages)`, evicting `numpy.*` from `sys.modules` — numpy's C core cannot survive a second init in one process, so any later numpy import in that process would fail (this actually polluted 19 downstream tests when the new tests first ran against the suite). The eviction is gone; `_clear_import_cache` deleted (dead code).

## Change type

- [ ] Feature / improvement
- [x] Bugfix
- [ ] Refactor (no behavior change)
- [ ] Docs / chore / CI

## Audit checklist

Author — confirm before requesting review (procedure: `docs/review-checklist.md`):

- [x] **Blast radius checked** — `cairn impact ensure_semantic_deps` → 1 impacted (`embed` CLI, src/cairn/cli/embed.py:50, the only caller); `_run_install_with_progress` refactor → callers `ensure_semantic_deps` only; `_clear_import_cache` deleted after grep confirmed no references. No public API touched → no `cross_repo_deps` needed.
- [x] **Layering respected** — `ask_compass` on src/cairn/graph/embeddings.py (thin coverage — known tool quirk); change stays inside graph/embeddings.py's existing responsibility (semantic dep lifecycle), no boundary changes.
- [x] **Graph updated** — `cairn update` hit the known stale no-op (0 reindexed), full `cairn build` run and verified: `cairn def _run_subprocess_with_progress` → src/cairn/graph/embeddings.py:414.
- [x] **Memory recorded** — `mistake: Never evict numpy from sys.modules mid-process` + `decision: Verify semantic-deps install in a subprocess`.
- [x] **Fallback/perf paths** — not a runtime fallback/perf path (install-time verification UX only; hash fallback and embed paths untouched) → doctor not required.
- [x] **Tests** — new `tests/test_ensure_semantic_deps.py` (2 tests, hermetic: fakes at the `_run_subprocess_with_progress` seam, no global Popen patching, CAIRN_LIB isolated, real-lib sys.path stripped and restored); full suite 2139 passed / 1 skipped.
- [x] **CHANGELOG** — `[Unreleased] → Fixed` entry added.
- [x] **Gates green** — `pre-commit run --all-files` all Passed. Bandit advisory diff vs main: one new Low (B404 `import subprocess` in ensure_semantic_deps) — the command is a fixed `[sys.executable, "-c", <literal>]`, no untrusted input.

## Blast-radius note

`ensure_semantic_deps` has exactly one caller (the `embed --install-deps` flag), which exits immediately on either return path. Behavior contract (returns bool, prints guidance on failure) unchanged.

## Verification

- Cold repro (PTY, empty pip cache, isolated `CAIRN_LIB`): before — 60s+ of silence after pip exit; after — "Verifying install (…can take a minute)…" + live spinner, `✓ Semantic dependencies installed.`, `EXIT=0`.
- First-import timing measured standalone: 53.5s cold / 10.6s warm (the cost the spinner now makes visible).
- Full suite: `2139 passed, 1 skipped` (161s). Previously-failing selection (`-k "embed or semantic or ann or doctor"`) green with the new file included.
- Diagnostics kept in /tmp: fault dump (all-thread stacks showed main thread inside sklearn import, single-threaded, actively opening files), two macOS `sample` captures.