### PR TITLE
chore(deps): sync uv.lock to cairn-intel 0.14.3

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -189,7 +189,7 @@ filecache = [
 
 [[package]]
 name = "cairn-intel"
-version = "0.14.2"
+version = "0.14.3"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

PR #61 carried the version bump to 0.14.3 but not the uv.lock self-reference sync (it still pinned cairn-intel 0.14.2). One-line lock refresh, matching the separate `chore(deps)` sync commit each release cut uses.

## Change type

- [ ] Feature / improvement
- [ ] Bugfix
- [ ] Refactor (no behavior change)
- [x] Docs / chore / CI

## Audit checklist

Author — confirm before requesting review (procedure: `docs/review-checklist.md`):

- [x] **Blast radius checked** — uv.lock self-reference only (`version = "0.14.2"` → `"0.14.3"`); no dependencies changed.
- [x] **Layering respected** — n/a.
- [x] **Graph updated** — no code symbols.
- [x] **Memory recorded** — release mechanics already captured.
- [x] **Fallback/perf paths** — none.
- [x] **Tests** — lockfile-only; CI runs the suite.
- [x] **CHANGELOG** — n/a (release-sync chore).
- [x] **Gates green** — conventional title; CI.

## Blast-radius note

none.

## Verification

`uv lock` output: `Updated cairn-intel v0.14.2 -> v0.14.3`; diff is exactly 1 line.