### PR TITLE
chore: release 0.14.2 sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,25 +10,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 > `0.4.0` entry below is the inaugural documented release; entries from future
 > releases will be appended here incrementally.
 
-## [Unreleased]
+## [0.14.2] - 2026-08-25
+
+> **Focus:** two robustness fixes — `cairn embed --install-deps` no longer
+> corrupts (and can now self-repair) when multiple Python interpreters share
+> a machine, and `cairn upgrade` / the model downloads show one progress
+> line instead of streaming pages of installer/downloader output.
 
 ### Fixed
-- `cairn upgrade` no longer dumps the installer's raw output into the
-  terminal (50+ lines of pipx/uv/pip venv-creation and
-  Collecting/Downloading/already-satisfied noise from a single upgrade).
-  The reinstall now runs behind the same single live progress line as
-  `cairn embed --install-deps`; the installer's output is captured and
-  shown only when the upgrade fails, followed by the exact manual retry
-  command, and a failed upgrade now exits non-zero instead of silently
-  returning 0.
-- `cairn embed --download-model` and `cairn download-reranker` get the same
-  treatment: the model fetch runs in a child interpreter behind one live
-  progress line instead of constructing the model in-process, which let
-  HuggingFace print one tqdm bar per repo file (plus transformers warnings)
-  straight into the terminal for an ~836 MB / ~1.1 GB multi-file download.
-  The child shares the parent's HuggingFace cache, so the weights are
-  immediately available to every process; the downloader's captured output
-  is shown only when the fetch fails.
 - `cairn embed --install-deps` no longer breaks — and becomes unrepairable —
   when two Python interpreters share one machine. The semantic-dependency
   directory is now scoped per interpreter ABI (`~/.cairn/lib/cp311/`,
@@ -45,6 +34,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   only sound repair for an interrupted or foreign-ABI install — and the
   no-pip uv fallback pins `--python` to the running interpreter so uv can no
   longer resolve wheels for a different ABI than the one running cairn.
+- `cairn upgrade` no longer dumps the installer's raw output into the
+  terminal (50+ lines of pipx/uv/pip venv-creation and
+  Collecting/Downloading/already-satisfied noise from a single upgrade).
+  The reinstall now runs behind the same single live progress line as
+  `cairn embed --install-deps`; the installer's output is captured and
+  shown only when the upgrade fails, followed by the exact manual retry
+  command, and a failed upgrade now exits non-zero instead of silently
+  returning 0.
+- `cairn embed --download-model` and `cairn download-reranker` get the same
+  treatment: the model fetch runs in a child interpreter behind one live
+  progress line instead of constructing the model in-process, which let
+  HuggingFace print one tqdm bar per repo file (plus transformers warnings)
+  straight into the terminal for an ~836 MB / ~1.1 GB multi-file download.
+  The child shares the parent's HuggingFace cache, so the weights are
+  immediately available to every process; the downloader's captured output
+  is shown only when the fetch fails.
 
 ## [0.14.1] - 2026-08-25
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "cairn-intel"
-version = "0.14.1"
+version = "0.14.2"
 description = "Local codebase intelligence system: structural graph + compass + wiki + agent memory"
 readme = "README.md"
 license = "MIT"
@@ -211,7 +211,7 @@ select = ["F"]
 # The custom template (.cz_templates/keepachangelog.j2) renders that draft in
 # the existing `## [X.Y.Z] - YYYY-MM-DD` format rather than commitizen's
 # default `## X.Y.Z (YYYY-MM-DD)`.
-version = "0.14.1"
+version = "0.14.2"
 version_scheme = "pep440"
 tag_format = "v$version"
 update_changelog_on_bump = false

--- a/src/cairn/__init__.py
+++ b/src/cairn/__init__.py
@@ -1,3 +1,3 @@
 """Cairn: local codebase intelligence system."""
-__version__ = "0.14.1"
+__version__ = "0.14.2"
 __package_name__ = "cairn-intel"

--- a/uv.lock
+++ b/uv.lock
@@ -189,7 +189,7 @@ filecache = [
 
 [[package]]
 name = "cairn-intel"
-version = "0.14.1"
+version = "0.14.2"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

Release cut for **0.14.2** (patch): ships the two merged fix trains — PR #57 (per-ABI shared lib dirs + self-repair for `embed --install-deps`) and PR #58 (single progress line for `cairn upgrade` and model downloads). Canonical release procedure (docs/release-checklist.md): changelog prep → `cz bump` (tag `v0.14.2`) → uv.lock sync. The tag is pushed after this PR merges.

## Change type

- [ ] Feature / improvement
- [ ] Bugfix
- [ ] Refactor (no behavior change)
- [x] Docs / chore / CI

## Audit checklist

Author — confirm before requesting review (procedure: `docs/review-checklist.md`):

- [x] **Blast radius checked** — version-only change (pyproject `version`, `src/cairn/__init__.py __version__`, CHANGELOG heading, uv.lock self-reference). No code paths touched.
- [x] **Layering respected** — n/a (no code).
- [x] **Graph updated** — `cairn update` runs post-merge as usual; no symbols changed.
- [x] **Memory recorded** — release mechanics already captured; nothing new.
- [x] **Fallback/perf paths** — none touched.
- [x] **Tests** — content PRs (#57, #58) each ran the full suite green + all CI checks green; this PR only bumps versions.
- [x] **CHANGELOG** — `[Unreleased]` converted to `[0.14.2] - 2026-08-25` with Focus blurb (no premature version heading sat on a feature branch).
- [x] **Gates green** — pre-commit will run in CI; conventional PR title (`chore:`).

## Blast-radius note

none — release-sync only.

## Verification

- `cz bump --dry-run` reported `bump: version 0.14.1 → 0.14.2`, `increment detected: PATCH` (three `fix:` commits since v0.14.1), matching the intended patch cut.
- `cz bump` updated both version files and created tag `v0.14.2`; `uv lock` updated the self-reference to `v0.14.2`.