### PR TITLE
chore: sync main with v0.14.1 release commits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 > `0.4.0` entry below is the inaugural documented release; entries from future
 > releases will be appended here incrementally.
 
-## [Unreleased]
+## [0.14.1] - 2026-08-25
+
+> **Focus:** one bugfix — `cairn embed --install-deps` (and
+> `--download-model`) no longer sit dead-silent and look hung while the
+> freshly installed semantic stack loads for the first time.
 
 ### Fixed
 - `cairn embed --install-deps` no longer looks hung after the dependency

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "cairn-intel"
-version = "0.14.0"
+version = "0.14.1"
 description = "Local codebase intelligence system: structural graph + compass + wiki + agent memory"
 readme = "README.md"
 license = "MIT"
@@ -211,7 +211,7 @@ select = ["F"]
 # The custom template (.cz_templates/keepachangelog.j2) renders that draft in
 # the existing `## [X.Y.Z] - YYYY-MM-DD` format rather than commitizen's
 # default `## X.Y.Z (YYYY-MM-DD)`.
-version = "0.14.0"
+version = "0.14.1"
 version_scheme = "pep440"
 tag_format = "v$version"
 update_changelog_on_bump = false

--- a/src/cairn/__init__.py
+++ b/src/cairn/__init__.py
@@ -1,3 +1,3 @@
 """Cairn: local codebase intelligence system."""
-__version__ = "0.14.0"
+__version__ = "0.14.1"
 __package_name__ = "cairn-intel"

--- a/uv.lock
+++ b/uv.lock
@@ -189,7 +189,7 @@ filecache = [
 
 [[package]]
 name = "cairn-intel"
-version = "0.14.0"
+version = "0.14.1"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

Release sync for **v0.14.1** (patch): carries the changelog preparation, the `cz bump` commit, and the `uv.lock` version sync to `main`. The tag `v0.14.1` is already pushed and the release workflow is building from it (PyPI + wheels + GitHub Release).

Contents: one bugfix — `cairn embed --install-deps` / `--download-model` no longer sit dead-silent while the freshly installed semantic stack first loads (PR #55).

## Change type

- [ ] Feature / improvement
- [ ] Bugfix
- [ ] Refactor (no behavior change)
- [x] Docs / chore / CI

## Audit checklist

- [x] **Blast radius checked** — version metadata only (pyproject, `__init__.py`, uv.lock, CHANGELOG); no code symbols touched.
- [x] **Layering respected** — n/a (no code).
- [x] **Graph updated** — graph was rebuilt after PR #55 merged; this PR adds no code.
- [x] **Memory recorded** — release mechanics memory applied verbatim (verified 0.14.0, reused 0.14.1).
- [x] **Fallback/perf paths** — none touched.
- [x] **Tests** — no behavior change; code covered by PR #55's suite run (2139 passed).
- [x] **CHANGELOG** — `[0.14.1] - 2026-08-25` section finalized with Focus line.
- [x] **Gates green** — pre-commit clean on the changelog/bump/lock commits (docs+metadata only).

## Blast-radius note

none — version/metadata files only.

## Verification

- `cz bump --dry-run` confirmed PATCH increment 0.14.0 → 0.14.1 before `cz bump --yes`.
- `uv lock` re-resolved cairn-intel to 0.14.1 (single-line lock diff, repo precedent).
- Tag `v0.14.1` pushed at the bump commit; release.yml triggered.