### PR TITLE
fix(cli): run upgrades and model downloads behind one progress line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   shown only when the upgrade fails, followed by the exact manual retry
   command, and a failed upgrade now exits non-zero instead of silently
   returning 0.
+- `cairn embed --download-model` and `cairn download-reranker` get the same
+  treatment: the model fetch runs in a child interpreter behind one live
+  progress line instead of constructing the model in-process, which let
+  HuggingFace print one tqdm bar per repo file (plus transformers warnings)
+  straight into the terminal for an ~836 MB / ~1.1 GB multi-file download.
+  The child shares the parent's HuggingFace cache, so the weights are
+  immediately available to every process; the downloader's captured output
+  is shown only when the fetch fails.
 - `cairn embed --install-deps` no longer breaks — and becomes unrepairable —
   when two Python interpreters share one machine. The semantic-dependency
   directory is now scoped per interpreter ABI (`~/.cairn/lib/cp311/`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- `cairn upgrade` no longer dumps the installer's raw output into the
+  terminal (50+ lines of pipx/uv/pip venv-creation and
+  Collecting/Downloading/already-satisfied noise from a single upgrade).
+  The reinstall now runs behind the same single live progress line as
+  `cairn embed --install-deps`; the installer's output is captured and
+  shown only when the upgrade fails, followed by the exact manual retry
+  command, and a failed upgrade now exits non-zero instead of silently
+  returning 0.
 - `cairn embed --install-deps` no longer breaks — and becomes unrepairable —
   when two Python interpreters share one machine. The semantic-dependency
   directory is now scoped per interpreter ABI (`~/.cairn/lib/cp311/`,

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -303,12 +303,18 @@ sentence-transformers) into the shared `~/.cairn/lib/cp<version>/` directory
 survives reinstalls, then exits without building the index. This is the
 recommended one-time way to get the default `BAAI/bge-m3` model — run
 `cairn embed --install-deps`, then `cairn embed` to build the index.
+`--download-model` pre-fetches the embedder weights into the local
+HuggingFace cache behind a single live progress line (the downloader's
+per-file output is captured and shown only on failure, like `cairn upgrade`
+and `cairn download-reranker`).
 
 `download-reranker` options: `--model` (default `BAAI/bge-reranker-base`, the
 natural pair for the bge-m3 embedder; honors `$CAIRN_RERANK_MODEL` if set).
-Fetches the weights into the local HuggingFace cache and writes a
-`~/.cairn/rerank_enabled` marker so reranking is on for subsequent queries —
-no `CAIRN_RERANK=1` needed. Set `CAIRN_RERANK=0` to turn it back off. If the
+Fetches the weights into the local HuggingFace cache (behind a single live
+progress line — the downloader's own per-file output is captured and shown
+only on failure, like `cairn upgrade` and `cairn embed --download-model`)
+and writes a `~/.cairn/rerank_enabled` marker so reranking is on for
+subsequent queries — no `CAIRN_RERANK=1` needed. Set `CAIRN_RERANK=0` to turn it back off. If the
 configured model is later missing/evicted from the cache, queries fall back to
 the hybrid (vector + BM25 + RRF) order rather than failing.
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -498,8 +498,12 @@ state, and prompts for which to install plus the config scope.
 installed version under PEP 440, and re-installs via whichever package
 manager cairn was installed with — `uv tool`, `pipx`, or `pip` (the install
 method is auto-detected by inspecting `uv tool list` / `pipx list` / the
-current interpreter path). `--check` prints both versions without changing
-anything. If PyPI is unreachable, it prints the manual command instead
+current interpreter path). The reinstall runs behind a single live progress
+line — the installer's own output (venv creation, dependency resolution,
+per-package downloads) is captured and shown only if the upgrade fails,
+followed by the exact manual retry command; a failed upgrade exits 1.
+`--check` prints both versions without changing anything. If PyPI is
+unreachable, it prints the manual command instead
 (`pip install --upgrade cairn-intel`).
 
 `cairn version` prints the installed version from package metadata, falling

--- a/src/cairn/cli/upgrade.py
+++ b/src/cairn/cli/upgrade.py
@@ -79,9 +79,18 @@ def _detect_install_method() -> str:
     return "unknown"
 
 
