### PR TITLE
docs: replace README ASCII architecture diagram with editorial SVG

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,25 +201,7 @@ dispatch hops — polymorphism that grep fundamentally cannot see.
 
 ## How It Works
 
-```text
- ┌─────────────────────────── your AI agents ───────────────────────────┐
- │   Claude Code · Cursor · ZCode · Droid · opencode · Claude Desktop   │
- └──────────────┬────────────────────────────────────▲──────────────────┘
-        MCP (stdio) · 27 tools                      │  results: verbatim source,
-                ▼                                   │  call paths, blast radius
-        ┌────────────────────────┐        ┌─────────┴────────┐
-        │    cairn MCP server    │◀──────▶│    cairn CLI     │
-        └───────────┬────────────┘        └──────────────────┘
-                    ▼
- ┌────────────────────── one local SQLite store (~/.cairn) ─────────────┐
- │ graph: symbols + exact/ambiguous/unresolved edges · compass + wiki   │
- │ tribal memory · knowledge (OKF) · embeddings (optional [semantic])   │
- └─────────────────────────────────▲────────────────────────────────────┘
-                                   │ candidate docs only — critic gate
-                     LLM task queue (never in the query path):
-                     every generated doc fact-checked against the graph
-                     before it lands; hallucinated symbols rejected
-```
+![cairn architecture: AI agents query the MCP server and CLI, which read one local SQLite store; an LLM task queue runs off-path, admitted only through a critic gate](docs/diagrams/readme-architecture.svg)
 
 The query path is deterministic: tree-sitter parsing → SQLite graph →
 FTS5/BM25 fused with vectors (RRF, always on when embeddings exist) and a

