### PR TITLE
chore: sync main with 0.14.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "cairn-intel"
-version = "0.14.3"
+version = "0.14.4"
 description = "Local codebase intelligence system: structural graph + compass + wiki + agent memory"
 readme = "README.md"
 license = "MIT"
@@ -211,7 +211,7 @@ select = ["F"]
 # The custom template (.cz_templates/keepachangelog.j2) renders that draft in
 # the existing `## [X.Y.Z] - YYYY-MM-DD` format rather than commitizen's
 # default `## X.Y.Z (YYYY-MM-DD)`.
-version = "0.14.3"
+version = "0.14.4"
 version_scheme = "pep440"
 tag_format = "v$version"
 update_changelog_on_bump = false

--- a/src/cairn/__init__.py
+++ b/src/cairn/__init__.py
@@ -1,3 +1,3 @@
 """Cairn: local codebase intelligence system."""
-__version__ = "0.14.3"
+__version__ = "0.14.4"
 __package_name__ = "cairn-intel"


### PR DESCRIPTION
Release sync: lands the `bump: version 0.14.3 → 0.14.4` commit (version files only) so main matches the v0.14.4 tag. CHANGELOG was finalized in #65; content = PRs #63/#64 (SSE transport fixes + kilo client support). Docs/chore only — no review checklist beyond gates.