-def _reinstall(method: str, version: str):
-    """Re-install cairn-intel using the detected method."""
+def _reinstall(method: str, version: str) -> bool:
+    """Re-install cairn-intel using the detected method. True on success.
+
+    The installer runs behind the shared quiet progress helper (the same
+    seam `embed --install-deps` uses): one live progress line, with the
+    installer's output drained silently and shown only on failure. Raw
+    `subprocess.run` with inherited stdout used to dump 50+ lines of
+    pipx/uv/pip noise (venv creation, every Collecting/Downloading/
+    already-satisfied line) straight into the terminal.
+    """
     from . import display
+    from ..graph.embeddings import _run_subprocess_with_progress
 
     spec = f"cairn-intel=={version}"
     if method == "uv":
@@ -95,9 +104,19 @@ def _reinstall(method: str, version: str):
             f"Cannot auto-upgrade (unknown install method). "
             f"Run manually: pip install --upgrade {spec}"
         )
-        return
-    display.info(f"Running: {' '.join(cmd)}")
-    subprocess.run(cmd, check=False)
+        return False
+    display.dim(f"Running: {' '.join(cmd)}")
+    try:
+        _run_subprocess_with_progress(cmd, f"Upgrading cairn-intel to {version}")
+    except subprocess.CalledProcessError:
+        # The helper already printed the installer's captured output above.
+        display.warning(
+            f"Upgrade failed. The full installer output is above; "
+            f"to retry manually: {' '.join(cmd)}"
+        )
+        return False
+    display.success(f"Upgraded cairn-intel -> {version}")
+    return True
 
 
 # --- Commands --------------------------------------------------------------
@@ -143,4 +162,5 @@ def upgrade(check):
 
     method = _detect_install_method()
     display.info(f"Upgrading cairn-intel {current} -> {latest} (via {method})")
-    _reinstall(method, latest)
+    if not _reinstall(method, latest):
+        sys.exit(1)

--- a/src/cairn/graph/embeddings.py
+++ b/src/cairn/graph/embeddings.py
@@ -395,20 +395,49 @@ def model_is_cached(model_name: Optional[str] = None) -> bool:
 
 
 def download_model(model_name: Optional[str] = None) -> bool:
-    """Download model weights into the local HuggingFace cache if not present."""
+    """Download model weights into the local HuggingFace cache if not present.
+
+    The fetch runs in a child interpreter behind the quiet progress helper:
+    constructing the model in-process let HuggingFace print one tqdm bar
+    per repo file (plus transformers warnings) straight into the terminal
+    -- a wall of lines for an ~836 MB multi-file model. The child shares
+    the parent's HF cache, so afterwards any process (this one included)
+    loads the weights from cache.
+    """
+    import subprocess
+    import sys
+
     m_name = model_name or current_model()
     if model_is_cached(m_name):
         print(f"Model '{m_name}' is already cached — skipping download.")
         return True
 
+    print(f"Downloading '{m_name}' model weights into local cache...")
+    # Constructing the model IS the download (weights land in the HF cache).
+    # trust_remote_code mirrors _get_local_model so what gets cached matches
+    # what the runtime path loads.
+    trust = os.environ.get("CAIRN_EMBED_TRUST_REMOTE_CODE") == "1"
+    code = (
+        "from sentence_transformers import SentenceTransformer; "
+        f"SentenceTransformer({m_name!r}, trust_remote_code={trust!r})"
+    )
     try:
-        print(f"Downloading '{m_name}' model weights into local cache...")
-        _get_local_model(m_name)
-        print(f"Model '{m_name}' downloaded successfully.")
-        return True
-    except Exception as exc:
-        print(f"Failed to download model '{m_name}': {exc}")
+        _run_subprocess_with_progress(
+            [sys.executable, "-c", code],
+            f"Downloading {m_name}",
+            env={**os.environ, "PYTHONPATH": _lib_pythonpath()},
+        )
+    except subprocess.CalledProcessError:
+        # The helper already printed the child's captured output above (the
+        # HF error -- or a ModuleNotFoundError when the [semantic] extra
+        # isn't importable anywhere the child can see).
+        print(
+            f"Failed to download model '{m_name}' (see the output above; if "
+            "it is an import error, run `cairn embed --install-deps` first)"
+        )
         return False