--- a/docs/diagrams/readme-architecture.html
+++ b/docs/diagrams/readme-architecture.html
@@ -1,0 +1,131 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>cairn architecture</title>
+<link href="https://fonts.googleapis.com/css2?family=Geist:wght@400;500;600&family=Geist+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+<style>
+  body { margin: 0; padding: 1.5rem; background: #f5f5f5; }
+</style>
+</head>
+<body>
+<svg viewBox="0 0 960 600" width="960" height="600" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="readme-arch-title readme-arch-desc">
+  <title id="readme-arch-title">cairn: agents, MCP server, CLI, and the local store</title>
+  <desc id="readme-arch-desc">Architecture diagram showing AI agents querying the cairn MCP server and CLI, which read one local SQLite store; an LLM task queue runs off-path, its candidate documents admitted only through a critic gate that fact-checks against the graph.</desc>
+  <defs>
+    <marker id="arrow" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto">
+      <polygon points="0 0, 8 3, 0 6" fill="#4f5d75"/>
+    </marker>
+    <marker id="arrow-accent" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto">
+      <polygon points="0 0, 8 3, 0 6" fill="#eb6c36"/>
+    </marker>
+  </defs>
+
+  <!-- background -->
+  <rect width="100%" height="100%" fill="#f5f5f5"/>
+
+  <!-- zone: one local SQLite store (drawn before arrows and nodes) -->
+  <rect x="120" y="288" width="720" height="136" rx="8" fill="rgba(45,49,66,0.02)" stroke="rgba(45,49,66,0.10)" stroke-width="0.8"/>
+  <rect x="128" y="292" width="368" height="12" rx="2" fill="#f5f5f5"/>
+  <text x="132" y="302" fill="rgba(45,49,66,0.40)" font-size="8" font-family="'Geist Mono', ui-monospace, 'SF Mono', Menlo, Consolas, monospace" letter-spacing="0.14em">ONE LOCAL SQLITE STORE · ~/.CAIRN</text>
+
+  <!-- arrows (before nodes) -->
+  <!-- agents -> MCP server: query -->
+  <line x1="320" y1="112" x2="320" y2="164" stroke="#4f5d75" stroke-width="1.2" marker-end="url(#arrow)"/>
+  <!-- MCP server -> agents: results -->
+  <line x1="368" y1="168" x2="368" y2="116" stroke="#4f5d75" stroke-width="1.2" marker-end="url(#arrow)"/>
+  <!-- MCP server -> store: queries -->
+  <line x1="320" y1="232" x2="320" y2="284" stroke="#4f5d75" stroke-width="1.2" marker-end="url(#arrow)"/>
+  <!-- CLI -> store: commands -->
+  <line x1="640" y1="232" x2="640" y2="284" stroke="#4f5d75" stroke-width="1.2" marker-end="url(#arrow)"/>
+  <!-- LLM task queue -> critic gate: candidates -->
+  <line x1="360" y1="488" x2="476" y2="488" stroke="#4f5d75" stroke-width="1.2" marker-end="url(#arrow)"/>
+  <!-- critic gate -> store: fact-check (dashed, reads the graph) -->
+  <line x1="552" y1="456" x2="552" y2="428" stroke="#4f5d75" stroke-width="1" stroke-dasharray="4,3" marker-end="url(#arrow)"/>
+  <!-- critic gate -> store: verified writes (accent) -->
+  <line x1="616" y1="456" x2="616" y2="428" stroke="#eb6c36" stroke-width="1.2" marker-end="url(#arrow-accent)"/>
+
+  <!-- arrow labels (masks with 6-10px gap to their stroke) -->
+  <rect x="232" y="132" width="72" height="12" rx="2" fill="#f5f5f5"/>
+  <text x="304" y="142" fill="#7a8399" font-size="8" text-anchor="end" font-family="'Geist Mono', ui-monospace, 'SF Mono', Menlo, Consolas, monospace" letter-spacing="0.06em">MCP · STDIO</text>
+  <rect x="376" y="132" width="60" height="12" rx="2" fill="#f5f5f5"/>
+  <text x="380" y="142" fill="#7a8399" font-size="8" font-family="'Geist Mono', ui-monospace, 'SF Mono', Menlo, Consolas, monospace" letter-spacing="0.06em">RESULTS</text>
+  <rect x="232" y="252" width="64" height="12" rx="2" fill="#f5f5f5"/>
+  <text x="304" y="262" fill="#7a8399" font-size="8" text-anchor="end" font-family="'Geist Mono', ui-monospace, 'SF Mono', Menlo, Consolas, monospace" letter-spacing="0.06em">QUERIES</text>
+  <rect x="648" y="252" width="80" height="12" rx="2" fill="#f5f5f5"/>
+  <text x="652" y="262" fill="#7a8399" font-size="8" font-family="'Geist Mono', ui-monospace, 'SF Mono', Menlo, Consolas, monospace" letter-spacing="0.06em">COMMANDS</text>
+  <rect x="384" y="466" width="84" height="12" rx="2" fill="#f5f5f5"/>
+  <text x="426" y="476" fill="#7a8399" font-size="8" text-anchor="middle" font-family="'Geist Mono', ui-monospace, 'SF Mono', Menlo, Consolas, monospace" letter-spacing="0.06em">CANDIDATES</text>
+  <rect x="480" y="432" width="64" height="12" rx="2" fill="#f5f5f5"/>
+  <text x="544" y="442" fill="#7a8399" font-size="8" text-anchor="end" font-family="'Geist Mono', ui-monospace, 'SF Mono', Menlo, Consolas, monospace" letter-spacing="0.06em">FACT-CHECK</text>
+  <rect x="624" y="432" width="124" height="12" rx="2" fill="#f5f5f5"/>
+  <text x="628" y="442" fill="#b25424" font-size="8" font-family="'Geist Mono', ui-monospace, 'SF Mono', Menlo, Consolas, monospace" letter-spacing="0.06em">VERIFIED WRITES</text>
+
+  <!-- nodes -->
+  <!-- your AI agents (input) -->
+  <rect x="280" y="48" width="400" height="64" rx="6" fill="#f5f5f5"/>
+  <rect x="280" y="48" width="400" height="64" rx="6" fill="rgba(79,93,117,0.10)" stroke="rgba(122,131,153,0.60)" stroke-width="1"/>
+  <text x="480" y="76" fill="#2d3142" font-size="12" font-weight="600" text-anchor="middle" font-family="'Geist', -apple-system, 'Segoe UI', 'Helvetica Neue', Arial, sans-serif">Your AI agents</text>
+  <text x="480" y="94" fill="#4f5d75" font-size="9" text-anchor="middle" font-family="'Geist Mono', ui-monospace, 'SF Mono', Menlo, Consolas, monospace">Claude Code · Cursor · ZCode · Droid · opencode · Claude Desktop</text>
+
+  <!-- cairn MCP server (api) -->
+  <rect x="200" y="168" width="240" height="64" rx="6" fill="#f5f5f5"/>
+  <rect x="200" y="168" width="240" height="64" rx="6" fill="#ffffff" stroke="#2d3142" stroke-width="1"/>
+  <text x="320" y="196" fill="#2d3142" font-size="12" font-weight="600" text-anchor="middle" font-family="'Geist', -apple-system, 'Segoe UI', 'Helvetica Neue', Arial, sans-serif">cairn MCP server</text>
+  <text x="320" y="214" fill="#4f5d75" font-size="9" text-anchor="middle" font-family="'Geist Mono', ui-monospace, 'SF Mono', Menlo, Consolas, monospace">27 tools · graph queries</text>
+
+  <!-- cairn CLI (api) -->
+  <rect x="520" y="168" width="240" height="64" rx="6" fill="#f5f5f5"/>
+  <rect x="520" y="168" width="240" height="64" rx="6" fill="#ffffff" stroke="#2d3142" stroke-width="1"/>
+  <text x="640" y="196" fill="#2d3142" font-size="12" font-weight="600" text-anchor="middle" font-family="'Geist', -apple-system, 'Segoe UI', 'Helvetica Neue', Arial, sans-serif">cairn CLI</text>
+  <text x="640" y="214" fill="#4f5d75" font-size="9" text-anchor="middle" font-family="'Geist Mono', ui-monospace, 'SF Mono', Menlo, Consolas, monospace">human mirror, same store</text>
+
+  <!-- store contents (store cells) -->
+  <rect x="136" y="328" width="160" height="64" rx="6" fill="#f5f5f5"/>
+  <rect x="136" y="328" width="160" height="64" rx="6" fill="rgba(45,49,66,0.05)" stroke="rgba(79,93,117,0.60)" stroke-width="1"/>
+  <text x="216" y="356" fill="#2d3142" font-size="12" font-weight="600" text-anchor="middle" font-family="'Geist', -apple-system, 'Segoe UI', 'Helvetica Neue', Arial, sans-serif">Structural graph</text>
+  <text x="216" y="374" fill="#4f5d75" font-size="9" text-anchor="middle" font-family="'Geist Mono', ui-monospace, 'SF Mono', Menlo, Consolas, monospace">symbols · labeled edges</text>
+
+  <rect x="312" y="328" width="160" height="64" rx="6" fill="#f5f5f5"/>
+  <rect x="312" y="328" width="160" height="64" rx="6" fill="rgba(45,49,66,0.05)" stroke="rgba(79,93,117,0.60)" stroke-width="1"/>
+  <text x="392" y="356" fill="#2d3142" font-size="12" font-weight="600" text-anchor="middle" font-family="'Geist', -apple-system, 'Segoe UI', 'Helvetica Neue', Arial, sans-serif">Compass + wiki</text>
+  <text x="392" y="374" fill="#4f5d75" font-size="9" text-anchor="middle" font-family="'Geist Mono', ui-monospace, 'SF Mono', Menlo, Consolas, monospace">generated · gated</text>
+
+  <rect x="488" y="328" width="160" height="64" rx="6" fill="#f5f5f5"/>
+  <rect x="488" y="328" width="160" height="64" rx="6" fill="rgba(45,49,66,0.05)" stroke="rgba(79,93,117,0.60)" stroke-width="1"/>
+  <text x="568" y="356" fill="#2d3142" font-size="12" font-weight="600" text-anchor="middle" font-family="'Geist', -apple-system, 'Segoe UI', 'Helvetica Neue', Arial, sans-serif">Memory + knowledge</text>
+  <text x="568" y="374" fill="#4f5d75" font-size="9" text-anchor="middle" font-family="'Geist Mono', ui-monospace, 'SF Mono', Menlo, Consolas, monospace">tribal · OKF bundle</text>
+
+  <rect x="664" y="328" width="160" height="64" rx="6" fill="#f5f5f5"/>
+  <rect x="664" y="328" width="160" height="64" rx="6" fill="rgba(45,49,66,0.05)" stroke="rgba(79,93,117,0.60)" stroke-width="1"/>
+  <text x="744" y="356" fill="#2d3142" font-size="12" font-weight="600" text-anchor="middle" font-family="'Geist', -apple-system, 'Segoe UI', 'Helvetica Neue', Arial, sans-serif">Embeddings</text>
+  <text x="744" y="374" fill="#4f5d75" font-size="9" text-anchor="middle" font-family="'Geist Mono', ui-monospace, 'SF Mono', Menlo, Consolas, monospace">optional [semantic]</text>
+
+  <!-- LLM task queue (off-path, optional/async treatment) -->
+  <rect x="120" y="456" width="240" height="64" rx="6" fill="#f5f5f5"/>
+  <rect x="120" y="456" width="240" height="64" rx="6" fill="rgba(45,49,66,0.02)" stroke="rgba(45,49,66,0.30)" stroke-width="1" stroke-dasharray="4,3"/>
+  <text x="240" y="484" fill="#2d3142" font-size="12" font-weight="600" text-anchor="middle" font-family="'Geist', -apple-system, 'Segoe UI', 'Helvetica Neue', Arial, sans-serif">LLM task queue</text>
+  <text x="240" y="502" fill="#4f5d75" font-size="9" text-anchor="middle" font-family="'Geist Mono', ui-monospace, 'SF Mono', Menlo, Consolas, monospace">off-path — never answers queries</text>
+
+  <!-- critic gate (focal) -->
+  <rect x="480" y="456" width="240" height="64" rx="6" fill="#f5f5f5"/>
+  <rect x="480" y="456" width="240" height="64" rx="6" fill="rgba(235,108,54,0.08)" stroke="#eb6c36" stroke-width="1"/>
+  <text x="600" y="484" fill="#2d3142" font-size="12" font-weight="600" text-anchor="middle" font-family="'Geist', -apple-system, 'Segoe UI', 'Helvetica Neue', Arial, sans-serif">Deterministic critic gate</text>
+  <text x="600" y="502" fill="#b25424" font-size="9" text-anchor="middle" font-family="'Geist Mono', ui-monospace, 'SF Mono', Menlo, Consolas, monospace">fact-checks every symbol · rejects hallucinations</text>
+
+  <!-- legend: horizontal strip at the bottom -->
+  <line x1="120" y1="548" x2="840" y2="548" stroke="rgba(45,49,66,0.10)" stroke-width="0.8"/>
+  <text x="120" y="568" fill="#4f5d75" font-size="8" font-family="'Geist Mono', ui-monospace, 'SF Mono', Menlo, Consolas, monospace" letter-spacing="0.14em">LEGEND</text>
+  <rect x="200" y="558" width="16" height="12" rx="2" fill="rgba(79,93,117,0.10)" stroke="rgba(122,131,153,0.60)" stroke-width="0.8"/>
+  <text x="224" y="568" fill="#4f5d75" font-size="8" font-family="'Geist Mono', ui-monospace, 'SF Mono', Menlo, Consolas, monospace">your agents</text>
+  <rect x="328" y="558" width="16" height="12" rx="2" fill="#ffffff" stroke="#2d3142" stroke-width="0.8"/>
+  <text x="352" y="568" fill="#4f5d75" font-size="8" font-family="'Geist Mono', ui-monospace, 'SF Mono', Menlo, Consolas, monospace">cairn surface</text>
+  <rect x="476" y="558" width="16" height="12" rx="2" fill="rgba(45,49,66,0.05)" stroke="rgba(79,93,117,0.60)" stroke-width="0.8"/>
+  <text x="500" y="568" fill="#4f5d75" font-size="8" font-family="'Geist Mono', ui-monospace, 'SF Mono', Menlo, Consolas, monospace">store contents</text>
+  <rect x="628" y="558" width="16" height="12" rx="2" fill="rgba(45,49,66,0.02)" stroke="rgba(45,49,66,0.30)" stroke-width="0.8" stroke-dasharray="4,3"/>
+  <text x="652" y="568" fill="#4f5d75" font-size="8" font-family="'Geist Mono', ui-monospace, 'SF Mono', Menlo, Consolas, monospace">off-path</text>
+  <rect x="744" y="558" width="16" height="12" rx="2" fill="rgba(235,108,54,0.08)" stroke="#eb6c36" stroke-width="0.8"/>
+  <text x="768" y="568" fill="#4f5d75" font-size="8" font-family="'Geist Mono', ui-monospace, 'SF Mono', Menlo, Consolas, monospace">the one gate</text>
+</svg>
+</body>
+</html>

--- a/docs/diagrams/readme-architecture.svg
+++ b/docs/diagrams/readme-architecture.svg
@@ -1,0 +1,120 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg viewBox="0 0 960 600" width="960" height="600" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="readme-arch-title readme-arch-desc">
+  <title id="readme-arch-title">cairn: agents, MCP server, CLI, and the local store</title>
+  <desc id="readme-arch-desc">Architecture diagram showing AI agents querying the cairn MCP server and CLI, which read one local SQLite store; an LLM task queue runs off-path, its candidate documents admitted only through a critic gate that fact-checks against the graph.</desc>
+  <defs>
+    <style>@import url('https://fonts.googleapis.com/css2?family=Geist:wght@400;500;600&amp;family=Geist+Mono:wght@400;500;600&amp;display=swap');</style>
+    <marker id="arrow" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto">
+      <polygon points="0 0, 8 3, 0 6" fill="#4f5d75"/>
+    </marker>
+    <marker id="arrow-accent" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto">
+      <polygon points="0 0, 8 3, 0 6" fill="#eb6c36"/>
+    </marker>
+  </defs>
+
+  <!-- background -->
+  <rect width="100%" height="100%" fill="#f5f5f5"/>
+
+  <!-- zone: one local SQLite store (drawn before arrows and nodes) -->
+  <rect x="120" y="288" width="720" height="136" rx="8" fill="rgba(45,49,66,0.02)" stroke="rgba(45,49,66,0.10)" stroke-width="0.8"/>
+  <rect x="128" y="292" width="368" height="12" rx="2" fill="#f5f5f5"/>
+  <text x="132" y="302" fill="rgba(45,49,66,0.40)" font-size="8" font-family="'Geist Mono', ui-monospace, 'SF Mono', Menlo, Consolas, monospace" letter-spacing="0.14em">ONE LOCAL SQLITE STORE · ~/.CAIRN</text>
+
+  <!-- arrows (before nodes) -->
+  <!-- agents -> MCP server: query -->
+  <line x1="320" y1="112" x2="320" y2="164" stroke="#4f5d75" stroke-width="1.2" marker-end="url(#arrow)"/>
+  <!-- MCP server -> agents: results -->
+  <line x1="368" y1="168" x2="368" y2="116" stroke="#4f5d75" stroke-width="1.2" marker-end="url(#arrow)"/>
+  <!-- MCP server -> store: queries -->
+  <line x1="320" y1="232" x2="320" y2="284" stroke="#4f5d75" stroke-width="1.2" marker-end="url(#arrow)"/>
+  <!-- CLI -> store: commands -->
+  <line x1="640" y1="232" x2="640" y2="284" stroke="#4f5d75" stroke-width="1.2" marker-end="url(#arrow)"/>
+  <!-- LLM task queue -> critic gate: candidates -->
+  <line x1="360" y1="488" x2="476" y2="488" stroke="#4f5d75" stroke-width="1.2" marker-end="url(#arrow)"/>
+  <!-- critic gate -> store: fact-check (dashed, reads the graph) -->
+  <line x1="552" y1="456" x2="552" y2="428" stroke="#4f5d75" stroke-width="1" stroke-dasharray="4,3" marker-end="url(#arrow)"/>
+  <!-- critic gate -> store: verified writes (accent) -->
+  <line x1="616" y1="456" x2="616" y2="428" stroke="#eb6c36" stroke-width="1.2" marker-end="url(#arrow-accent)"/>
+
+  <!-- arrow labels (masks with 6-10px gap to their stroke) -->
+  <rect x="232" y="132" width="72" height="12" rx="2" fill="#f5f5f5"/>
+  <text x="304" y="142" fill="#7a8399" font-size="8" text-anchor="end" font-family="'Geist Mono', ui-monospace, 'SF Mono', Menlo, Consolas, monospace" letter-spacing="0.06em">MCP · STDIO</text>
+  <rect x="376" y="132" width="60" height="12" rx="2" fill="#f5f5f5"/>
+  <text x="380" y="142" fill="#7a8399" font-size="8" font-family="'Geist Mono', ui-monospace, 'SF Mono', Menlo, Consolas, monospace" letter-spacing="0.06em">RESULTS</text>
+  <rect x="232" y="252" width="64" height="12" rx="2" fill="#f5f5f5"/>
+  <text x="304" y="262" fill="#7a8399" font-size="8" text-anchor="end" font-family="'Geist Mono', ui-monospace, 'SF Mono', Menlo, Consolas, monospace" letter-spacing="0.06em">QUERIES</text>
+  <rect x="648" y="252" width="80" height="12" rx="2" fill="#f5f5f5"/>
+  <text x="652" y="262" fill="#7a8399" font-size="8" font-family="'Geist Mono', ui-monospace, 'SF Mono', Menlo, Consolas, monospace" letter-spacing="0.06em">COMMANDS</text>
+  <rect x="384" y="466" width="84" height="12" rx="2" fill="#f5f5f5"/>
+  <text x="426" y="476" fill="#7a8399" font-size="8" text-anchor="middle" font-family="'Geist Mono', ui-monospace, 'SF Mono', Menlo, Consolas, monospace" letter-spacing="0.06em">CANDIDATES</text>
+  <rect x="480" y="432" width="64" height="12" rx="2" fill="#f5f5f5"/>
+  <text x="544" y="442" fill="#7a8399" font-size="8" text-anchor="end" font-family="'Geist Mono', ui-monospace, 'SF Mono', Menlo, Consolas, monospace" letter-spacing="0.06em">FACT-CHECK</text>
+  <rect x="624" y="432" width="124" height="12" rx="2" fill="#f5f5f5"/>
+  <text x="628" y="442" fill="#b25424" font-size="8" font-family="'Geist Mono', ui-monospace, 'SF Mono', Menlo, Consolas, monospace" letter-spacing="0.06em">VERIFIED WRITES</text>
+
+  <!-- nodes -->
+  <!-- your AI agents (input) -->
+  <rect x="280" y="48" width="400" height="64" rx="6" fill="#f5f5f5"/>
+  <rect x="280" y="48" width="400" height="64" rx="6" fill="rgba(79,93,117,0.10)" stroke="rgba(122,131,153,0.60)" stroke-width="1"/>
+  <text x="480" y="76" fill="#2d3142" font-size="12" font-weight="600" text-anchor="middle" font-family="'Geist', -apple-system, 'Segoe UI', 'Helvetica Neue', Arial, sans-serif">Your AI agents</text>
+  <text x="480" y="94" fill="#4f5d75" font-size="9" text-anchor="middle" font-family="'Geist Mono', ui-monospace, 'SF Mono', Menlo, Consolas, monospace">Claude Code · Cursor · ZCode · Droid · opencode · Claude Desktop</text>
+
+  <!-- cairn MCP server (api) -->
+  <rect x="200" y="168" width="240" height="64" rx="6" fill="#f5f5f5"/>
+  <rect x="200" y="168" width="240" height="64" rx="6" fill="#ffffff" stroke="#2d3142" stroke-width="1"/>
+  <text x="320" y="196" fill="#2d3142" font-size="12" font-weight="600" text-anchor="middle" font-family="'Geist', -apple-system, 'Segoe UI', 'Helvetica Neue', Arial, sans-serif">cairn MCP server</text>
+  <text x="320" y="214" fill="#4f5d75" font-size="9" text-anchor="middle" font-family="'Geist Mono', ui-monospace, 'SF Mono', Menlo, Consolas, monospace">27 tools · graph queries</text>
+
+  <!-- cairn CLI (api) -->
+  <rect x="520" y="168" width="240" height="64" rx="6" fill="#f5f5f5"/>
+  <rect x="520" y="168" width="240" height="64" rx="6" fill="#ffffff" stroke="#2d3142" stroke-width="1"/>
+  <text x="640" y="196" fill="#2d3142" font-size="12" font-weight="600" text-anchor="middle" font-family="'Geist', -apple-system, 'Segoe UI', 'Helvetica Neue', Arial, sans-serif">cairn CLI</text>
+  <text x="640" y="214" fill="#4f5d75" font-size="9" text-anchor="middle" font-family="'Geist Mono', ui-monospace, 'SF Mono', Menlo, Consolas, monospace">human mirror, same store</text>
+
+  <!-- store contents (store cells) -->
+  <rect x="136" y="328" width="160" height="64" rx="6" fill="#f5f5f5"/>
+  <rect x="136" y="328" width="160" height="64" rx="6" fill="rgba(45,49,66,0.05)" stroke="rgba(79,93,117,0.60)" stroke-width="1"/>
+  <text x="216" y="356" fill="#2d3142" font-size="12" font-weight="600" text-anchor="middle" font-family="'Geist', -apple-system, 'Segoe UI', 'Helvetica Neue', Arial, sans-serif">Structural graph</text>
+  <text x="216" y="374" fill="#4f5d75" font-size="9" text-anchor="middle" font-family="'Geist Mono', ui-monospace, 'SF Mono', Menlo, Consolas, monospace">symbols · labeled edges</text>
+
+  <rect x="312" y="328" width="160" height="64" rx="6" fill="#f5f5f5"/>
+  <rect x="312" y="328" width="160" height="64" rx="6" fill="rgba(45,49,66,0.05)" stroke="rgba(79,93,117,0.60)" stroke-width="1"/>
+  <text x="392" y="356" fill="#2d3142" font-size="12" font-weight="600" text-anchor="middle" font-family="'Geist', -apple-system, 'Segoe UI', 'Helvetica Neue', Arial, sans-serif">Compass + wiki</text>
+  <text x="392" y="374" fill="#4f5d75" font-size="9" text-anchor="middle" font-family="'Geist Mono', ui-monospace, 'SF Mono', Menlo, Consolas, monospace">generated · gated</text>
+
+  <rect x="488" y="328" width="160" height="64" rx="6" fill="#f5f5f5"/>
+  <rect x="488" y="328" width="160" height="64" rx="6" fill="rgba(45,49,66,0.05)" stroke="rgba(79,93,117,0.60)" stroke-width="1"/>
+  <text x="568" y="356" fill="#2d3142" font-size="12" font-weight="600" text-anchor="middle" font-family="'Geist', -apple-system, 'Segoe UI', 'Helvetica Neue', Arial, sans-serif">Memory + knowledge</text>
+  <text x="568" y="374" fill="#4f5d75" font-size="9" text-anchor="middle" font-family="'Geist Mono', ui-monospace, 'SF Mono', Menlo, Consolas, monospace">tribal · OKF bundle</text>
+
+  <rect x="664" y="328" width="160" height="64" rx="6" fill="#f5f5f5"/>
+  <rect x="664" y="328" width="160" height="64" rx="6" fill="rgba(45,49,66,0.05)" stroke="rgba(79,93,117,0.60)" stroke-width="1"/>
+  <text x="744" y="356" fill="#2d3142" font-size="12" font-weight="600" text-anchor="middle" font-family="'Geist', -apple-system, 'Segoe UI', 'Helvetica Neue', Arial, sans-serif">Embeddings</text>
+  <text x="744" y="374" fill="#4f5d75" font-size="9" text-anchor="middle" font-family="'Geist Mono', ui-monospace, 'SF Mono', Menlo, Consolas, monospace">optional [semantic]</text>
+
+  <!-- LLM task queue (off-path, optional/async treatment) -->
+  <rect x="120" y="456" width="240" height="64" rx="6" fill="#f5f5f5"/>
+  <rect x="120" y="456" width="240" height="64" rx="6" fill="rgba(45,49,66,0.02)" stroke="rgba(45,49,66,0.30)" stroke-width="1" stroke-dasharray="4,3"/>
+  <text x="240" y="484" fill="#2d3142" font-size="12" font-weight="600" text-anchor="middle" font-family="'Geist', -apple-system, 'Segoe UI', 'Helvetica Neue', Arial, sans-serif">LLM task queue</text>
+  <text x="240" y="502" fill="#4f5d75" font-size="9" text-anchor="middle" font-family="'Geist Mono', ui-monospace, 'SF Mono', Menlo, Consolas, monospace">off-path — never answers queries</text>
+
+  <!-- critic gate (focal) -->
+  <rect x="480" y="456" width="240" height="64" rx="6" fill="#f5f5f5"/>
+  <rect x="480" y="456" width="240" height="64" rx="6" fill="rgba(235,108,54,0.08)" stroke="#eb6c36" stroke-width="1"/>
+  <text x="600" y="484" fill="#2d3142" font-size="12" font-weight="600" text-anchor="middle" font-family="'Geist', -apple-system, 'Segoe UI', 'Helvetica Neue', Arial, sans-serif">Deterministic critic gate</text>
+  <text x="600" y="502" fill="#b25424" font-size="9" text-anchor="middle" font-family="'Geist Mono', ui-monospace, 'SF Mono', Menlo, Consolas, monospace">fact-checks every symbol · rejects hallucinations</text>
+
+  <!-- legend: horizontal strip at the bottom -->
+  <line x1="120" y1="548" x2="840" y2="548" stroke="rgba(45,49,66,0.10)" stroke-width="0.8"/>
+  <text x="120" y="568" fill="#4f5d75" font-size="8" font-family="'Geist Mono', ui-monospace, 'SF Mono', Menlo, Consolas, monospace" letter-spacing="0.14em">LEGEND</text>
+  <rect x="200" y="558" width="16" height="12" rx="2" fill="rgba(79,93,117,0.10)" stroke="rgba(122,131,153,0.60)" stroke-width="0.8"/>
+  <text x="224" y="568" fill="#4f5d75" font-size="8" font-family="'Geist Mono', ui-monospace, 'SF Mono', Menlo, Consolas, monospace">your agents</text>
+  <rect x="328" y="558" width="16" height="12" rx="2" fill="#ffffff" stroke="#2d3142" stroke-width="0.8"/>
+  <text x="352" y="568" fill="#4f5d75" font-size="8" font-family="'Geist Mono', ui-monospace, 'SF Mono', Menlo, Consolas, monospace">cairn surface</text>
+  <rect x="476" y="558" width="16" height="12" rx="2" fill="rgba(45,49,66,0.05)" stroke="rgba(79,93,117,0.60)" stroke-width="0.8"/>
+  <text x="500" y="568" fill="#4f5d75" font-size="8" font-family="'Geist Mono', ui-monospace, 'SF Mono', Menlo, Consolas, monospace">store contents</text>
+  <rect x="628" y="558" width="16" height="12" rx="2" fill="rgba(45,49,66,0.02)" stroke="rgba(45,49,66,0.30)" stroke-width="0.8" stroke-dasharray="4,3"/>
+  <text x="652" y="568" fill="#4f5d75" font-size="8" font-family="'Geist Mono', ui-monospace, 'SF Mono', Menlo, Consolas, monospace">off-path</text>
+  <rect x="744" y="558" width="16" height="12" rx="2" fill="rgba(235,108,54,0.08)" stroke="#eb6c36" stroke-width="0.8"/>
+  <text x="768" y="568" fill="#4f5d75" font-size="8" font-family="'Geist Mono', ui-monospace, 'SF Mono', Menlo, Consolas, monospace">the one gate</text>
+</svg>


### PR DESCRIPTION
## Summary

Replaces the README's hand-drawn ASCII architecture diagram with an editorial SVG (drawn with the diagram-design skill, architecture type, `doc-inline` 960×600, default skin) committed at `docs/diagrams/readme-architecture.svg` and embedded via a relative path — GitHub serves committed SVGs in READMEs through its image proxy. The HTML source stays beside the other `docs/diagrams/` sources.

Content is faithful to the ASCII it replaces: agents → MCP server (stdio · 27 tools) and CLI, one local SQLite store (graph, compass + wiki, memory + knowledge, embeddings), and the LLM task queue strictly off-path behind the deterministic critic gate — drawn as the single coral focal to make the "LLM never in the query path" headline visual.

## Change type

- [ ] Feature / improvement
- [ ] Bugfix
- [ ] Refactor (no behavior change)
- [x] Docs / chore / CI

## Audit checklist

- [x] **Blast radius checked** — docs/asset only; no code touched.
- [x] **Layering respected** — n/a.
- [x] **Graph updated** — n/a (no code change).
- [x] **Memory recorded** — n/a.
- [x] **Fallback/perf paths** — n/a.
- [x] **Tests** — n/a (asset + README only); pre-commit green; SVG well-formed XML, skill `self_check` pass.
- [x] **CHANGELOG** — n/a (docs-only).
- [x] **Gates green** — pre-commit green; conventional title.

## Notes / known trade-offs

- **Fonts**: GitHub's README image proxy blocks external resources, so the SVG's Geist/Geist Mono stacks fall back to system sans/mono when viewed on github.com. The @import is retained for Figma/browser-direct use. Pixel-perfect alternative: a PNG export (Playwright rasterization) — say the word and I'll add it and switch the embed.
- **Dark mode**: the diagram uses the light default skin; on GitHub dark theme it reads as a light card (same as most README badges). A dark-skin variant can be added later.
- The ASCII block is fully replaced (its content is 100% represented in the SVG); the explanatory prose below it is unchanged.
