### PR TITLE
feat(install): support the kilo CLI (Kilo Code)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `install-agents` now supports the **kilo** CLI (Kilo Code): MCP wired
+  into `kilo.json` (workspace) or `~/.config/kilo/kilo.json` (global)
+  under the `mcp` key — the opencode-format schema kilo documents
+  (`type: remote` + `url` under the SSE default, `type: local` +
+  command-array for `--stdio`). Detection covers the `kilo` CLI on PATH,
+  `~/.config/kilo/`, and a workspace `kilo.json`/`.kilo/`; uninstall
+  strips all scopes.
+
 ### Fixed
 - The SSE-by-default transport now also covers the two subprocess MCP
   registrations: `install-agents --client claude --scope global` registers

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ cairn install-agents
 ```
 
 Detects which AI clients you have (Claude Code, Cursor, ZCode, Droid, Claude
-Desktop, opencode, agy), shows what's already wired, and prompts for scope:
+Desktop, opencode, agy, kilo), shows what's already wired, and prompts for scope:
 `workspace` (per-project `./.claude/`, `./.cursor/` …) or `global`
 (`~/.claude/` — every project inherits it). Non-interactive:
 `cairn install-agents --yes --scope global`. Manual wiring is one JSON block:
@@ -312,7 +312,7 @@ Also: `CAIRN_HOME` (store location, default `~/.cairn`), `CAIRN_TELEMETRY=off`
 - **Platforms** — anywhere Python ≥ 3.10 runs; CI tests 3.10–3.14 (macOS +
   Linux; `make ci-local` replicates CI in a clean Linux container).
 - **Agents** — Claude Code, Cursor, ZCode, Droid, Claude Desktop, opencode,
-  agy — wired by `cairn install-agents`, or any MCP client via the manual
+  agy, kilo — wired by `cairn install-agents`, or any MCP client via the manual
   JSON block above.
 
 ## Troubleshooting

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -486,7 +486,7 @@ stdout.
 | `cairn upgrade` | Upgrade cairn in place (detects install method). |
 
 `install-agents` options: `--client` (repeatable:
-`claude|claude-desktop|cursor|droid|zcode|agy|opencode|all`), `--workspace`,
+`claude|claude-desktop|cursor|droid|zcode|agy|opencode|kilo|all`), `--workspace`,
 `--scope workspace|global` (where to write configs; if omitted, prompts),
 `--yes`/`-y` (skip the prompt; install for detected-not-installed clients),
 `--force`, `--dry-run`, `--git-hooks`, `--sse`, `--stdio`, `--sse-url`.

--- a/src/cairn/agent_install/__init__.py
+++ b/src/cairn/agent_install/__init__.py
@@ -58,12 +58,14 @@ from .clients import droid as _droid
 from .clients import zcode as _zcode
 from .clients import agy as _agy
 from .clients import opencode as _opencode
+from .clients import kilo as _kilo
 from .clients import claude_desktop as _claude_desktop
 
 # Per-client config generators (re-exported for backward compat — some callers
 # and tests import them by name from the top-level module).
 from .clients.zcode import zcode_mcp_config_json
 from .clients.opencode import opencode_mcp_config_json
+from .clients.kilo import kilo_mcp_config_json
 from .clients.claude_desktop import mcp_config_json_desktop
 from .clients.claude import claude_hooks_block
 from .clients.cursor import cursor_hooks_json
@@ -76,6 +78,7 @@ from .clients.droid import install_droid
 from .clients.zcode import install_zcode
 from .clients.agy import install_agy
 from .clients.opencode import install_opencode
+from .clients.kilo import install_kilo
 
 # Instruction-file builders (re-exported; test_agent_surface imports
 # _agents_instructions and also parses _INSTRUCTIONS_BODY from source).
@@ -104,6 +107,7 @@ __all__ = [
     "mcp_config_json",
     "zcode_mcp_config_json",
     "opencode_mcp_config_json",
+    "kilo_mcp_config_json",
     "mcp_config_json_desktop",
     # Hooks
     "claude_hooks_block",
@@ -116,6 +120,7 @@ __all__ = [
     "install_zcode",
     "install_agy",
     "install_opencode",
+    "install_kilo",
     # Private helpers re-exported for internal callers / tests
     "_SLASH_COMMANDS",
     "_already_installed",
@@ -148,6 +153,9 @@ __all__ = [
 #   opencode        : MCP YES (opencode.json, `mcp` key) | Skill FALLBACK (.agents/skills/
 #                     discovered) | Cmds/Subs NOT discovered (reads .opencode/commands/ +
 #                     opencode.json agents)  [MCP + skill-via-fallback]
+#   kilo            : MCP YES (kilo.json, opencode format) | Skill/Cmds/Subs/Hooks NOT
+#                     documented for the CLI (config format is opencode-derived; skill
+#                     may reach it via the .agents/ fallback)  [MCP-only]
 #   agy             : MCP YES (~/.gemini/config/mcp_config.json) -- Skill/Cmds/Subs/Hooks NOT
 #                     discovered (agy has no skill/command dirs)  [MCP-only]
 #   claude-desktop  : MCP YES (stdio only) -- no Skill/Cmds/Subs/Hooks (app is MCP-only)  [MCP-only]
@@ -230,6 +238,7 @@ _INSTALLERS = {
     "zcode": _zcode.install_zcode,
     "agy": _agy.install_agy,
     "opencode": _opencode.install_opencode,
+    "kilo": _kilo.install_kilo,
 }
 
 _UNINSTALLERS = {
@@ -240,6 +249,7 @@ _UNINSTALLERS = {
     "zcode": _zcode.uninstall,
     "agy": _agy.uninstall,
     "opencode": _opencode.uninstall,
+    "kilo": _kilo.uninstall,
 }
 
 

--- a/src/cairn/agent_install/_common.py
+++ b/src/cairn/agent_install/_common.py
@@ -13,7 +13,7 @@ from pathlib import Path
 # All supported clients. Order matters only for display.
 # "claude" is Claude Code (CLI, workspace-scoped); "claude-desktop" is the
 # Claude Desktop GUI app (global config, MCP-only).
-CLIENTS = ["claude", "claude-desktop", "cursor", "droid", "zcode", "agy", "opencode"]
+CLIENTS = ["claude", "claude-desktop", "cursor", "droid", "zcode", "agy", "opencode", "kilo"]
 
 # Slash commands provided by cairn (single source of truth for all client modules).
 _SLASH_COMMANDS = [

--- a/src/cairn/agent_install/clients/kilo.py
+++ b/src/cairn/agent_install/clients/kilo.py
@@ -1,0 +1,73 @@
+"""kilo (Kilo Code CLI) integration: config + install + uninstall, together.
+
+kilo CLI schema (https://kilo.ai/docs/automate/mcp/using-in-cli) — the
+opencode config format: ``kilo.json`` at the project root (or
+``~/.config/kilo/kilo.json`` globally), MCP servers under a top-level
+``"mcp"`` key keyed by name: ``{"mcp": {"<name>": {"type": "local",
+"command": [...]} or {"type": "remote", "url": ...}}}``. The CLI also
+accepts ``kilo.jsonc``/``config.json`` globally and ``.kilo/kilo.json``
+per-project; we write the recommended names only.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from .._common import InstallResult, default_sse_url, resolve_cg_command
+from ..merge import _merge_json_file, _strip_mcp_kilo
+
+
+def kilo_mcp_config_json(transport: str = "stdio", sse_url: str | None = None) -> dict:
+    """MCP server config in kilo's opencode-format schema.
+
+    Args:
+        transport: "stdio" (default) or "sse" (shared daemon).
+        sse_url: when transport="sse", the URL clients should connect to.
+    """
+    if transport == "sse":
+        return {"mcp": {"cairn": {"type": "remote", "url": default_sse_url(sse_url), "enabled": True}}}
+    return {"mcp": {"cairn": {"type": "local", "command": resolve_cg_command() + ["serve"], "enabled": True}}}
+
+
+def _kilo_config_path(workspace: str, scope: str = "workspace") -> Path:
+    """kilo.json location for the install scope.
+
+    ``scope="workspace"`` (default) targets ``<workspace>/kilo.json`` at the
+    project root; ``scope="global"`` targets ``~/.config/kilo/kilo.json``
+    — kilo's recommended global config path, which check_installed probes
+    so a global install is detected.
+    """
+    if scope == "global":
+        return Path.home() / ".config" / "kilo" / "kilo.json"
+    return Path(workspace) / "kilo.json"
+
+
+def install_kilo(workspace: str, force: bool = False, dry_run: bool = False,
+                 transport: str = "stdio", sse_url: str | None = None,
+                 scope: str = "workspace") -> InstallResult:
+    """Wire cairn into the kilo CLI.
+
+    Reach: like opencode, MCP is wired via the config file; skills reach
+    kilo agents via the ``.agents/skills/`` fallback written by
+    install_cross_tool (kilo's config format is opencode-derived).
+    """
+    res = InstallResult("kilo")
+    # config_key="kilo" routes the merge through the opencode-format branch
+    # of _already_installed / _deep_merge (mcp.<name>, command-as-array).
+    p = _kilo_config_path(workspace, scope)
+    _merge_json_file(p, kilo_mcp_config_json(transport, sse_url), force, res,
+                     config_key="kilo", dry_run=dry_run)
+    res.notes.append(f"MCP server written to {p} under the `mcp` key (kilo's schema).")
+    res.notes.append("Skill (golden rules + tool-behaviors) may reach kilo via the .agents/skills/ fallback.")
+    return res
+
+
+def uninstall(ws: Path, res: InstallResult, scope: str = "workspace") -> None:
+    """Remove cairn entries from kilo.json files.
+
+    ``scope="workspace"`` (default, historical) strips ``<ws>/kilo.json``;
+    ``scope="global"`` strips ``~/.config/kilo/kilo.json``; ``scope="all"``
+    strips both.
+    """
+    scopes = ["workspace", "global"] if scope == "all" else [scope]
+    for s in scopes:
+        _strip_mcp_kilo(_kilo_config_path(str(ws), s), res)

--- a/src/cairn/agent_install/detect.py
+++ b/src/cairn/agent_install/detect.py
@@ -98,6 +98,16 @@ def detect_clients(workspace: str) -> list[Detection]:
                              else "~/.config/opencode exists" if (home / ".config" / "opencode").is_dir()
                              else "not found"))
 
+    # Kilo Code CLI: CLI, ~/.config/kilo, or a kilo.json/.kilo in the workspace
+    kilo = (bool(shutil.which("kilo")) or (ws / "kilo.json").exists()
+            or (ws / ".kilo").is_dir() or (home / ".config" / "kilo").is_dir())
+    results.append(Detection("kilo", kilo,
+                             "kilo CLI on PATH" if shutil.which("kilo")
+                             else "kilo.json in workspace" if (ws / "kilo.json").exists()
+                             else ".kilo/ in workspace" if (ws / ".kilo").is_dir()
+                             else "~/.config/kilo exists" if (home / ".config" / "kilo").is_dir()
+                             else "not found"))
+
     return results
 
 
@@ -175,6 +185,12 @@ def check_installed(workspace: str) -> dict[str, bool]:
     result["opencode"] = (
         _json_has_cairn(ws / "opencode.json")
         or _json_has_cairn(home / ".config" / "opencode" / "opencode.json")
+    )
+
+    # kilo: kilo.json (workspace or global) has cairn MCP entry
+    result["kilo"] = (
+        _json_has_cairn(ws / "kilo.json")
+        or _json_has_cairn(home / ".config" / "kilo" / "kilo.json")
     )
 
     return result

--- a/src/cairn/agent_install/merge.py
+++ b/src/cairn/agent_install/merge.py
@@ -228,10 +228,10 @@ def _already_installed(existing: dict, merger: dict, *, config_key: str = "mcpSe
         cur_cmd = cur.get("command", "") + " " + " ".join(cur.get("args", []))
         new_cmd = new.get("command", "") + " " + " ".join(new.get("args", []))
         return cur_cmd.strip() == new_cmd.strip()
-    if config_key == "opencode" and "mcp" in merger:
-        # opencode: mcp.<name> = {type, command:[...], enabled}. The command is
-        # a single array (no separate args), so compare it joined. Remote
-        # servers carry `url` instead; compare that.
+    if config_key in ("opencode", "kilo") and "mcp" in merger:
+        # opencode/kilo: mcp.<name> = {type, command:[...], enabled}. The
+        # command is a single array (no separate args), so compare it joined.
+        # Remote servers carry `url` instead; compare that.
         mcp = existing.get("mcp")
         cur = mcp.get("cairn") if isinstance(mcp, dict) else None
         if not isinstance(cur, dict):
@@ -324,9 +324,9 @@ def _deep_merge(existing: dict, addition: dict, *, config_key: str = "mcpServers
             out["mcp"] = mcp_out
             # Remove stale mcpServers key if present (ZCode doesn't use it).
             out.pop("mcpServers", None)
-        elif key == "mcp" and config_key == "opencode" and isinstance(val, dict):
-            # opencode: mcp.<name> = {...}; replace the named server in place.
-            # Unlike ZCode there is no nested "servers" sub-key.
+        elif key == "mcp" and config_key in ("opencode", "kilo") and isinstance(val, dict):
+            # opencode/kilo: mcp.<name> = {...}; replace the named server in
+            # place. Unlike ZCode there is no nested "servers" sub-key.
             prev = out.get("mcp")
             mcp_out = dict(prev) if isinstance(prev, dict) else {}
             mcp_out.update(val)
@@ -487,6 +487,21 @@ def _strip_mcp_opencode(path: Path, res) -> None:
         if isinstance(stray_data, dict) and "cairn" in (stray_data.get("mcpServers") or {}):
             stray.unlink()
             res.written.append(f"removed stray {stray}")
+
+
+def _strip_mcp_kilo(path: Path, res) -> None:
+    """Remove the cairn server from a kilo.json (opencode-format mcp key)."""
+    data = _load_json_or_none(path)
+    if isinstance(data, dict):
+        mcp = data.get("mcp", {})
+        if "cairn" in mcp:
+            del mcp["cairn"]
+            if mcp:
+                data["mcp"] = mcp
+            else:
+                data.pop("mcp", None)
+            _atomic_write_text(path, json.dumps(data, indent=2) + "\n")
+            res.written.append(f"stripped cairn from {path}")
 
 
 def _strip_hooks(path: Path, res: InstallResult) -> None:

--- a/src/cairn/cli/agents.py
+++ b/src/cairn/cli/agents.py
@@ -9,7 +9,7 @@ from .main import main
 
 @main.command(name="install-agents")
 @click.option("--client", "clients", multiple=True,
-              type=click.Choice(["claude", "claude-desktop", "cursor", "droid", "zcode", "agy", "opencode", "all"]),
+              type=click.Choice(["claude", "claude-desktop", "cursor", "droid", "zcode", "agy", "opencode", "kilo", "all"]),
               help="Override detection: install for these clients (repeatable). Skips the interactive prompt.")
 @click.option("--workspace", "ws_arg", default=None, help="Workspace root (default: cwd).")
 @click.option("--scope", "scope_arg", type=click.Choice(["workspace", "global"]), default=None,
@@ -208,7 +208,7 @@ def install_agents(clients, ws_arg, scope_arg, force, dry_run, git_hooks, sse, s
 
 @main.command(name="uninstall-agents")
 @click.option("--client", "clients", multiple=True,
-              type=click.Choice(["claude", "claude-desktop", "cursor", "droid", "zcode", "agy", "opencode", "all"]),
+              type=click.Choice(["claude", "claude-desktop", "cursor", "droid", "zcode", "agy", "opencode", "kilo", "all"]),
               help="Which clients to remove from (repeatable). Default: detected.")
 @click.option("--scope", "scope", type=click.Choice(["workspace", "global", "all"]), default="workspace",
               show_default=True,

--- a/src/cairn/cli/uninstall.py
+++ b/src/cairn/cli/uninstall.py
@@ -298,7 +298,7 @@ def _dir_size(path: Path) -> int:
 @click.option("--graph-only", is_flag=True, help="Remove graph + knowledge data only.")
 @click.option("--package-only", is_flag=True, help="Remove the cairn binary only.")
 @click.option("--client", "clients", multiple=True,
-              type=click.Choice(["claude", "claude-desktop", "cursor", "droid", "zcode", "agy", "opencode", "all"]),
+              type=click.Choice(["claude", "claude-desktop", "cursor", "droid", "zcode", "agy", "opencode", "kilo", "all"]),
               help="Limit agent removal to these clients (repeatable).")
 @click.option("--scope", "scope", type=click.Choice(["workspace", "global", "all"]), default="workspace",
               show_default=True,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,7 +30,7 @@ from cairn.graph.schema import _apply_schema
 # Names agent-client detection probes via shutil.which (agent_install/detect.py
 # + clients/*). Blocked suite-wide so a developer machine with real CLIs
 # installed behaves like a clean CI runner.
-_AGENT_CLIS = ("claude", "cursor", "droid", "agy", "opencode")
+_AGENT_CLIS = ("claude", "cursor", "droid", "agy", "opencode", "kilo")
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_install_uninstall_fidelity.py
+++ b/tests/test_install_uninstall_fidelity.py
@@ -770,3 +770,76 @@ class TestTransportDefault:
         entry = cfg["mcpServers"]["cairn"]
         assert "command" in entry
         assert "serverUrl" not in entry
+
+
+# --------------------------------------------------------------------------
+# kilo (Kilo Code CLI): opencode-format config, kilo.json paths
+# --------------------------------------------------------------------------
+
+class TestKiloClient:
+    def test_sse_default_writes_remote_entry(self, fake_home, tmp_path, monkeypatch):
+        """Default transport: kilo.json gets mcp.cairn = {type: remote, url}
+        (kilo's documented remote shape — same schema as opencode)."""
+        from cairn.mcp_server import lifecycle as lc
+        ws = tmp_path / "ws"
+        ws.mkdir()
+
+        install(str(ws), clients=["kilo"])
+
+        cfg = json.loads((ws / "kilo.json").read_text(encoding="utf-8"))
+        entry = cfg["mcp"]["cairn"]
+        assert entry["type"] == "remote"
+        assert entry["url"] == f"http://127.0.0.1:{lc.DEFAULT_PORT}/sse"
+        assert entry["enabled"] is True
+
+    def test_stdio_writes_local_command_array(self, fake_home, tmp_path, monkeypatch):
+        """stdio: mcp.cairn = {type: local, command: [...]} — command is a
+        single array per kilo's schema, ending in `serve`."""
+        ws = tmp_path / "ws"
+        ws.mkdir()
+
+        install(str(ws), clients=["kilo"], transport="stdio")
+
+        cfg = json.loads((ws / "kilo.json").read_text(encoding="utf-8"))
+        entry = cfg["mcp"]["cairn"]
+        assert entry["type"] == "local"
+        assert isinstance(entry["command"], list)
+        assert entry["command"][-1] == "serve"
+
+    def test_global_scope_writes_global_config(self, fake_home, tmp_path, monkeypatch):
+        """scope=global lands in ~/.config/kilo/kilo.json (kilo's global
+        config path) and is detected by check_installed."""
+        ws = tmp_path / "ws"
+        ws.mkdir()
+
+        install(str(ws), clients=["kilo"], scope="global")
+
+        global_cfg = fake_home / ".config" / "kilo" / "kilo.json"
+        assert global_cfg.exists(), "scope=global must write ~/.config/kilo/kilo.json"
+        assert not (ws / "kilo.json").exists(), "scope=global must not write the workspace"
+        assert "cairn" in json.loads(global_cfg.read_text(encoding="utf-8"))["mcp"]
+        assert check_installed(str(ws))["kilo"], \
+            "a global install must be detected by check_installed (it probes the global path)"
+
+    def test_workspace_install_detected(self, fake_home, tmp_path, monkeypatch):
+        ws = tmp_path / "ws"
+        ws.mkdir()
+
+        install(str(ws), clients=["kilo"])
+        assert check_installed(str(ws))["kilo"]
+
+    def test_uninstall_strips_cairn_preserves_others(self, fake_home, tmp_path, monkeypatch):
+        ws = tmp_path / "ws"
+        ws.mkdir()
+        install(str(ws), clients=["kilo"])
+
+        p = ws / "kilo.json"
+        data = json.loads(p.read_text(encoding="utf-8"))
+        data["mcp"]["other-server"] = {"type": "local", "command": ["echo"]}
+        p.write_text(json.dumps(data))
+
+        uninstall(str(ws), clients=["kilo"])
+
+        after = json.loads(p.read_text(encoding="utf-8"))
+        assert "cairn" not in after.get("mcp", {})
+        assert after["mcp"]["other-server"] == {"type": "local", "command": ["echo"]}


### PR DESCRIPTION
## Summary

`install-agents` / `uninstall-agents` now support the **kilo** CLI (Kilo Code). kilo documents the opencode config format: MCP servers under a top-level `mcp` key in `kilo.json` — `{type: "remote", url}` under the SSE-by-default transport, `{type: "local", command: [...]}` for `--stdio`. Workspace scope writes `<ws>/kilo.json`; global writes `~/.config/kilo/kilo.json`. Skills reach kilo only via the cross-tool `.agents/` fallback (nothing documented for the CLI), same tier as agy.

## Change type

- [x] Feature / improvement
- [ ] Bugfix
- [ ] Refactor (no behavior change)
- [ ] Docs / chore / CI

## Audit checklist

Author — confirm before requesting review (procedure: `docs/review-checklist.md`):

- [x] **Blast radius checked** — new symbols only (`install_kilo`, `kilo_mcp_config_json`, `_strip_mcp_kilo`, `_kilo_config_path`): no existing callers. Existing-code touches are additive: CLIENTS append, dispatcher dict entries, `config_key in ("opencode", "kilo")` tuple extension (opencode behavior unchanged — verified by the existing opencode tests staying green), detect additions, CLI choice lists. No public API break → no `cross_repo_deps` needed.
- [x] **Layering respected** — kilo.py mirrors the opencode/zcode client-module pattern (per-client config shapes live in `clients/`); the reach table comment in `__init__.py` gains a row; README/docs enumerations updated.
- [x] **Graph updated** — full `cairn build` re-ran (incremental update hit the known stale no-op); `cairn def install_kilo` resolves at `clients/kilo.py:44`.
- [x] **Memory recorded** — pattern: kilo speaks the opencode config format; _AGENT_CLIS must extend for every probed CLI (hygiene guard).
- [x] **Fallback/perf paths** — N/A (no fallback/perf path touched).
- [x] **Tests** — TDD: 5 kilo tests written first, all failed with `ValueError: Unknown clients: ['kilo']`, then green. Covers: SSE remote shape (exact URL), stdio local command-array, global scope path + detection, workspace detection, uninstall strip preserving other servers. Suite-hygiene guard surfaced the missing conftest `_AGENT_CLIS` entry — fixed, guard green. Full suite: 2178 passed, 1 skipped. Hermetic (fake_home; `kilo` blocked suite-wide via conftest).
- [x] **CHANGELOG** — `[Unreleased]` → `### Added` entry.
- [x] **Gates green** — `pre-commit run --all-files` all 7 hooks Passed; PR title conventional; no new mypy/bandit findings (no subprocess/exec added — kilo registers via config file, not CLI).

## Blast-radius note

None — all new symbols; the only shared-code change (`config_key in ("opencode", "kilo")`) is a widening that leaves opencode's behavior identical (existing opencode tests pin it).

## Verification

- RED→GREEN: `uv run pytest tests/test_install_uninstall_fidelity.py::TestKiloClient` — 5 failed (unknown client) → 5 passed.
- Schema verified against kilo's official MCP docs (opencode format, mcp key, local/remote types, command-as-array, ~/.config/kilo/kilo.json global path).
- Full suite `uv run pytest -q` → 2178 passed, 1 skipped; pre-commit all Passed.