### PR TITLE
fix(install): zcode global MCP path + SSE-default transport (0.14.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 > `0.4.0` entry below is the inaugural documented release; entries from future
 > releases will be appended here incrementally.
 
-## [Unreleased]
+## [0.14.3] - 2026-08-26
 
 ### Changed
 - `install-agents` now defaults to **SSE** transport for every supported

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 > `0.4.0` entry below is the inaugural documented release; entries from future
 > releases will be appended here incrementally.
 
+## [Unreleased]
+
+### Changed
+- `install-agents` now defaults to **SSE** transport for every supported
+  client, instead of only when the SSE daemon happened to be reachable
+  (falling back to stdio otherwise). Claude Desktop still always gets a
+  stdio config — the app does not support SSE/HTTP MCP transports. If the
+  daemon is not reachable at install time, the CLI prints a note to run
+  `cairn serve start`; `--stdio` opts out globally.
+
+### Fixed
+- `install-agents --scope global` for ZCode now writes the MCP entry to
+  `~/.zcode/cli/config.json` — the file the ZCode CLI actually reads for
+  user-scope MCP servers (skills/commands/agents still go to `~/.zcode/`).
+  It previously wrote `~/.zcode/config.json`, which the CLI does not read
+  for MCP servers, so global installs silently never connected — sessions
+  reported "Required MCP server is not connected: cairn". Re-running the
+  installer migrates an existing legacy entry (strips it from the old
+  path), and uninstall/installed-detection now know both paths.
+
 ## [0.14.2] - 2026-08-25
 
 > **Focus:** two robustness fixes — `cairn embed --install-deps` no longer

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "cairn-intel"
-version = "0.14.2"
+version = "0.14.3"
 description = "Local codebase intelligence system: structural graph + compass + wiki + agent memory"
 readme = "README.md"
 license = "MIT"
@@ -211,7 +211,7 @@ select = ["F"]
 # The custom template (.cz_templates/keepachangelog.j2) renders that draft in
 # the existing `## [X.Y.Z] - YYYY-MM-DD` format rather than commitizen's
 # default `## X.Y.Z (YYYY-MM-DD)`.
-version = "0.14.2"
+version = "0.14.3"
 version_scheme = "pep440"
 tag_format = "v$version"
 update_changelog_on_bump = false

--- a/src/cairn/__init__.py
+++ b/src/cairn/__init__.py
@@ -1,3 +1,3 @@
 """Cairn: local codebase intelligence system."""
-__version__ = "0.14.2"
+__version__ = "0.14.3"
 __package_name__ = "cairn-intel"

--- a/src/cairn/agent_install/__init__.py
+++ b/src/cairn/agent_install/__init__.py
@@ -166,12 +166,14 @@ class InstallReport:
     transport: str = "stdio"  # the transport actually used (after auto-detect)
 
 
-def _detect_default_transport(sse_url: str | None = None) -> str:
-    """Pick the transport for install when the caller didn't specify.
+def sse_daemon_reachable(sse_url: str | None = None) -> bool:
+    """Probe whether the shared SSE daemon is accepting connections.
 
-    If the SSE daemon is running (probes http://127.0.0.1:{DEFAULT_PORT}/sse), default to
-    "sse" — this is what you almost always want once the daemon is up. Otherwise
-    fall back to "stdio" (safe for fresh installs with no daemon).
+    Connects to the host:port parsed out of the SSE URL (default
+    ``http://127.0.0.1:{DEFAULT_PORT}/sse``). Installs default to SSE
+    transport for every client except Claude Desktop (stdio-only), so this
+    is used only to warn when the daemon is not yet running — not to pick
+    the transport.
     """
     import socket
 
@@ -185,12 +187,12 @@ def _detect_default_transport(sse_url: str | None = None) -> str:
         host, port_s = host_part.rsplit(":", 1)
         port = int(port_s)
     except (IndexError, ValueError):
-        return "stdio"
+        return False
     try:
         with socket.create_connection((host, port), timeout=1.0):
-            return "sse"
+            return True
     except OSError:
-        return "stdio"
+        return False
 
 
 def install_cross_tool(workspace: str, force: bool, dry_run: bool = False) -> InstallResult:
@@ -257,9 +259,14 @@ def install(
     ``"workspace"`` (default) writes to ``./.claude/``, ``./.cursor/`` etc.;
     ``"global"`` writes to ``~/.claude/``, ``~/.cursor/`` etc. Single-scope
     clients (claude-desktop, agy) ignore the parameter.
+
+    ``transport`` defaults to ``"sse"`` — one shared daemon started with
+    ``cairn serve start`` (the SSE URL derives from ``lifecycle.DEFAULT_PORT``).
+    Claude Desktop is stdio-only and always gets a stdio config regardless;
+    pass ``transport="stdio"`` to opt out everywhere.
     """
     if transport is None:
-        transport = _detect_default_transport(sse_url)
+        transport = "sse"
 
     detections = detect_clients(workspace)
     if clients:

--- a/src/cairn/agent_install/clients/zcode.py
+++ b/src/cairn/agent_install/clients/zcode.py
@@ -2,8 +2,10 @@
 
 ZCode reads ``.zcode/config.json`` with a nested
 ``{"mcp": {"servers": {"cairn": {...}}}}`` shape (an explicit ``"type"``
-field) — NOT the top-level ``mcpServers`` format used by Claude/Cursor. This
-module owns that shape so install and uninstall agree.
+field) — NOT the top-level ``mcpServers`` format used by Claude/Cursor —
+for workspace scope; the user (global) scope MCP file is
+``~/.zcode/cli/config.json`` (same nested shape). This module owns those
+shapes so install and uninstall agree.
 """
 from __future__ import annotations
 
@@ -55,21 +57,31 @@ def zcode_mcp_config_json(transport: str = "stdio", sse_url: str | None = None) 
 def install_zcode(workspace: str, force: bool, dry_run: bool,
                   transport: str = "stdio", sse_url: str | None = None,
                   scope: str = "workspace") -> InstallResult:
-    """Wire cairn into ZCode (.zcode/config.json, .zcode/ skill + commands).
+    """Wire cairn into ZCode (.zcode/ config + skill, commands, agents).
 
-    ZCode reads <base>/.zcode/config.json and expects the nested shape
+    ZCode reads ``<workspace>/.zcode/config.json`` and expects the nested shape
     ``{"mcp": {"servers": {"cairn": {...}}}}`` — NOT the top-level
     ``mcpServers`` format used by Claude/Cursor.
 
     ``scope="workspace"`` writes to ``<workspace>/.zcode/`` (default).
-    ``scope="global"`` writes to ``~/.zcode/``.
+    ``scope="global"`` writes the MCP entry to ``~/.zcode/cli/config.json`` —
+    the ZCode CLI's user-scope MCP file — while skills/commands/agents go to
+    ``~/.zcode/`` (the CLI reads those from the top level). A legacy cairn
+    entry in ``~/.zcode/config.json`` (written by installers before this fix;
+    the CLI does not read that file for MCP) is stripped on install.
     """
     ws = Path(workspace)
     base = ws if scope == "workspace" else Path.home()
     res = InstallResult("zcode")
 
-    # MCP: ZCode reads .zcode/config.json (nested mcp.servers format).
-    _merge_json_file(base / ".zcode" / "config.json", zcode_mcp_config_json(transport, sse_url), force, res, config_key="zcode", dry_run=dry_run)
+    # MCP: workspace scope -> <ws>/.zcode/config.json; global scope ->
+    # ~/.zcode/cli/config.json (user-scope MCP file the ZCode CLI reads).
+    mcp_path = base / ".zcode" / "config.json"
+    if scope == "global":
+        mcp_path = base / ".zcode" / "cli" / "config.json"
+        if not dry_run:
+            _strip_mcp_zcode(base / ".zcode" / "config.json", res)
+    _merge_json_file(mcp_path, zcode_mcp_config_json(transport, sse_url), force, res, config_key="zcode", dry_run=dry_run)
 
     _write_tree(base / ".zcode" / "skills" / "cairn", _TEMPLATE_DIR / "skill", force, res, dry_run=dry_run)
     for name in _SLASH_COMMANDS:
@@ -98,14 +110,16 @@ def uninstall(ws: Path, res: InstallResult, scope: str = "workspace") -> None:
 
     ``scope="workspace"`` (the default, historical behavior) strips
     ``<ws>/.zcode/``. ``scope="global"`` strips ``~/.zcode/`` -- where a
-    ``--scope global`` install wrote config.json, skills, commands, and
-    agents. ``scope="all"`` does both. AGENTS.md is never removed (install
-    writes it create-if-absent only).
+    ``--scope global`` install wrote skills, commands, and agents -- plus the
+    MCP entry in ``~/.zcode/cli/config.json`` and any legacy entry in
+    ``~/.zcode/config.json``. ``scope="all"`` does both. AGENTS.md is never
+    removed (install writes it create-if-absent only).
 
     Commands/agents are only removed when byte-identical to what the
     installer writes, so a user's own file at the same path survives.
     """
     for base in _uninstall_bases(ws, scope):
+        _strip_mcp_zcode(base / ".zcode" / "cli" / "config.json", res)
         _strip_mcp_zcode(base / ".zcode" / "config.json", res)
         _rm_tree_if_cairn(base / ".zcode" / "skills" / "cairn", res)
         for n in _SLASH_COMMANDS:

--- a/src/cairn/agent_install/detect.py
+++ b/src/cairn/agent_install/detect.py
@@ -160,10 +160,12 @@ def check_installed(workspace: str) -> dict[str, bool]:
     # droid: .factory/skills/cairn/ exists
     result["droid"] = (ws / ".factory" / "skills" / "cairn" / "SKILL.md").exists()
 
-    # zcode: .zcode/config.json has cairn entry
+    # zcode: .zcode/config.json (workspace) or ~/.zcode/cli/config.json
+    # (global, current) has cairn entry; ~/.zcode/config.json is legacy global.
     result["zcode"] = (
         _json_has_cairn(ws / ".zcode" / "config.json")
         or _json_has_cairn(home / ".zcode" / "config.json")
+        or _json_has_cairn(home / ".zcode" / "cli" / "config.json")
     )
 
     # agy: ~/.gemini/config/mcp_config.json has cairn

--- a/src/cairn/cli/agents.py
+++ b/src/cairn/cli/agents.py
@@ -18,9 +18,9 @@ from .main import main
 @click.option("--dry-run", is_flag=True, help="Show what would be written; change nothing.")
 @click.option("--git-hooks", is_flag=True, help="Also install git post-commit hooks in repos.")
 @click.option("--sse", "sse", is_flag=True,
-              help="Force SSE configs (shared daemon). Run `cairn serve start` first.")
+              help="Use SSE configs (shared daemon) — this is the default; the flag is kept for explicitness. Run `cairn serve start` first.")
 @click.option("--stdio", "stdio", is_flag=True,
-              help="Force stdio configs (one process per client). Overrides auto-detection.")
+              help="Use stdio configs (one process per client) instead of the SSE default. Claude Desktop is always stdio either way.")
 @click.option("--sse-url", "sse_url", default=None,
               help="SSE URL (default http://127.0.0.1:9876/sse).")
 @click.option("--yes", "-y", is_flag=True,
@@ -166,6 +166,11 @@ def install_agents(clients, ws_arg, scope_arg, force, dry_run, git_hooks, sse, s
         else "stdio (one process per client)"
     )
     click.echo(f"MCP transport: {tp_note}")
+    if report.transport == "sse":
+        from ..agent_install import sse_daemon_reachable
+        if not sse_daemon_reachable(sse_url):
+            click.echo("  note: SSE daemon not reachable — run `cairn serve start` "
+                       "(installs a launchd agent), or pass --stdio for one process per client.")
     click.echo("")
 
     targeted = {r.client for r in report.results}

--- a/tests/test_install_uninstall_fidelity.py
+++ b/tests/test_install_uninstall_fidelity.py
@@ -203,7 +203,7 @@ class TestGlobalScopeUninstall:
 
         assert (fake_home / ".claude" / "skills" / "cairn").is_dir()
         assert (fake_home / ".cursor" / "hooks.json").exists()
-        assert (fake_home / ".zcode" / "config.json").exists()
+        assert (fake_home / ".zcode" / "cli" / "config.json").exists()
 
         uninstall(str(ws), clients=["claude", "cursor", "zcode"], scope="global")
 
@@ -214,8 +214,30 @@ class TestGlobalScopeUninstall:
         assert "hooks" not in st, "cairn hooks must be stripped from ~/.claude/settings.json"
         cur = json.loads((fake_home / ".cursor" / "hooks.json").read_text(encoding="utf-8"))
         assert "hooks" not in cur, "cairn hooks must be stripped from ~/.cursor/hooks.json"
-        zc = json.loads((fake_home / ".zcode" / "config.json").read_text(encoding="utf-8"))
+        zc = json.loads((fake_home / ".zcode" / "cli" / "config.json").read_text(encoding="utf-8"))
         assert "cairn" not in zc.get("mcp", {}).get("servers", {})
+
+    def test_zcode_global_install_migrates_legacy_config(self, fake_home, tmp_path, monkeypatch):
+        """A pre-fix global install left cairn in ~/.zcode/config.json (which the
+        ZCode CLI does not read for MCP). Re-installing must move the entry to
+        ~/.zcode/cli/config.json and strip the legacy one."""
+        _no_cli(monkeypatch, "zcode")
+        ws = tmp_path / "ws"
+        ws.mkdir()
+        legacy = fake_home / ".zcode" / "config.json"
+        legacy.parent.mkdir(parents=True)
+        legacy.write_text(json.dumps(
+            {"mcp": {"servers": {"cairn": {"type": "stdio", "command": "/old/cairn",
+                                           "args": ["serve"]}}}}), encoding="utf-8")
+
+        install(str(ws), clients=["zcode"], scope="global", transport="sse",
+                sse_url="http://127.0.0.1:9876/sse")
+
+        new = json.loads((fake_home / ".zcode" / "cli" / "config.json").read_text(encoding="utf-8"))
+        assert new["mcp"]["servers"]["cairn"]["type"] == "sse"
+        leg = json.loads(legacy.read_text(encoding="utf-8"))
+        assert "cairn" not in leg.get("mcp", {}).get("servers", {}), \
+            "legacy entry must be stripped so only one source of truth remains"
 
     def test_global_uninstall_preserves_user_entries(self, fake_home, tmp_path, monkeypatch):
         _no_cli(monkeypatch, "claude")
@@ -613,3 +635,34 @@ class TestCliScopeWiring:
         assert (ws / ".cursor" / "hooks.json").read_text(encoding="utf-8") == before
         assert (ws / ".agents" / "skills" / "cairn").exists(), \
             "dry-run must not remove the cross-tool copies either"
+
+
+# --------------------------------------------------------------------------
+# Transport default: SSE everywhere except Claude Desktop (stdio-only)
+# --------------------------------------------------------------------------
+
+class TestTransportDefault:
+    def test_install_defaults_to_sse_except_claude_desktop(self, fake_home, tmp_path, monkeypatch):
+        """No explicit transport: clients get an SSE config pointing at the
+        shared daemon; Claude Desktop stays stdio (the app is stdio-only)."""
+        _no_cli(monkeypatch, "claude", "zcode")
+        from cairn.mcp_server import lifecycle as lc
+        ws = tmp_path / "ws"
+        ws.mkdir()
+
+        install(str(ws), clients=["zcode", "claude", "claude-desktop"])
+
+        expected_url = f"http://127.0.0.1:{lc.DEFAULT_PORT}/sse"
+        # zcode (workspace scope): nested mcp.servers shape, SSE.
+        zc = json.loads((ws / ".zcode" / "config.json").read_text(encoding="utf-8"))
+        assert zc["mcp"]["servers"]["cairn"]["type"] == "sse"
+        assert zc["mcp"]["servers"]["cairn"]["url"] == expected_url
+        # claude code (workspace scope): flat mcpServers shape, SSE.
+        cl = json.loads((ws / ".mcp.json").read_text(encoding="utf-8"))
+        assert cl["mcpServers"]["cairn"]["type"] == "sse"
+        assert cl["mcpServers"]["cairn"]["url"] == expected_url
+        # claude-desktop: ALWAYS stdio, even under the SSE default.
+        from cairn.agent_install.detect import claude_desktop_config_path
+        cd = json.loads(claude_desktop_config_path().read_text(encoding="utf-8"))
+        assert "command" in cd["mcpServers"]["cairn"]
+        assert "url" not in cd["mcpServers"]["cairn"]


### PR DESCRIPTION
## Summary

Fixes two installer issues and cuts 0.14.3.

**1. ZCode global-scope installs never connected.** `install-agents --scope global` wrote the MCP entry to `~/.zcode/config.json`, which no ZCode surface reads for MCP servers — sessions reported `Required MCP server is not connected: cairn` even though the install reported success. Global installs now write `~/.zcode/cli/config.json` (the ZCode CLI's user-scope MCP file), strip the stale legacy entry on reinstall, and uninstall / installed-detection know both paths. Skills, commands, and agents still go to `~/.zcode/` (the CLI does read those from the top level). Workspace scope is unchanged: `<ws>/.zcode/config.json` is the correct file there.

**2. SSE is now the default transport.** `install-agents` generates SSE configs for every client that supports it, instead of only when the daemon happened to be reachable (falling back to stdio otherwise). Claude Desktop stays stdio — the app does not support SSE/HTTP MCP transports. The CLI now warns with a `cairn serve start` hint when the daemon is not reachable; `--stdio` still opts out globally.

## Changes

- `agent_install/clients/zcode.py` — global MCP write path moved to `~/.zcode/cli/config.json`; legacy entry stripped on install (self-migrating); uninstall strips both paths
- `agent_install/detect.py` — installed-check also looks at `~/.zcode/cli/config.json`
- `agent_install/__init__.py` — default transport is `"sse"`; `_detect_default_transport` replaced by a `sse_daemon_reachable()` probe used only for the CLI warning
- `cli/agents.py` — `--sse`/`--stdio` help updated for the new default; daemon-down note after the transport summary
- `tests/test_install_uninstall_fidelity.py` — global-scope assertions updated; new legacy-migration test and SSE-default-vs-claude-desktop test
- `CHANGELOG.md` + version bump 0.14.2 → 0.14.3 (pyproject ×2, `__version__`)

## Testing

- [x] 51 install-fidelity + atomic-config-write tests pass
- [x] 79 install/transport-related tests pass (incl. the port-DRY lint test)
- [x] 60 version-sensitive tests pass after the bump (bench stamping, report, upgrade)
- [x] Live-verified on macOS: full SSE MCP round-trip (initialize → tools/list → tool call) against the launchd daemon, a real `install-agents --client zcode --scope global` migrating the legacy config, and a flagless dry-run confirming the SSE default
