### PR TITLE
fix(install): honor SSE everywhere — claude-global/droid CLIs + agy serverUrl shape

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 > `0.4.0` entry below is the inaugural documented release; entries from future
 > releases will be appended here incrementally.
 
+## [Unreleased]
+
+### Fixed
+- The SSE-by-default transport now also covers the two subprocess MCP
+  registrations: `install-agents --client claude --scope global` registers
+  via `claude mcp add --transport sse --scope user cairn <url>` and a
+  droid install with the `droid` CLI on PATH registers via
+  `droid mcp add cairn <url> --type sse`. Both previously ignored the
+  transport setting and always registered a stdio command spawn, so a
+  global/default install silently ran one process per client while the
+  CLI summary claimed SSE. `--stdio` still opts out; the shared daemon
+  URL resolution is deduplicated in one `default_sse_url` helper.
+
 ## [0.14.3] - 2026-08-26
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   global/default install silently ran one process per client while the
   CLI summary claimed SSE. `--stdio` still opts out; the shared daemon
   URL resolution is deduplicated in one `default_sse_url` helper.
+- agy (Antigravity) SSE installs now write the documented remote shape —
+  `mcpServers.cairn.serverUrl` — instead of the shared `type`/`url`
+  fields. Antigravity does not support legacy `url`/`httpUrl` fields
+  (per its docs), so the previous entry was silently ignored and cairn
+  never connected. The stdio shape (`command`/`args`) is unchanged.
 
 ## [0.14.3] - 2026-08-26
 

--- a/src/cairn/agent_install/_common.py
+++ b/src/cairn/agent_install/_common.py
@@ -82,6 +82,13 @@ def resolve_cg_str() -> str:
     return " ".join(cmd)
 
 
+def default_sse_url(sse_url: str | None = None) -> str:
+    """Resolve the SSE daemon URL: explicit --sse-url or the shared default."""
+    from ..mcp_server import lifecycle as lc
+
+    return sse_url or f"http://127.0.0.1:{lc.DEFAULT_PORT}/sse"
+
+
 def mcp_config_json(transport: str = "stdio", sse_url: str | None = None) -> dict:
     """MCP server config pointing at `cairn serve` (shared mcpServers shape).
 
@@ -95,10 +102,8 @@ def mcp_config_json(transport: str = "stdio", sse_url: str | None = None) -> dic
         sse_url: when transport="sse", the URL clients should connect to.
             Defaults to http://127.0.0.1:{lc.DEFAULT_PORT}/sse.
     """
-    from ..mcp_server import lifecycle as lc
-
     if transport == "sse":
-        url = sse_url or f"http://127.0.0.1:{lc.DEFAULT_PORT}/sse"
+        url = default_sse_url(sse_url)
         # Include "type": "sse" explicitly for maximum cross-client compat.
         # Some clients (Cursor) infer from `url`; others (ZCode, older Claude
         # Desktop builds) want the explicit type. Harmless where it's ignored.