+    print(f"Model '{m_name}' downloaded successfully.")
+    return True
 
 
 def _run_subprocess_with_progress(
@@ -496,6 +525,26 @@ def _install_cmd(packages: list[str], lib_dir) -> Optional[list[str]]:
     ]
 
 
+def _lib_pythonpath() -> str:
+    """PYTHONPATH for child interpreters: shared lib dirs first, then existing.
+
+    Mirrors the in-process sys.path order paths._inject_shared_libs
+    establishes (ABI dir, then the legacy flat dir under the default
+    layout), so a child interpreter resolves the semantic stack from the
+    same places the parent would -- the venv's site-packages still apply
+    via the child's own interpreter.
+    """
+    from ..paths import SHARED_LIB, shared_lib_path
+
+    dirs = [shared_lib_path()]
+    if not os.environ.get("CAIRN_LIB"):
+        dirs.append(SHARED_LIB)
+    parts = [str(d) for d in dirs]
+    if os.environ.get("PYTHONPATH"):
+        parts.append(os.environ["PYTHONPATH"])
+    return os.pathsep.join(parts)
+
+
 def _verify_install(lib_dir) -> None:
     """Import the fresh stack in a FRESH subprocess, under a progress bar.
 
@@ -510,10 +559,6 @@ def _verify_install(lib_dir) -> None:
     """
     import sys
 
-    pythonpath = os.pathsep.join(
-        [str(lib_dir)]
-        + ([os.environ["PYTHONPATH"]] if os.environ.get("PYTHONPATH") else [])
-    )
     print(
         "Verifying install (first import loads hundreds of native "
         "libraries; this can take a minute)..."
@@ -525,7 +570,7 @@ def _verify_install(lib_dir) -> None:
             "import sentence_transformers, numpy, sqlite_vec",
         ],
         "Verifying install",
-        env={**os.environ, "PYTHONPATH": pythonpath},
+        env={**os.environ, "PYTHONPATH": _lib_pythonpath()},
     )
 
 

--- a/src/cairn/graph/reranker.py
+++ b/src/cairn/graph/reranker.py
@@ -157,28 +157,47 @@ def download_reranker_model(model_name: Optional[str] = None) -> bool:
     so ``cairn download-reranker`` and ``cairn embed --download-model`` share
     a shape. Does not require ``CAIRN_RERANK=1`` — pre-fetching the weights
     should not depend on the feature being enabled at download time.
