### PR TITLE
docs: document env-propagation surfaces (config --json, doctor environment check, install-agents verification)

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -14,7 +14,7 @@ are read at process start, not per call.
 | `cairn update [--file <path>]` | incremental reindex (git-diff driven) |
 | `cairn stats` | graph statistics |
 | `cairn checkpoint` | snapshot the store |
-| `cairn config` | show effective configuration |
+| `cairn config` | show effective configuration (`--json` emits `cairn_home`/`workspace`/`db`/`knowledge` as one JSON document — read-only, registers nothing; the scripting/probe surface) |
 | `cairn uninstall` | remove cairn integration artifacts |
 
 ## Query
@@ -66,9 +66,9 @@ Group: `cairn memory …`
 
 | Command | Purpose |
 |---|---|
-| `cairn serve run|start|stop|status|restart` | MCP server (stdio foreground / SSE daemon `:9876`) |
+| `cairn serve run|start|stop|status|restart` | MCP server (stdio foreground / SSE daemon `:9876`). `start`/`stop`/`restart` manage the macOS launchd LaunchAgent; `start` embeds `CAIRN_HOME`/`CAIRN_WORKSPACE`/`CAIRN_DB`/`CAIRN_KNOWLEDGE` into the plist when a custom home is in effect. On Linux these exit 1 — run `cairn serve --port 9876` under a process supervisor, or prefer stdio. |
 | `cairn dashboard [--db] [--port]` | loopback dashboard `:8765` (read-only views + Settings) |
-| `cairn install-agents` / `uninstall-agents` | wire cairn into AI clients (claude, droid, zcode, cursor, opencode, kilo, omp, agy, claude-desktop) |
+| `cairn install-agents` / `uninstall-agents` | wire cairn into AI clients (claude, droid, zcode, cursor, opencode, kilo, omp, agy, claude-desktop). With a custom `CAIRN_HOME`, generated stdio registrations embed `env.CAIRN_HOME` (claude global scope via `claude mcp add -e`), hook commands embed the assignment, and each written stdio registration is spawn-verified — the report shows per-client `verify: PASS/FAIL` naming both stores on mismatch. SSE and CLI-registered clients are skipped with a note; `--dry-run` never spawns. |
 
 ## Compass / wiki / tasks / dataflow
 
@@ -84,7 +84,7 @@ Group: `cairn memory …`
 | Command | Purpose |
 |---|---|
 | `cairn status` | build state, parse errors, resource health |
-| `cairn doctor` | degradation check (exit 0 = PASS/WARN, 1 = FAIL) |
+| `cairn doctor` | degradation check (exit 0 = PASS/WARN, 1 = FAIL). 10 checks: the 9 store-internal ones plus `environment` — store existence, client-registration consistency (FAIL on a provable wrong-store or unreachable SSE endpoint, WARN on stale missing-env registrations), platform/transport supportability (SSE on non-macOS ⇒ WARN), binary coherence. Emitted last, also on the db-unavailable degraded path. |
 | `cairn metrics` / `report` | tool-metrics and health reports |
 | `cairn validate` / `validate-paths` / `verify` | store integrity checks |
 | `cairn bench` | performance suites |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -25,13 +25,29 @@ store directory is `sha256(workspace_path)[:16]` under `CAIRN_HOME`
 `CAIRN_HOME` binds at process start — in-process env changes do nothing; use
 `--db` / `--workspace` flags instead.
 
+**Custom `CAIRN_HOME` and agent integrations.** Resolution is
+process-relative, so every process spawned on cairn's behalf must agree on
+`CAIRN_HOME`. Generated integrations handle this automatically: with a
+non-default home, `cairn install-agents` embeds `env.CAIRN_HOME` into every
+stdio MCP registration it writes (the Claude global-scope registration uses
+`claude mcp add -e`; droid's CLI path degrades to a warning — use its
+workspace-scope file registration), prefixes generated hook commands with
+the assignment, adds an `export` line to the git post-commit template, and
+`cairn serve start` propagates it into the LaunchAgent plist. With the
+default home nothing is added — generated configs are unchanged. Re-run
+`cairn install-agents` after moving the store. Verify any environment with
+`cairn config --json` (what *this* environment resolves) and
+`cairn doctor` (the `environment` check audits registration consistency,
+platform/transport supportability, and binary coherence; a missing store
+fails naming the resolved path, the env chain, and the remediation).
+
 ## Environment variables
 
 **Paths & identity**
 
 | Var | Effect |
 |---|---|
-| `CAIRN_HOME` | central home dir (default `~/.cairn`) |
+| `CAIRN_HOME` | central home dir (default `~/.cairn`; a custom value is embedded into generated agent registrations — see [Store resolution](#store-resolution)) |
 | `CAIRN_WORKSPACE` | explicit workspace root |
 | `CAIRN_DB` / `CAIRN_KNOWLEDGE` | hard path overrides |
 | `CAIRN_LIB` | shared dependency library path |


### PR DESCRIPTION
## Summary

Documents the surfaces shipped in #71 (Closes #70 follow-through):
- `docs/cli-reference.md`: `cairn config --json` probe, the doctor `environment` check (10-check list, mixed severity), `serve start` plist propagation + Linux guidance, and `install-agents` env embedding + spawn-verification behavior.
- `docs/configuration.md`: a "Custom `CAIRN_HOME` and agent integrations" section under Store resolution — the propagation contract, what each generated surface carries, the re-run-after-moving rule, and the `config --json`/`doctor` verification commands; the `CAIRN_HOME` env row now points at it.

## Change type

- [ ] Feature / improvement
- [ ] Bugfix
- [ ] Refactor (no behavior change)
- [x] Docs / chore / CI

## Audit checklist

- [x] **Blast radius checked** — docs-only; no code or public surface changed.
- [x] **Layering respected** — n/a (docs).
- [x] **Graph updated** — n/a (no code change; graph current from #71).
- [x] **Memory recorded** — the standing docs→wiki sync rule is recorded; wiki sync happens in the same pass (see below).
- [x] **Fallback/perf paths** — n/a (docs-only).
- [x] **Tests** — n/a (docs-only); pre-commit all gates pass.
- [x] **CHANGELOG** — n/a (docs-only; the feature entry landed with #71).
- [x] **Gates green** — pre-commit green; conventional title.

## Verification

All documented claims verified against the shipped implementation during #71's closing audit (2602 tests green): `cairn config --json` 4-key output, doctor 10-name sequence, plist env propagation, install-verify PASS/FAIL rendering.