--- a/src/cairn/agent_install/_common.py
+++ b/src/cairn/agent_install/_common.py
@@ -92,9 +92,9 @@ def default_sse_url(sse_url: str | None = None) -> str:
 def mcp_config_json(transport: str = "stdio", sse_url: str | None = None) -> dict:
     """MCP server config pointing at `cairn serve` (shared mcpServers shape).
 
-    Used by claude, cursor, droid, agy, and (via mcp_config_json_desktop) the
-    Claude Desktop app. Client-specific MCP shapes live in their own client
-    modules.
+    Used by claude, cursor, droid, and (via mcp_config_json_desktop) the
+    Claude Desktop app. Client-specific MCP shapes (zcode, opencode, agy)
+    live in their own client modules.
 
     Args:
         transport: "stdio" (default, one process per client) or "sse" (one

--- a/src/cairn/agent_install/clients/agy.py
+++ b/src/cairn/agent_install/clients/agy.py
@@ -10,7 +10,7 @@ import os
 import sys
 from pathlib import Path
 
-from .._common import InstallResult, mcp_config_json
+from .._common import InstallResult, default_sse_url, resolve_cg_command
 from ..merge import _merge_json_file, _strip_mcp
 
 
@@ -35,13 +35,32 @@ def agy_config_path() -> Path:
     return base / "gemini" / "config" / "mcp_config.json"
 
 
+def agy_mcp_config_json(transport: str = "stdio", sse_url: str | None = None) -> dict:
+    """MCP server config in agy (Antigravity) format.
+
+    agy nests servers under ``mcpServers`` like Claude/Cursor, but its
+    transport fields differ: remote servers use ``serverUrl`` and there is
+    no ``type`` field — the transport is implied by which field is present
+    (per https://antigravity.google/docs/mcp/, legacy ``url``/``httpUrl``
+    fields are NOT supported). stdio servers use ``command``/``args``
+    like the shared shape.
+    """
+    if transport == "sse":
+        return {"mcpServers": {"cairn": {"serverUrl": default_sse_url(sse_url)}}}
+    cmd = resolve_cg_command()
+    if len(cmd) == 1:
+        return {"mcpServers": {"cairn": {"command": cmd[0], "args": ["serve"]}}}
+    command, *prefix = cmd
+    return {"mcpServers": {"cairn": {"command": command, "args": [*prefix, "serve"]}}}
+
+
 def install_agy(workspace: str, force: bool, dry_run: bool,
                 transport: str = "stdio", sse_url: str | None = None,
                 scope: str = "workspace") -> InstallResult:
     """Wire cairn into agy (global mcp_config.json)."""
     res = InstallResult("agy")
     cfg = agy_config_path()
-    _merge_json_file(cfg, mcp_config_json(transport, sse_url), force, res, dry_run=dry_run)
+    _merge_json_file(cfg, agy_mcp_config_json(transport, sse_url), force, res, dry_run=dry_run)
     res.notes.append(f"Global MCP config: {cfg}")
     res.notes.append("Start or restart `agy` CLI to load the server.")
     return res

--- a/src/cairn/agent_install/clients/claude.py
+++ b/src/cairn/agent_install/clients/claude.py
@@ -27,6 +27,7 @@ from .._common import (
     _claude_hook_command,
     _claude_instructions,
     _uninstall_bases,
+    default_sse_url,
     mcp_config_json,
     resolve_cg_command,
 )
@@ -90,12 +91,15 @@ def install_claude(workspace: str, force: bool, dry_run: bool,
         if dry_run:
             res.notes.append("[dry-run] Would register MCP globally via `claude mcp add --scope user`.")
         elif shutil.which("claude"):
-            cmd = resolve_cg_command()
+            if transport == "sse":
+                url = default_sse_url(sse_url)
+                argv = ["claude", "mcp", "add", "--transport", "sse",
+                        "--scope", "user", "cairn", url]
+            else:
+                cmd = resolve_cg_command()
+                argv = ["claude", "mcp", "add", "cairn", "--scope", "user", *cmd, "serve"]
             try:
-                subprocess.run(
-                    ["claude", "mcp", "add", "cairn", "--scope", "user", *cmd, "serve"],
-                    capture_output=True, timeout=15, check=False,
-                )
+                subprocess.run(argv, capture_output=True, timeout=15, check=False)
                 res.notes.append("Registered MCP globally via `claude mcp add --scope user`.")
             except (subprocess.SubprocessError, OSError) as e:
                 res.notes.append(

--- a/src/cairn/agent_install/clients/droid.py
+++ b/src/cairn/agent_install/clients/droid.py
@@ -15,9 +15,10 @@ from .._common import (
     _TEMPLATE_DIR,
     _SLASH_COMMANDS,
     _claude_agent_md,
+    _read_template,
+    default_sse_url,
     mcp_config_json,
     resolve_cg_command,
-    _read_template,
 )
 from ..merge import (
     _merge_json_file,
@@ -50,12 +51,14 @@ def install_droid(workspace: str, force: bool, dry_run: bool,
 
     # MCP: prefer `droid mcp add` if the CLI is available; else write a config file.
     if shutil.which("droid") and not dry_run:
-        cmd = resolve_cg_command()
+        if transport == "sse":
+            url = default_sse_url(sse_url)
+            argv = ["droid", "mcp", "add", "cairn", url, "--type", "sse"]
+        else:
+            cmd = resolve_cg_command()
+            argv = ["droid", "mcp", "add", "cairn", *cmd, "serve"]
         try:
-            subprocess.run(
-                ["droid", "mcp", "add", "cairn", *cmd, "serve"],
-                capture_output=True, timeout=10, check=False,
-            )
+            subprocess.run(argv, capture_output=True, timeout=10, check=False)
             res.notes.append("Registered MCP via `droid mcp add`.")
         except (subprocess.SubprocessError, OSError):
             res.notes.append("`droid mcp add` failed; no config file written for MCP.")

--- a/src/cairn/agent_install/clients/opencode.py
+++ b/src/cairn/agent_install/clients/opencode.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from .._common import InstallResult, resolve_cg_command
+from .._common import InstallResult, default_sse_url, resolve_cg_command
 from ..merge import _merge_json_file, _strip_mcp_opencode
 
 
@@ -46,13 +46,10 @@ def opencode_mcp_config_json(transport: str = "stdio", sse_url: str | None = Non
 
     Args:
         transport: "stdio" (default) or "sse" (shared daemon).
-        sse_url: when transport="sse", the URL clients connect to.
+        sse_url: when transport="sse", the URL clients should connect to.
     """