+
+    The fetch runs in a child interpreter behind the quiet progress helper,
+    like ``embeddings.download_model``: constructing the CrossEncoder
+    in-process let HuggingFace print one tqdm bar per repo file straight
+    into the terminal. The child shares the parent's HF cache.
     """
+    import subprocess
+    import sys
+
     m_name = model_name or current_rerank_model()
     if reranker_model_is_cached(m_name):
         print(f"Reranker model '{m_name}' is already cached — skipping download.")
         return True
+
+    print(f"Downloading reranker '{m_name}' weights into local cache...")
+    # Constructing the CrossEncoder IS the download (weights land in the HF
+    # cache). max_length is a runtime-only knob (_get_reranker pins it) and
+    # does not change what gets fetched.
+    code = (
+        "from sentence_transformers import CrossEncoder; "
+        f"CrossEncoder({m_name!r})"
+    )
     try:
-        from sentence_transformers import CrossEncoder  # noqa: F401
-    except ImportError:
+        from .embeddings import _lib_pythonpath, _run_subprocess_with_progress
+
+        _run_subprocess_with_progress(
+            [sys.executable, "-c", code],
+            f"Downloading {m_name}",
+            env={**os.environ, "PYTHONPATH": _lib_pythonpath()},
+        )
+    except subprocess.CalledProcessError:
+        # The helper already printed the child's captured output above (the
+        # HF error -- or a ModuleNotFoundError when sentence-transformers
+        # isn't importable anywhere the child can see).
         print(
-            f"Cannot download reranker '{m_name}': sentence-transformers is not "
-            f"installed. {install_hint()}"
+            f"Failed to download reranker model '{m_name}' (see the output "
+            "above)"
         )
         return False
-    try:
-        print(f"Downloading reranker '{m_name}' weights into local cache...")
-        # Constructing a CrossEncoder fetches the weights into the HF cache.
-        CrossEncoder(m_name)
-        print(f"Reranker model '{m_name}' downloaded successfully.")
-        return True
-    except Exception as exc:
-        print(f"Failed to download reranker model '{m_name}': {exc}")
-        return False
+    print(f"Reranker model '{m_name}' downloaded successfully.")
+    return True
 
 
 def _get_reranker():

--- a/tests/test_embed_cli_download_model.py
+++ b/tests/test_embed_cli_download_model.py
@@ -51,3 +51,77 @@ def test_download_model_without_deps_exits_with_install_hint(monkeypatch):
     assert result.exit_code == 1
     assert "Semantic dependencies unavailable" in result.stdout
     assert "--install-deps" in result.stdout
+
+
+# --- download_model fetches in a quiet child interpreter -------------------
+#
+# Regression guard: the fetch used to construct SentenceTransformer
+# in-process, so HuggingFace printed one tqdm bar per repo file (plus
+# transformers warnings) straight into the terminal -- a wall of lines for
+# an ~836 MB multi-file model. The fetch now runs in a child interpreter
+# behind the shared quiet progress helper, sharing the parent's HF cache.
+# Faked at the _run_subprocess_with_progress seam, same as the
+# ensure_semantic_deps tests (never patch subprocess.Popen globally).
+
+def test_download_model_fetches_in_quiet_subprocess(monkeypatch, capsys):
+    import os
+    import sys
+
+    from cairn.paths import shared_lib_path
+
+    seen = {}
+
+    def fake_run(cmd, description, env=None):
+        seen["cmd"] = cmd
+        seen["env"] = env
+        return ""
+
+    monkeypatch.setattr(emb, "_run_subprocess_with_progress", fake_run)
+    monkeypatch.setattr(emb, "model_is_cached", lambda m=None: False)
+
+    assert emb.download_model("BAAI/bge-m3") is True
+
+    # The fetch is a child interpreter constructing the model (which is
+    # what downloads the weights into the shared HF cache)...
+    assert seen["cmd"][:2] == [sys.executable, "-c"]
+    assert "SentenceTransformer" in seen["cmd"][2]
+    assert "BAAI/bge-m3" in seen["cmd"][2]
+    # ...with the shared lib dirs first on PYTHONPATH so the child resolves
+    # the semantic stack exactly where the parent would.
+    pythonpath = (seen["env"] or {}).get("PYTHONPATH", "")
+    assert pythonpath.split(os.pathsep)[0] == str(shared_lib_path())
+    out = capsys.readouterr().out
+    assert "Downloading 'BAAI/bge-m3'" in out
+    assert "downloaded successfully" in out
+
+
+def test_download_model_cached_skips_subprocess(monkeypatch):
+    calls = []
+
+    monkeypatch.setattr(
+        emb, "_run_subprocess_with_progress",
+        lambda *a, **k: calls.append(a),
+    )
+    monkeypatch.setattr(emb, "model_is_cached", lambda m=None: True)
+
+    assert emb.download_model("BAAI/bge-m3") is True
+    assert calls == []
+
+
+def test_download_model_failure_surfaces_child_output(monkeypatch, capsys):
+    import subprocess
+
+    def fake_run(cmd, description, env=None):
+        print("Connection error: couldn't reach huggingface.co")
+        raise subprocess.CalledProcessError(1, cmd, "conn")
+
+    monkeypatch.setattr(emb, "_run_subprocess_with_progress", fake_run)
+    monkeypatch.setattr(emb, "model_is_cached", lambda m=None: False)
+
+    assert emb.download_model("BAAI/bge-m3") is False
+
+    out = capsys.readouterr().out
+    # The child's actual error is surfaced (quiet must never mean opaque)...
+    assert "huggingface.co" in out
+    # ...along with the failure line.
+    assert "Failed to download model 'BAAI/bge-m3'" in out

--- a/tests/test_reranker.py
+++ b/tests/test_reranker.py
@@ -656,3 +656,74 @@ class TestSemanticSearchPassesEnrichedQuery:
 
         semantic_search(conn, "safeApiCall", limit=5, threshold=0.0)
         assert recorded["query"] == "safeApiCall"
+
+
+# --- download_reranker_model fetches in a quiet child interpreter ----------
+#
+# Regression guard, mirroring the embeddings.download_model tests: the fetch
+# used to construct CrossEncoder in-process, so HuggingFace printed one tqdm
+# bar per repo file (plus transformers warnings) into the terminal for a
+# ~1.1 GB model. The fetch now runs in a child interpreter behind the shared
+# quiet progress helper, sharing the parent's HF cache. Faked at the
+# _run_subprocess_with_progress seam (never patch subprocess.Popen globally).
+
+def test_download_reranker_model_fetches_in_quiet_subprocess(monkeypatch, capsys):
+    import sys
+
+    from cairn.graph import embeddings as emb_mod
+    from cairn.graph import reranker as rrk
+
+    seen = {}
+
+    def fake_run(cmd, description, env=None):
+        seen["cmd"] = cmd
+        seen["env"] = env
+        return ""
+
+    monkeypatch.setattr(emb_mod, "_run_subprocess_with_progress", fake_run)
+    monkeypatch.setattr(rrk, "reranker_model_is_cached", lambda m=None: False)
+
+    assert rrk.download_reranker_model("BAAI/bge-reranker-base") is True
+
+    # A child interpreter constructs the CrossEncoder (which is what
+    # downloads the weights into the shared HF cache).
+    assert seen["cmd"][:2] == [sys.executable, "-c"]
+    assert "CrossEncoder" in seen["cmd"][2]
+    assert "BAAI/bge-reranker-base" in seen["cmd"][2]
+    out = capsys.readouterr().out
+    assert "Downloading reranker 'BAAI/bge-reranker-base'" in out
+    assert "downloaded successfully" in out
+
+
+def test_download_reranker_model_cached_skips_subprocess(monkeypatch):
+    from cairn.graph import embeddings as emb_mod
+    from cairn.graph import reranker as rrk
+
+    calls = []
+    monkeypatch.setattr(
+        emb_mod, "_run_subprocess_with_progress", lambda *a, **k: calls.append(a)
+    )
+    monkeypatch.setattr(rrk, "reranker_model_is_cached", lambda m=None: True)
+
+    assert rrk.download_reranker_model("BAAI/bge-reranker-base") is True
+    assert calls == []
+
+
+def test_download_reranker_model_failure_surfaces_child_output(monkeypatch, capsys):
+    import subprocess as sp
+
+    from cairn.graph import embeddings as emb_mod
+    from cairn.graph import reranker as rrk
+
+    def fake_run(cmd, description, env=None):
+        print("Connection error: couldn't reach huggingface.co")
+        raise sp.CalledProcessError(1, cmd, "conn")
+
+    monkeypatch.setattr(emb_mod, "_run_subprocess_with_progress", fake_run)
+    monkeypatch.setattr(rrk, "reranker_model_is_cached", lambda m=None: False)
+
+    assert rrk.download_reranker_model("BAAI/bge-reranker-base") is False
+
+    out = capsys.readouterr().out
+    assert "huggingface.co" in out
+    assert "Failed to download reranker" in out

--- a/tests/test_upgrade.py
+++ b/tests/test_upgrade.py
@@ -8,7 +8,9 @@ and `subprocess.run` for the install-method sniff.
 from __future__ import annotations
 
 import subprocess
+import sys
 
+import pytest
 from click.testing import CliRunner
 
 from cairn.cli import main
@@ -34,7 +36,9 @@ def _set_versions(monkeypatch, installed=None, latest=None, reinstall=None):
     if latest is not _UNSET:
         monkeypatch.setattr(upgrade_mod, "_pypi_latest", lambda: latest)
     if reinstall is None:
-        reinstall = lambda method, version: calls.append((method, version))
+        def reinstall(method, version):
+            calls.append((method, version))
+            return True
     monkeypatch.setattr(upgrade_mod, "_reinstall", reinstall)
     return calls
 
@@ -138,6 +142,114 @@ def test_upgrade_when_pypi_unreachable(monkeypatch):
     # rather than the exact "pip install --upgrade" substring.
     assert "pip install" in result.output
     assert "--upgrade" in result.output
+
+
+# --- reinstall output (quiet progress, no installer spam) ------------------
+#
+# Regression guard: _reinstall used to hand the terminal straight to
+# pipx/uv/pip (`subprocess.run` with inherited stdout), so an upgrade dumped
+# 50+ lines of installer noise -- venv creation, every "Collecting /
+# Downloading / Requirement already satisfied" line, install progress bars.
+# The reinstall now runs under the same single-line progress helper the
+# `embed --install-deps` path uses (graph.embeddings._run_subprocess_with_
+# progress): output is drained silently behind one progress line and shown
+# only on failure. The subprocess is faked at that same seam (never by
+# patching subprocess.Popen globally -- the mcp package evaluates
+# `subprocess.Popen[...]` annotations at import time and explodes under a
+# patched Popen).
+
+@pytest.fixture
+def fake_quiet_run(monkeypatch):
+    """Replace the shared quiet-subprocess helper; record calls."""
+    from cairn.graph import embeddings
+
+    calls = []
+
+    def _run(cmd, description, env=None):
+        calls.append({"cmd": cmd, "description": description})
+        return ""
+
+    monkeypatch.setattr(embeddings, "_run_subprocess_with_progress", _run)
+    return calls
+
+
+def test_reinstall_runs_quiet_with_one_progress_line(fake_quiet_run, capsys):
+    """The installer runs behind the quiet helper, not raw subprocess.run."""
+    assert upgrade_mod._reinstall("pipx", "9.9.9") is True
+
+    assert len(fake_quiet_run) == 1
+    assert fake_quiet_run[0]["cmd"] == [
+        "pipx", "install", "--force", "cairn-intel==9.9.9",
+    ]
+    # The user still sees WHAT is about to run and a final result line --
+    # silence about intent would be its own regression (see the 0.14.1
+    # dead-silent-import fixes).
+    out = capsys.readouterr().out
+    assert "pipx install --force cairn-intel==9.9.9" in out
+    assert "Upgraded cairn-intel -> 9.9.9" in out
+
+
+@pytest.mark.parametrize(
+    "method, prefix",
+    [
+        ("uv", ["uv", "tool", "install", "--force"]),
+        ("pipx", ["pipx", "install", "--force"]),
+        ("pip", [sys.executable, "-m", "pip", "install", "--upgrade"]),
+    ],
+)
+def test_reinstall_method_commands(fake_quiet_run, method, prefix):
+    """Every install method goes through the quiet helper with its own cmd."""
+    assert upgrade_mod._reinstall(method, "9.9.9") is True
+    cmd = fake_quiet_run[0]["cmd"]
+    assert cmd[: len(prefix)] == prefix
+    assert cmd[-1] == "cairn-intel==9.9.9"
+
+
+def test_reinstall_failure_surfaces_child_output_and_manual_hint(monkeypatch, capsys):
+    """A failed upgrade shows the captured installer output + manual command.
+
+    Quiet must never mean opaque: the helper prints the child's captured
+    output before raising, and _reinstall converts that into a warning with
+    the exact manual re-run command instead of raising past the user.
+    """
+    from cairn.graph import embeddings
+
+    def _failing_run(cmd, description, env=None):
+        child = "ERROR: no matching distribution for cairn-intel==9.9.9\n"
+        print(child)
+        raise subprocess.CalledProcessError(1, cmd, child)
+
+    monkeypatch.setattr(embeddings, "_run_subprocess_with_progress", _failing_run)
+
+    assert upgrade_mod._reinstall("pipx", "9.9.9") is False
+
+    out = capsys.readouterr().out
+    assert "no matching distribution" in out
+    assert "pipx install --force cairn-intel==9.9.9" in out
+
+
+def test_reinstall_unknown_method_warns_without_subprocess(fake_quiet_run, capsys):
+    assert upgrade_mod._reinstall("unknown", "9.9.9") is False
+    assert fake_quiet_run == []
+    assert "Cannot auto-upgrade" in capsys.readouterr().out
+
+
+def test_upgrade_command_exits_nonzero_when_reinstall_fails(monkeypatch):
+    """End-to-end: a failed reinstall makes `cairn upgrade` exit 1."""
+    _set_versions(
+        monkeypatch,
+        installed="0.1.0",
+        latest="9.9.9",
+        reinstall=lambda method, version: False,
+    )
+    monkeypatch.setattr(upgrade_mod, "_detect_install_method", lambda: "pipx")
+
+    runner = CliRunner()
+    result = runner.invoke(main, ["upgrade"])
+
+    assert result.exit_code == 1
+    # The command-level intent line is still shown before the reinstall.
+    assert "Upgrading cairn-intel 0.1.0 -> 9.9.9 (via pipx)" in result.output
 
 
 # --- install-method detection ---------------------------------------------


### PR DESCRIPTION
## Summary

Three commands dumped third-party progress noise straight into the terminal. All now run their long work behind the same single live progress line (`_run_subprocess_with_progress`, the seam `embed --install-deps` already uses), with the child's output captured and shown **only on failure**:

- **`cairn upgrade`** — streamed raw pipx/uv/pip output (50+ lines of venv-creation / Collecting / Downloading / already-satisfied noise). Now: one progress line, a dim "Running: <cmd>" intent line, an "Upgraded" result line; failures surface the captured installer output + the exact manual retry command and exit 1 (was: silent exit 0).
- **`cairn embed --download-model`** — constructed SentenceTransformer in-process; HuggingFace printed one tqdm bar per repo file plus transformers warnings for an ~836 MB model. Now the fetch runs in a child interpreter sharing the parent's HF cache.
- **`cairn download-reranker`** — same in-process CrossEncoder issue for a ~1.1 GB model; same child-interpreter fix.

New `_lib_pythonpath()` helper builds the child's PYTHONPATH (shared lib dirs first, mirroring `paths._inject_shared_libs` order); `_verify_install` now shares it.

## Change type

- [ ] Feature / improvement
- [x] Bugfix
- [ ] Refactor (no behavior change)
- [ ] Docs / chore / CI

## Audit checklist

Author — confirm before requesting review (procedure: `docs/review-checklist.md`):

- [x] **Blast radius checked** — `_reinstall` has one caller (`upgrade` cmd); `download_model` one caller (`embed --download-model`); `download_reranker_model` one caller (`download-reranker`); `_verify_install` one caller (`ensure_semantic_deps`, PYTHONPATH semantics unchanged: lib dir still first, now also mirrors the legacy-dir ordering). `_run_subprocess_with_progress` itself untouched.
- [x] **Layering respected** — `cli.upgrade` → `graph.embeddings` (lazy, same direction as `cli/embed.py`); `graph.reranker` → `graph.embeddings` (graph-internal, reranker already mirrors embeddings' shapes); helper `_lib_pythonpath` lives beside its only producer/consumers.
- [x] **Graph updated** — `cairn update` + full rebuild ran after the prior merge; runs again post-merge.
- [x] **Memory recorded** — pattern memory "quiet-subprocess seam for long installer subprocesses" recorded (covers all three commands).
- [x] **Fallback/perf paths** — no fallback/perf path altered; failure paths improved (exit 1 + surfaced output for upgrade; False + surfaced output for downloads). `cairn doctor` PASS on this workspace.
- [x] **Tests** — 6 upgrade tests (all three install methods via parametrize, success/failure surfacing, unknown-method, end-to-end exit 1) + 6 download tests (3 per command: quiet fetch cmd + PYTHONPATH ordering, cached skip, failure surfaces child output). Full suite **2158 passed, 1 skipped, exit 0** on 3.11; changed-area tests green on 3.14 incl. `test_stray_sweeper_safety` (the CI 3.14 flake — unrelated file, passes locally on 3.14, rerunning in CI). Hermetic: no network, subprocesses faked at the `_run_subprocess_with_progress` seam (never patching `subprocess.Popen` globally).
- [x] **CHANGELOG** — two `[Unreleased] → Fixed` entries added.
- [x] **Gates green** — `pre-commit run --all-files` exit 0; no new mypy findings (lazy imports of existing symbols); pip-audit/bandit in CI.

## Blast-radius note

All changed functions are CLI-command-private with exactly one call site each (verified by grep + cairn graph). The shared helper and `_verify_install`'s observable behavior are unchanged (`PYTHONPATH` first entry is still the shared lib dir).

## Verification

- TDD red→green for both commits (upgrade tests failed against old `_reinstall`; download tests failed against in-process fetch).
- Full suite 2158 passed / 1 skipped / exit 0 on 3.11 (hermetic `CAIRN_LIB`, mirroring CI); changed tests green under 3.14 locally.
- Pre-commit exit 0.
- `cairn embed --download-model` cached path still prints the one-line skip.