### PR TITLE
docs: prepare 0.14.4 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 > `0.4.0` entry below is the inaugural documented release; entries from future
 > releases will be appended here incrementally.
 
-## [Unreleased]
+## [0.14.4] - 2026-08-26
 
 ### Added
 - `install-agents` now supports the **kilo** CLI (Kilo Code): MCP wired

--- a/README.md
+++ b/README.md
@@ -54,7 +54,9 @@ Detects which AI clients you have (Claude Code, Cursor, ZCode, Droid, Claude
 Desktop, opencode, agy, kilo), shows what's already wired, and prompts for scope:
 `workspace` (per-project `./.claude/`, `./.cursor/` …) or `global`
 (`~/.claude/` — every project inherits it). Non-interactive:
-`cairn install-agents --yes --scope global`. Manual wiring is one JSON block:
+`cairn install-agents --yes --scope global`. Manual wiring is one JSON block
+(stdio — or point clients that support SSE at `http://127.0.0.1:9876/sse`
+after `cairn serve start`, which is what install-agents does by default):
 
 ```json
 { "mcpServers": { "cairn": { "command": "cairn", "args": ["serve"] } } }

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -479,7 +479,7 @@ stdout.
 
 | Command | Description |
 |---------|-------------|
-| `cairn install-agents` | Wire cairn into detected AI coding clients (Claude Code/Claude Desktop/Cursor/Droid/ZCode). |
+| `cairn install-agents` | Wire cairn into detected AI coding clients (Claude Code/Claude Desktop/Cursor/Droid/ZCode/opencode/agy/kilo). |
 | `cairn uninstall-agents` | Remove cairn entries from AI client configs (idempotent). |
 | `cairn uninstall` | Full teardown: agent wiring, hooks, graph store, and the `cairn` binary. |
 | `cairn version` | Print the installed cairn version. |


### PR DESCRIPTION
## Summary

Release prep for 0.14.4: folds the accumulated `[Unreleased]` entries (kilo client support + the three SSE-transport fixes from #63/#64) into a dated `## [0.14.4] - 2026-08-26` section for the release-notes awk, plus two doc corrections found in the pre-release doc sweep: `docs/cli-reference.md`'s command-table row was missing opencode/agy/kilo, and README's manual JSON block now notes the SSE-default alternative (`cairn serve start` → `http://127.0.0.1:9876/sse`).

Doc verification run: `scripts/check_doc_links.py` → 0 broken links (one pre-existing advisory orphan); README/docs client enumerations current; CLI help verified to list kilo; SSE port matches `lifecycle.DEFAULT_PORT` (9876).

## Change type

- [ ] Feature / improvement
- [ ] Bugfix
- [ ] Refactor (no behavior change)
- [x] Docs / chore / CI

## Audit checklist

- [x] **Blast radius checked** — docs-only; no symbols touched.
- [x] **Layering respected** — N/A.
- [x] **Graph updated** — no code changes; graph untouched.
- [x] **Memory recorded** — N/A (no decision/pattern; release mechanics already in memory).
- [x] **Fallback/perf paths** — N/A.
- [x] **Tests** — docs-only; full suite green on both parent commits (#63, #64 CI runs).
- [x] **CHANGELOG** — this PR *is* the changelog prep (`[0.14.4]` dated section; awk-extractable).
- [x] **Gates green** — pre-commit (docs pass through unchanged hooks); conventional title.

## Blast-radius note

None — markdown only.

## Verification

- `uv run python scripts/check_doc_links.py` → TOTAL broken: 0.
- `awk -v v="0.14.4" ...` section extraction verified by the dated-heading format matching release.yml's expectations.