-    from ...mcp_server import lifecycle as lc
-
     if transport == "sse":
-        url = sse_url or f"http://127.0.0.1:{lc.DEFAULT_PORT}/sse"
-        return {"mcp": {"cairn": {"type": "remote", "url": url, "enabled": True}}}
+        return {"mcp": {"cairn": {"type": "remote", "url": default_sse_url(sse_url), "enabled": True}}}
     cmd = resolve_cg_command() + ["serve"]
     return {"mcp": {"cairn": {"type": "local", "command": cmd, "enabled": True}}}
 

--- a/src/cairn/agent_install/clients/zcode.py
+++ b/src/cairn/agent_install/clients/zcode.py
@@ -19,6 +19,7 @@ from .._common import (
     _claude_agent_md,
     _claude_command_md,
     _uninstall_bases,
+    default_sse_url,
     resolve_cg_command,
 )
 from ..merge import (
@@ -42,11 +43,8 @@ def zcode_mcp_config_json(transport: str = "stdio", sse_url: str | None = None) 
         transport: "stdio" (default) or "sse" (shared daemon).
         sse_url: when transport="sse", the URL clients should connect to.
     """
-    from ...mcp_server import lifecycle as lc
-
     if transport == "sse":
-        url = sse_url or f"http://127.0.0.1:{lc.DEFAULT_PORT}/sse"
-        return {"mcp": {"servers": {"cairn": {"type": "sse", "url": url}}}}
+        return {"mcp": {"servers": {"cairn": {"type": "sse", "url": default_sse_url(sse_url)}}}}
     cmd = resolve_cg_command()
     if len(cmd) == 1:
         return {"mcp": {"servers": {"cairn": {"type": "stdio", "command": cmd[0], "args": ["serve"]}}}}

--- a/tests/test_install_uninstall_fidelity.py
+++ b/tests/test_install_uninstall_fidelity.py
@@ -666,3 +666,77 @@ class TestTransportDefault:
         cd = json.loads(claude_desktop_config_path().read_text(encoding="utf-8"))
         assert "command" in cd["mcpServers"]["cairn"]
         assert "url" not in cd["mcpServers"]["cairn"]
+
+    def test_claude_global_sse_registers_sse_transport(self, fake_home, tmp_path, monkeypatch):
+        """Global-scope claude install must honor the SSE default: the
+        `claude mcp add --scope user` registration uses --transport sse with
+        the daemon URL, not a stdio command spawn."""
+        _cli_at(monkeypatch, "claude")
+        calls = _spy_subprocess(monkeypatch)
+        from cairn.mcp_server import lifecycle as lc
+        ws = tmp_path / "ws"
+        ws.mkdir()
+
+        install(str(ws), clients=["claude"], scope="global")
+
+        expected_url = f"http://127.0.0.1:{lc.DEFAULT_PORT}/sse"
+        assert ["claude", "mcp", "add", "--transport", "sse", "--scope", "user",
+                "cairn", expected_url] in calls
+
+    def test_claude_global_sse_custom_url(self, fake_home, tmp_path, monkeypatch):
+        """--sse-url propagates to the global claude registration."""
+        _cli_at(monkeypatch, "claude")
+        calls = _spy_subprocess(monkeypatch)
+        ws = tmp_path / "ws"
+        ws.mkdir()
+
+        install(str(ws), clients=["claude"], scope="global",
+                sse_url="http://localhost:9999/sse")
+
+        assert ["claude", "mcp", "add", "--transport", "sse", "--scope", "user",
+                "cairn", "http://localhost:9999/sse"] in calls
+
+    def test_claude_global_stdio_keeps_stdio_registration(self, fake_home, tmp_path, monkeypatch):
+        """transport=stdio global install registers the command spawn, with
+        no --transport flag (regression pin for the pre-SSE behavior)."""
+        _cli_at(monkeypatch, "claude")
+        calls = _spy_subprocess(monkeypatch)
+        ws = tmp_path / "ws"
+        ws.mkdir()
+
+        install(str(ws), clients=["claude"], scope="global", transport="stdio")
+
+        add = [c for c in calls if c[:3] == ["claude", "mcp", "add"]]
+        assert len(add) == 1
+        assert "--transport" not in add[0]
+        assert add[0][3] == "cairn"  # name positional, then --scope user
+        assert "serve" in add[0]
+
+    def test_droid_cli_sse_registers_sse_type(self, tmp_path, monkeypatch):
+        """With the droid CLI present, the default SSE transport must
+        register the daemon URL via `--type sse`, not a stdio command spawn."""
+        _cli_at(monkeypatch, "droid")
+        calls = _spy_subprocess(monkeypatch)
+        from cairn.mcp_server import lifecycle as lc
+        ws = tmp_path / "ws"
+        ws.mkdir()
+
+        install(str(ws), clients=["droid"])
+
+        expected_url = f"http://127.0.0.1:{lc.DEFAULT_PORT}/sse"
+        assert ["droid", "mcp", "add", "cairn", expected_url, "--type", "sse"] in calls
+
+    def test_droid_cli_stdio_keeps_stdio_registration(self, tmp_path, monkeypatch):
+        """transport=stdio droid install registers the command spawn, with
+        no --type flag (regression pin)."""
+        _cli_at(monkeypatch, "droid")
+        calls = _spy_subprocess(monkeypatch)
+        ws = tmp_path / "ws"
+        ws.mkdir()
+
+        install(str(ws), clients=["droid"], transport="stdio")
+
+        add = [c for c in calls if c[:3] == ["droid", "mcp", "add"]]
+        assert len(add) == 1
+        assert "--type" not in add[0]
+        assert "serve" in add[0]

--- a/tests/test_install_uninstall_fidelity.py
+++ b/tests/test_install_uninstall_fidelity.py
@@ -740,3 +740,33 @@ class TestTransportDefault:
         assert len(add) == 1
         assert "--type" not in add[0]
         assert "serve" in add[0]
+
+    def test_agy_sse_uses_serverurl_shape(self, fake_home, tmp_path, monkeypatch):
+        """agy (Antigravity) remote servers use the `serverUrl` field; the
+        official docs state legacy `url`/`httpUrl` fields are NOT supported
+        and there is no `type` field — transport is implied by the field."""
+        from cairn.mcp_server import lifecycle as lc
+        from cairn.agent_install.clients.agy import agy_config_path
+        ws = tmp_path / "ws"
+        ws.mkdir()
+
+        install(str(ws), clients=["agy"])
+
+        cfg = json.loads(agy_config_path().read_text(encoding="utf-8"))
+        entry = cfg["mcpServers"]["cairn"]
+        assert entry["serverUrl"] == f"http://127.0.0.1:{lc.DEFAULT_PORT}/sse"
+        assert "url" not in entry
+        assert "type" not in entry
+
+    def test_agy_stdio_keeps_command_args_shape(self, fake_home, tmp_path, monkeypatch):
+        """stdio pin: command/args shape (agy's documented stdio form)."""
+        from cairn.agent_install.clients.agy import agy_config_path
+        ws = tmp_path / "ws"
+        ws.mkdir()
+
+        install(str(ws), clients=["agy"], transport="stdio")
+
+        cfg = json.loads(agy_config_path().read_text(encoding="utf-8"))
+        entry = cfg["mcpServers"]["cairn"]
+        assert "command" in entry
+        assert "serverUrl" not in entry


### PR DESCRIPTION
## Summary

Three install-agents paths violated or broke the SSE-by-default behavior (from #61 / 42556e1):

1. **claude `--scope global`** — `claude mcp add --scope user <cmd> serve` ignored `transport`, always registering stdio. Now registers `claude mcp add --transport sse --scope user cairn <url>` under the SSE default.
2. **droid with the droid CLI on PATH** — same: `droid mcp add cairn <cmd> serve` → now `droid mcp add cairn <url> --type sse` (the documented droid SSE form). The no-CLI `.factory/mcp.json` fallback already honored SSE.
3. **agy (Antigravity)** — the shared `{"type": "sse", "url": ...}` shape is invalid for agy: its docs state remote servers are `{"serverUrl": ...}` and legacy `url`/`httpUrl` fields are NOT supported. The entry was silently ignored, so cairn never connected in agy. agy now has its own `agy_mcp_config_json` (stdio `command`/`args` unchanged).

`--stdio` keeps every legacy shape (pinned by regression tests). The five duplicated daemon-URL defaults collapse into one `default_sse_url` helper in `_common.py` (behavior-preserving).

## Change type

- [ ] Feature / improvement
- [x] Bugfix
- [ ] Refactor (no behavior change)
- [ ] Docs / chore / CI

## Audit checklist

Author — confirm before requesting review (procedure: `docs/review-checklist.md`):

- [x] **Blast radius checked** — `impact_analysis("mcp_config_json")`: 6 impacted symbols, all within `agent_install`; change there is a pure URL-default extraction + docstring. `agy_mcp_config_json` is a new symbol (no consumers outside agy.py). Detection (`_json_has_cairn`) and uninstall (`_strip_mcp`) are shape-agnostic (key off `mcpServers.cairn` presence) — verified before the shape change.
- [x] **Layering respected** — `ask_compass` on claude.py/agy.py clean; client-specific config shapes live in their client modules (zcode/opencode precedent); shared writer docstring updated.
- [x] **Graph updated** — full `cairn build` re-ran after the incremental-update stale no-op (0 reindexed, `cairn def default_sse_url` missing → rebuild); `default_sse_url` resolves at `_common.py:85`; rebuild queued again after the agy commit.
- [x] **Memory recorded** — pattern: CLI MCP registrations (claude `--transport` vs droid `--type`) must branch on transport explicitly; plus the agy `serverUrl` schema note.
- [x] **Fallback/perf paths** — N/A (no fallback/perf path touched).
- [x] **Tests** — TDD throughout: claude-global/droid SSE argv tests + agy `serverUrl` shape test all failed first for the right reason, then green; 3 stdio/agy-shape regression pins. Full suite: 2173 passed, 1 skipped. Hermetic: `_cli_at`/`_spy_subprocess`/`fake_home` — no PATH/HOME/env dependence, no real subprocess.
- [x] **CHANGELOG** — `[Unreleased]` → `### Fixed` entries for both fixes.
- [x] **Gates green** — `pre-commit run --all-files` passed (first commit) + re-ran on the agy diff; PR title conventional; no new mypy/bandit findings expected.

## Blast-radius note

`mcp_config_json` callers (claude/cursor/droid/claude-desktop writers) — output identical. `install_agy` — dispatcher + tests only. New symbols: `default_sse_url`, `agy_mcp_config_json` (no external consumers).

## Verification

- RED→GREEN per commit: claude/droid (3 argv tests failed on stdio-shaped registrations), agy (`KeyError: 'serverUrl'` before the fix).
- Full suite `uv run pytest -q` → 2173 passed, 1 skipped (both commits).
- Gates: pre-commit all Passed.
- agy shape verified against official Antigravity docs (serverUrl required; legacy url/httpUrl unsupported); droid `--type sse` against Factory docs; claude `--transport sse` against Claude Code CLI reference.