### PR TITLE
feat(dashboard): curate module graph scope and add symbol inspect side panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Graph tab curation and side panel (dashboard): the module scope's default
+  view now ranks candidates by degree (fan-in + fan-out) instead of an
+  arbitrary first-50 rowid sample — which had been filling the canvas with
+  test nodes — and excludes tests by default behind an explicit
+  "Include tests" toggle, with `tests_included`/`truncated` reported in the
+  scope metadata. A new `/graph/inspect` endpoint answers the panel's
+  question for one symbol in a single call — identity (kind, file:line,
+  docstring, same-name count), resolved callers and callees (capped, with
+  honest truncation flags), and the depth-3 impact view with the
+  affected-test classification reused from the impact layer. Selecting a
+  node on the canvas fills the side panel; deselecting collapses it and the
+  canvas keeps the full width.
 - Environment propagation and wiring verification for custom `CAIRN_HOME`
   installs (root cause of #70): every cairn-generated integration now
   carries the store location — stdio MCP registrations embed

--- a/src/cairn/dashboard/app.py
+++ b/src/cairn/dashboard/app.py
@@ -231,6 +231,7 @@ def create_app(
         get_session_chains,
         get_task_queue,
         get_tool_tokens,
+        inspect_symbol,
         list_history,
         list_projects,
         prewarm_probes,
@@ -369,6 +370,10 @@ def create_app(
         repo = request.query_params.get("repo", "").strip() or None
         depth_raw = request.query_params.get("depth", "").strip()
         depth = int(depth_raw) or None if depth_raw.isdigit() else None
+        # Tests toggle: only an explicit opt-in includes test symbols in the
+        # module scope; anything else falls back to the curated default,
+        # matching the scope/layout fallback conventions.
+        include_tests = request.query_params.get("tests", "") in ("1", "on", "true")
         # Layout choice (FR-004): only "force" | "hier" are meaningful;
         # absent/bogus falls back to force, matching the scope fallback.
         layout = request.query_params.get("layout", "force")
@@ -380,7 +385,8 @@ def create_app(
         conn = get_read_only_db(selected_db)
         try:
             graph_data = get_graph(
-                conn, scope=scope, focus=focus, repo=repo, depth=depth
+                conn, scope=scope, focus=focus, repo=repo, depth=depth,
+                include_tests=include_tests,
             )
         finally:
             conn.close()
@@ -395,6 +401,7 @@ def create_app(
                 "repo": repo or "",
                 "depth": depth_raw if depth is not None else "",
                 "layout": layout,
+                "include_tests": include_tests,
                 "store_key": store_key,
             },
         )
@@ -441,6 +448,20 @@ def create_app(
         conn = get_read_only_db(selected_db)
         try:
             result = viz_query.get_symbol_neighbors(conn, names, **depth_kwargs)
+        finally:
+            conn.close()
+        return JSONResponse(result)
+
+    def graph_inspect(request: Request) -> Response:
+        # Side-panel payload for one symbol (identity + callers + callees +
+        # impact with affected tests). Missing/blank names hit the data
+        # function's not-found contract (200 with found=False), never an
+        # error — the panel just stays empty.
+        name = request.query_params.get("name", "")
+        selected_db, _, _ = resolve_selection(request, db_path, knowledge_dir)
+        conn = get_read_only_db(selected_db)
+        try:
+            result = inspect_symbol(conn, name)
         finally:
             conn.close()
         return JSONResponse(result)
@@ -894,6 +915,7 @@ def create_app(
         Route("/graph/candidates", graph_candidates, name="graph_candidates"),
         Route("/graph/suggest", graph_suggest, name="graph_suggest"),
         Route("/graph/neighbors", graph_neighbors, name="graph_neighbors"),
+        Route("/graph/inspect", graph_inspect, name="graph_inspect"),
         Route("/history", history, name="history"),
         Route("/history.csv", history_csv, name="history_csv"),
         Route("/history.json", history_json, name="history_json"),

--- a/src/cairn/dashboard/data.py
+++ b/src/cairn/dashboard/data.py
@@ -121,15 +121,18 @@ def get_graph(
     focus: Optional[str] = None,
     repo: Optional[str] = None,
     depth: Optional[int] = None,
+    include_tests: bool = False,
 ) -> Dict:
     """Dispatch to a viz query scope; returns its ``{nodes, edges, metadata}``
     verbatim — the scope functions already cap result size (LIMIT 30/50,
     ``max_nodes``), and their metadata carries the possibly-truncated counts.
+    ``include_tests`` only applies to the module scope (the other scopes are
+    focus-driven, where the user asked for exactly that symbol's world).
     """
     if scope == "symbol":
         return viz_query.get_symbol_graph(conn, focus or "", 1 if depth is None else depth)
     if scope == "module":
-        return viz_query.get_module_graph(conn, focus or "")
+        return viz_query.get_module_graph(conn, focus or "", include_tests=include_tests)
     if scope == "impact":
         return viz_query.get_impact_graph(conn, focus or "", 3 if depth is None else depth)
     if scope == "deps":
@@ -137,6 +140,107 @@ def get_graph(
     if scope == "repo":
         return viz_query.get_repo_graph(conn, repo or "", max_nodes=30)
     raise ValueError(f"unknown graph scope: {scope!r}")
+
+
+INSPECT_NEIGHBOR_CAP = 10
+INSPECT_IMPACT_CAP = 15
+
+
+def inspect_symbol(conn: sqlite3.Connection, name: str) -> Dict:
+    """One-call answer payload for the graph tab's side panel: identity,
+    callers, callees, and the impact view with affected tests.
+
+    Same-name rows are possible; the first by (file path, id) is inspected
+    (deterministic, mirroring ``symbol_candidates``' ordering) and
+    ``same_name_count`` tells the panel when more definitions exist. Callers
+    and callees follow resolved edges only, capped at
+    :data:`INSPECT_NEIGHBOR_CAP` with honest ``*_truncated`` flags. Impact
+    reuses the graph engine's recursive caller traversal at depth 3 (the
+    viz impact scope's default), surfacing ``total`` plus the first
+    :data:`INSPECT_IMPACT_CAP` impacted symbols and affected tests — the
+    tests are the graph layer's ``filter_tests`` classification of the
+    impacted set, not a separate traversal. An empty/unknown name yields
+    ``{"found": False, "name": ...}`` at HTTP 200, never an error.
+    """
+    if not name or not name.strip():
+        return {"found": False, "name": name}
+    name = name.strip()
+    from ..graph.queries import impact_analysis
+    from ..graph.tests import filter_tests
+
+    cur = conn.cursor()
+    row = cur.execute(
+        "SELECT s.id, s.name, s.kind, s.qualified_name, s.line_start, s.docstring, "
+        "f.path AS file, f.repo_id "
+        "FROM symbols s JOIN files f ON s.file_id = f.id "
+        "WHERE s.name = ? ORDER BY f.path ASC, s.id ASC LIMIT 1",
+        (name,),
+    ).fetchone()
+    if row is None:
+        return {"found": False, "name": name}
+
+    same_name_count = cur.execute(
+        "SELECT COUNT(*) FROM symbols WHERE name = ?", (name,)
+    ).fetchone()[0]
+
+    def _neighbors(sql: str) -> tuple:
+        fetched = cur.execute(sql, (row["id"],)).fetchall()
+        truncated = len(fetched) > INSPECT_NEIGHBOR_CAP
+        return (
+            [
+                {"name": r["name"], "kind": r["kind"], "file": r["file"]}
+                for r in fetched[:INSPECT_NEIGHBOR_CAP]
+            ],
+            truncated,
+        )
+
+    cap = INSPECT_NEIGHBOR_CAP + 1
+    callers, callers_truncated = _neighbors(
+        f"SELECT s.name, s.kind, f.path AS file "
+        f"FROM edges e JOIN symbols s ON e.source_id = s.id "
+        f"JOIN files f ON s.file_id = f.id "
+        f"WHERE e.target_id = ? LIMIT {cap}"
+    )
+    callees, callees_truncated = _neighbors(
+        f"SELECT t.name, t.kind, f.path AS file "
+        f"FROM edges e JOIN symbols t ON e.target_id = t.id "
+        f"JOIN files f ON t.file_id = f.id "
+        f"WHERE e.source_id = ? LIMIT {cap}"
+    )
+
+    impact = impact_analysis(conn, name, max_depth=3)
+    affected = filter_tests(impact["impacted"])
+    impact_view = {
+        "total": impact["total"],
+        "truncated": impact["truncated"],
+        "top": [
+            {"symbol": r["symbol"], "file": r["file"], "depth": r["depth"]}
+            for r in impact["impacted"][:INSPECT_IMPACT_CAP]
+        ],
+        "affected_tests": [
+            {"symbol": t["symbol"], "file": t["file"]}
+            for t in affected[:INSPECT_IMPACT_CAP]
+        ],
+        "affected_tests_total": len(affected),
+    }
+    return {
+        "found": True,
+        "symbol": {
+            "name": row["name"],
+            "kind": row["kind"],
+            "qualified_name": row["qualified_name"],
+            "file": row["file"],
+            "repo": row["repo_id"],
+            "line_start": row["line_start"],
+            "docstring": row["docstring"],
+        },
+        "same_name_count": same_name_count,
+        "callers": callers,
+        "callers_truncated": callers_truncated,
+        "callees": callees,
+        "callees_truncated": callees_truncated,
+        "impact": impact_view,
+    }
 
 
 CANDIDATES_LIMIT = 10

--- a/src/cairn/dashboard/static/app.css
+++ b/src/cairn/dashboard/static/app.css
@@ -415,6 +415,116 @@ body.app-shell {
   border-radius: var(--radius);
 }
 
+/* Canvas + inspect side panel. The panel participates only while visible
+   (:has keeps the canvas full-width when it's hidden). */
+.graph-layout {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 300px;
+  gap: 0.8rem;
+  align-items: start;
+}
+
+.graph-layout:has(> .graph-panel[hidden]) {
+  grid-template-columns: 1fr;
+}
+
+.graph-panel {
+  max-height: min(72vh, 780px);
+  overflow-y: auto;
+  padding: 0.75rem 0.85rem;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  font-size: 0.86rem;
+}
+
+.panel-head-row {
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+  min-width: 0;
+}
+
+.panel-kind {
+  flex: none;
+  padding: 0.08rem 0.5rem;
+  border-radius: 999px;
+  background: var(--accent-soft);
+  color: var(--accent);
+  font-size: 0.74rem;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+
+.panel-title {
+  min-width: 0;
+  overflow-wrap: anywhere;
+  font-weight: 600;
+}
+
+.panel-sub {
+  margin: 0.2rem 0 0;
+  color: var(--muted);
+  overflow-wrap: anywhere;
+}
+
+.panel-doc {
+  margin: 0.45rem 0 0;
+  padding-left: 0.6rem;
+  border-left: 2px solid var(--border);
+  color: var(--muted);
+}
+
+.panel-note {
+  margin: 0.25rem 0 0;
+  color: var(--muted);
+  font-size: 0.78rem;
+}
+
+.panel-section {
+  margin-top: 0.7rem;
+}
+
+.panel-head {
+  margin: 0 0 0.25rem;
+  font-size: 0.8rem;
+  color: var(--muted);
+  font-weight: 600;
+}
+
+.panel-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.panel-row {
+  display: flex;
+  flex-direction: column;
+  padding: 0.22rem 0;
+  border-bottom: 1px solid color-mix(in srgb, var(--border) 55%, transparent);
+}
+
+.panel-row:last-child {
+  border-bottom: none;
+}
+
+.panel-name {
+  overflow-wrap: anywhere;
+  font-weight: 500;
+}
+
+.panel-empty {
+  margin: 0.15rem 0;
+  color: var(--muted);
+}
+
+@media (max-width: 900px) {
+  .graph-layout {
+    grid-template-columns: 1fr;
+  }
+}
+
 .graph-overlay {
   position: absolute;
   left: 0.8rem;

--- a/src/cairn/dashboard/static/app.js
+++ b/src/cairn/dashboard/static/app.js
@@ -559,12 +559,171 @@
     inspectAction.appendChild(link);
   }
 
+  /* Side panel (graph-tab info panel): selecting a node fetches
+     /graph/inspect and fills #graph-panel with the one-call answer —
+     identity, callers, callees, and the impact view with affected tests.
+     Deselecting hides the panel. Built with DOM APIs only (no innerHTML
+     with node data), mirroring the inspect hint above. */
+  var panel = document.getElementById("graph-panel");
+  var panelRequest = 0;
+
+  function el(tag, className, text) {
+    var node = document.createElement(tag);
+    if (className) {
+      node.className = className;
+    }
+    if (text !== undefined && text !== null && text !== "") {
+      node.textContent = text;
+    }
+    return node;
+  }
+
+  function panelRows(list, items, nameKey, withDepth) {
+    if (!items.length) {
+      list.appendChild(el("li", "panel-empty", "none"));
+      return;
+    }
+    items.forEach(function (item) {
+      var row = el("li", "panel-row");
+      row.appendChild(el("span", "panel-name", item[nameKey]));
+      var sub = item.file || "";
+      if (withDepth && item.depth !== undefined && item.depth !== null) {
+        sub = "depth " + item.depth + (sub ? " — " + sub : "");
+      }
+      if (sub) {
+        row.appendChild(el("span", "panel-sub", sub));
+      }
+      list.appendChild(row);
+    });
+  }
+
+  function panelSection(title, items, nameKey, withDepth) {
+    var section = el("section", "panel-section");
+    var head = title + " (" + items.length + ")";
+    section.appendChild(el("h3", "panel-head", head));
+    var list = el("ul", "panel-list");
+    panelRows(list, items, nameKey, withDepth);
+    section.appendChild(list);
+    return section;
+  }
+
+  function renderPanel(data) {
+    panel.textContent = "";
+    var sym = data.symbol || {};
+    var head = el("div", "panel-head-row");
+    head.appendChild(el("span", "panel-kind", sym.kind || "?"));
+    head.appendChild(el("span", "panel-title", sym.name));
+    panel.appendChild(head);
+    var where = (sym.file || "") + (sym.line_start ? ":" + sym.line_start : "");
+    if (where) {
+      panel.appendChild(el("p", "panel-sub", where));
+    }
+    if (data.same_name_count > 1) {
+      panel.appendChild(
+        el("p", "panel-note", data.same_name_count + " same-name definitions — showing the first")
+      );
+    }
+    if (sym.docstring) {
+      panel.appendChild(el("p", "panel-doc", sym.docstring));
+    }
+    panel.appendChild(
+      panelSection("Callers", data.callers || [], "name", false)
+    );
+    if (data.callers_truncated) {
+      panel.appendChild(el("p", "panel-note", "more callers not shown"));
+    }
+    panel.appendChild(
+      panelSection("Callees", data.callees || [], "name", false)
+    );
+    if (data.callees_truncated) {
+      panel.appendChild(el("p", "panel-note", "more callees not shown"));
+    }
+    var impact = data.impact || {};
+    var impactSection = el("section", "panel-section");
+    impactSection.appendChild(
+      el(
+        "h3",
+        "panel-head",
+        "Impact — " + impact.total + " symbol" + (impact.total === 1 ? "" : "s") + " affected" +
+          (impact.truncated ? " (capped)" : "")
+      )
+    );
+    var topList = el("ul", "panel-list");
+    panelRows(topList, impact.top || [], "symbol", true);
+    impactSection.appendChild(topList);
+    panel.appendChild(impactSection);
+    var tests = impact.affected_tests || [];
+    var testsSection = el("section", "panel-section");
+    var testHead = "Affected tests";
+    if (impact.affected_tests_total > tests.length) {
+      testHead += " — " + impact.affected_tests_total + " total";
+    } else {
+      testHead += " (" + tests.length + ")";
+    }
+    testsSection.appendChild(el("h3", "panel-head", testHead));
+    var testList = el("ul", "panel-list");
+    panelRows(testList, tests, "symbol", false);
+    testsSection.appendChild(testList);
+    panel.appendChild(testsSection);
+  }
+
+  function inspectPanel(id) {
+    if (!panel) {
+      return;
+    }
+    panelRequest += 1;
+    var seq = panelRequest;
+    if (!id) {
+      panel.hidden = true;
+      panel.textContent = "";
+      return;
+    }
+    panel.hidden = false;
+    panel.textContent = "";
+    panel.appendChild(el("p", "panel-empty", "loading '" + id + "'…"));
+    fetch(
+      "/graph/inspect?name=" +
+        encodeURIComponent(id) +
+        (inspectStore ? "&store=" + encodeURIComponent(inspectStore) : "")
+    )
+      .then(function (resp) {
+        if (!resp.ok) {
+          throw new Error("inspect request failed");
+        }
+        return resp.json();
+      })
+      .then(
+        function (data) {
+          if (seq !== panelRequest) {
+            return; /* a newer selection already owns the panel */
+          }
+          panel.textContent = "";
+          if (!data.found) {
+            panel.appendChild(
+              el("p", "panel-empty", "no definition of '" + id + "' in the index")
+            );
+            return;
+          }
+          renderPanel(data);
+        },
+        function () {
+          if (seq !== panelRequest) {
+            return;
+          }
+          panel.textContent = "";
+          panel.appendChild(el("p", "panel-empty", "inspect request failed"));
+        }
+      );
+  }
+
   network.on("selectNode", function (event) {
     var id = event.nodes && event.nodes.length ? event.nodes[0] : null;
     renderInspect(id);
+    inspectPanel(id);
   });
   network.on("deselectNode", function () {
     renderInspect(null);
+    inspectPanel(null);
   });
 
   /* Layout toggle (FR-004): clicking an anchor in #layout-control

--- a/src/cairn/dashboard/templates/graph.html
+++ b/src/cairn/dashboard/templates/graph.html
@@ -33,6 +33,10 @@
     <label>Depth
       <input type="number" name="depth" min="1" value="{{ depth }}">
     </label>
+    <label class="graph-tests-toggle">
+      <input type="checkbox" name="tests" value="1"{% if include_tests %} checked{% endif %}>
+      Include tests
+    </label>
     <button type="submit">Apply</button>
   </form>
   {#- Layout toggle (FR-004): links swap only the layout param, keeping
@@ -46,6 +50,7 @@
   {%- if focus %}{% set _ = q.update({"focus": focus}) %}{% endif %}
   {%- if repo %}{% set _ = q.update({"repo": repo}) %}{% endif %}
   {%- if depth %}{% set _ = q.update({"depth": depth}) %}{% endif %}
+  {%- if include_tests %}{% set _ = q.update({"tests": "1"}) %}{% endif %}
   {{- links.url(request.url.path, q) }}
   {%- endmacro %}
   <p class="muted" id="layout-control">
@@ -75,7 +80,8 @@
     scope queries are capped, so a count at the cap means the graph was truncated.
   </p>
   {% if graph.nodes %}
-  <div class="graph-stage">
+  <div class="graph-layout">
+    <div class="graph-stage">
     <div id="graph-canvas" data-layout="{{ layout }}" class="graph-canvas"></div>
     {#- Overlay controls float over the canvas's bottom-left; app.js
         wires the data-graph-action buttons to vis zoom/fit. -#}
@@ -90,6 +96,11 @@
         <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M8 3H5a2 2 0 0 0-2 2v3M16 3h3a2 2 0 0 1 2 2v3M8 21H5a2 2 0 0 1-2-2v-3M16 21h3a2 2 0 0 0 2-2v-3"/></svg>
       </button>
     </div>
+    </div>
+    {#- Side panel (graph-tab info panel): app.js fills it from
+        /graph/inspect when a node is selected; hidden when empty so the
+        canvas keeps the full width. -#}
+    <aside id="graph-panel" class="graph-panel" aria-live="polite" hidden></aside>
   </div>
   {% else %}
   <p class="empty-state">No nodes for this scope — adjust the controls above.</p>

--- a/src/cairn/viz/query.py
+++ b/src/cairn/viz/query.py
@@ -166,17 +166,51 @@ def get_repo_graph(conn: sqlite3.Connection, repo: str, max_nodes: int = 30) -> 
             "metadata": {"scope": "repo", "repo": repo, "node_count": len(nodes)}}
 
 
-def get_module_graph(conn: sqlite3.Connection, module: str) -> Dict:
-    """All symbols in a module + their internal edges."""
+_MODULE_CAP = 50
+_MODULE_EDGE_CAP = 100
+
+
+def get_module_graph(
+    conn: sqlite3.Connection, module: str = "", include_tests: bool = False
+) -> Dict:
+    """Symbols in a module + their internal edges, curated for usefulness.
+
+    An empty ``module`` (the dashboard's default landing view) matches every
+    path, so "first 50 by rowid" used to fill the canvas with an arbitrary
+    sample — dominated by whichever files the indexer touched first (in
+    practice, tests). Candidates are instead ranked by degree (fan-in +
+    fan-out of any edges) then name, so the cap lands on the symbols that
+    carry the module's structure. Tests are excluded by default (the
+    ``is_test_symbol`` heuristics from the impact layer); ``include_tests``
+    opts back in. ``metadata.tests_included`` and ``metadata.truncated``
+    report both choices honestly.
+    """
+    from ..graph.tests import is_test_symbol
+
     cur = conn.cursor()
     nodes = {}
     edges = []
-    for r in cur.execute(
-        "SELECT s.name, s.kind, f.path, f.repo_id FROM symbols s "
-        "JOIN files f ON s.file_id = f.id WHERE f.path LIKE ? LIMIT 50",
+    rows = cur.execute(
+        "SELECT s.name, s.kind, f.path, f.repo_id, s.qualified_name, "
+        "(SELECT COUNT(*) FROM edges e WHERE e.target_id = s.id) + "
+        "(SELECT COUNT(*) FROM edges e WHERE e.source_id = s.id) AS degree "
+        "FROM symbols s JOIN files f ON s.file_id = f.id "
+        "WHERE f.path LIKE ? "
+        "ORDER BY degree DESC, s.name ASC",
         (f"%{module}%",),
-    ).fetchall():
+    ).fetchall()
+    kept = 0
+    eligible = 0
+    for r in rows:
+        if not include_tests and is_test_symbol(
+            r["path"], r["name"], r["qualified_name"] or ""
+        )["is_test"]:
+            continue
+        eligible += 1
+        if eligible > _MODULE_CAP:
+            continue
         _add_node(nodes, r["name"], r["kind"], r["path"], r["repo_id"])
+        kept += 1
     # Internal edges.
     if nodes:
         names = list(nodes.keys())
@@ -185,14 +219,24 @@ def get_module_graph(conn: sqlite3.Connection, module: str) -> Dict:
             f"SELECT s1.name AS src, COALESCE(s2.name, e.target_name) AS tgt, e.kind "
             f"FROM edges e JOIN symbols s1 ON e.source_id = s1.id "
             f"LEFT JOIN symbols s2 ON e.target_id = s2.id "
-            f"WHERE s1.name IN ({placeholders}) LIMIT 100",
+            f"WHERE s1.name IN ({placeholders}) LIMIT {_MODULE_EDGE_CAP}",
             names,
         ).fetchall()
         for r in rows:
             if r["tgt"] in nodes:
                 edges.append({"source": r["src"], "target": r["tgt"], "kind": r["kind"]})
-    return {"nodes": list(nodes.values()), "edges": edges,
-            "metadata": {"scope": "module", "module": module, "node_count": len(nodes), "edge_count": len(edges)}}
+    return {
+        "nodes": list(nodes.values()),
+        "edges": edges,
+        "metadata": {
+            "scope": "module",
+            "module": module,
+            "node_count": len(nodes),
+            "edge_count": len(edges),
+            "tests_included": include_tests,
+            "truncated": eligible > _MODULE_CAP,
+        },
+    }
 
 
 # --- helpers -------------------------------------------------------------

--- a/tests/test_dashboard_app.py
+++ b/tests/test_dashboard_app.py
@@ -3516,3 +3516,31 @@ def test_embeddings_status_core_schema_only_db_renders_unknown_rows(
     assert "never" in resp.text
     # The two absent tables degrade to em-dash rows, not an error page.
     assert resp.text.count('<td class="num">—</td>') == 2
+
+
+@requires_vis_network
+def test_graph_route_has_include_tests_toggle_and_inspect_panel(tmp_path):
+    """The graph tab ships the tests toggle in the toolbar and the empty
+    side-panel shell the node-inspect fetch fills."""
+    client = _client(tmp_path, seed=True)
+    resp = client.get("/graph", params={"scope": "module", "focus": "src/demo"})
+    assert resp.status_code == 200
+    assert 'name="tests"' in resp.text
+    assert 'id="graph-panel"' in resp.text
+
+
+def test_graph_inspect_route_returns_json_payload(tmp_path):
+    """/graph/inspect answers the panel's question in one call: identity,
+    callers, callees, and the impact view with affected tests."""
+    client = _client(tmp_path, seed=True)
+    resp = client.get("/graph/inspect", params={"name": "demo_main"})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["found"] is True
+    assert data["symbol"]["name"] == "demo_main"
+    assert data["symbol"]["file"] == "src/demo/core.py"
+    assert {c["name"] for c in data["callees"]} == {"demo_helper"}
+
+    missing = client.get("/graph/inspect", params={"name": "missing_symbol"})
+    assert missing.status_code == 200
+    assert missing.json()["found"] is False

--- a/tests/test_dashboard_data.py
+++ b/tests/test_dashboard_data.py
@@ -2336,3 +2336,136 @@ def test_tokens_render_distinguishes_truncation_unknown_from_zero(fresh_db):
         row = _rendered_tool_row(html, no_evidence)
         assert ">unknown</td>" in row
         assert ">—</td>" in row
+
+
+# ---------------------------------------------------------------------------
+# Module-scope curation (graph-tab info panel): the empty-focus default shows
+# connectivity-ranked production hubs instead of an arbitrary first-50 sample,
+# and tests are excluded by default with an explicit opt-in.
+# ---------------------------------------------------------------------------
+
+
+def _seed_hubs(conn):
+    """55 test symbols inserted first (rowid order), then 6 production
+    symbols whose edges make hub_main the top hub. Under today's
+    LIMIT-50-rowid sample the canvas is entirely test nodes."""
+    conn.executemany(
+        "INSERT INTO repos (id, name, path, language, indexed_at) VALUES (?, ?, ?, ?, ?)",
+        [("hub", "hub", ".", "python", "2026-08-27T00:00:00")],
+    )
+    conn.executemany(
+        "INSERT INTO files (id, repo_id, path, language, indexed_at) VALUES (?, ?, ?, ?, ?)",
+        [
+            ("f_t1", "hub", "tests/test_pack.py", "python", "2026-08-27T00:00:00"),
+            ("f_p1", "hub", "src/pack/core.py", "python", "2026-08-27T00:00:00"),
+            ("f_p2", "hub", "src/pack/util.py", "python", "2026-08-27T00:00:00"),
+        ],
+    )
+    rows = [
+        (f"s_t{i}", "f_t1", f"test_case_{i:02d}",
+         f"tests.test_pack.test_case_{i:02d}", "function")
+        for i in range(55)
+    ]
+    rows += [
+        ("s_p0", "f_p1", "hub_main", "pack.core.hub_main", "function"),
+        ("s_p1", "f_p1", "in_a", "pack.core.in_a", "function"),
+        ("s_p2", "f_p1", "in_b", "pack.core.in_b", "function"),
+        ("s_p3", "f_p2", "out_a", "pack.util.out_a", "function"),
+        ("s_p4", "f_p2", "out_b", "pack.util.out_b", "function"),
+        ("s_p5", "f_p2", "pack_leaf", "pack.util.pack_leaf", "function"),
+    ]
+    conn.executemany(
+        "INSERT INTO symbols (id, file_id, name, qualified_name, kind, docstring) "
+        "VALUES (?, ?, ?, ?, ?, ?)",
+        [r + (None,) for r in rows[:-6]]
+        + [r + ("the hub.",) for r in rows[-6:]],
+    )
+    conn.executemany(
+        "INSERT INTO edges (id, source_id, target_id, kind) VALUES (?, ?, ?, ?)",
+        [
+            ("he1", "s_p0", "s_p3", "calls"),
+            ("he2", "s_p0", "s_p4", "calls"),
+            ("he3", "s_p1", "s_p0", "calls"),
+            ("he4", "s_p2", "s_p0", "calls"),
+            ("he5", "s_t0", "s_p0", "calls"),
+        ],
+    )
+    conn.commit()
+
+
+def test_module_default_excludes_tests_and_ranks_hubs(fresh_db):
+    from cairn.dashboard.data import get_graph
+
+    _seed_hubs(fresh_db)
+    graph = get_graph(fresh_db)  # scope defaults to module, no focus
+
+    ids = {n["id"] for n in graph["nodes"]}
+    assert ids == {"hub_main", "in_a", "in_b", "out_a", "out_b", "pack_leaf"}
+    assert graph["metadata"]["tests_included"] is False
+    assert graph["metadata"]["node_count"] == 6
+    assert graph["metadata"]["edge_count"] == 4  # he1-he4; he5's test source is dropped
+    # Ranked by degree: the hub first, the unconnected leaf last.
+    assert graph["nodes"][0]["id"] == "hub_main"
+    assert graph["nodes"][-1]["id"] == "pack_leaf"
+
+
+def test_module_scope_include_tests_opt_in(fresh_db):
+    from cairn.dashboard.data import get_graph
+
+    _seed_hubs(fresh_db)
+    graph = get_graph(fresh_db, include_tests=True)
+
+    ids = {n["id"] for n in graph["nodes"]}
+    assert "test_case_00" in ids
+    assert "hub_main" in ids
+    assert graph["metadata"]["tests_included"] is True
+    assert graph["metadata"]["truncated"] is True  # 61 candidates > the 50 cap
+
+
+def test_module_scope_focus_filters_tests_too(fresh_db):
+    from cairn.dashboard.data import get_graph
+
+    _seed_hubs(fresh_db)
+    # "pack" matches production AND test paths (tests/test_pack.py).
+    default = get_graph(fresh_db, focus="pack")
+    assert not any(n["id"].startswith("test_") for n in default["nodes"])
+    assert "hub_main" in {n["id"] for n in default["nodes"]}
+
+    opted_in = get_graph(fresh_db, focus="pack", include_tests=True)
+    assert "test_case_00" in {n["id"] for n in opted_in["nodes"]}
+
+
+# ---------------------------------------------------------------------------
+# Symbol inspect payload (graph-tab side panel): one call answering
+# "what is this, what feeds it, what does it touch, what breaks".
+# ---------------------------------------------------------------------------
+
+
+def test_inspect_symbol_returns_panel_payload(fresh_db):
+    from cairn.dashboard.data import inspect_symbol
+
+    _seed_hubs(fresh_db)
+    data = inspect_symbol(fresh_db, "hub_main")
+
+    assert data["found"] is True
+    assert data["symbol"]["name"] == "hub_main"
+    assert data["symbol"]["kind"] == "function"
+    assert data["symbol"]["file"] == "src/pack/core.py"
+    assert data["symbol"]["docstring"] == "the hub."
+    assert {c["name"] for c in data["callers"]} >= {"in_a", "in_b", "test_case_00"}
+    assert {c["name"] for c in data["callees"]} >= {"out_a", "out_b"}
+    assert data["impact"]["total"] >= 2
+    tests = {t["symbol"] for t in data["impact"]["affected_tests"]}
+    assert "test_case_00" in tests
+    # The ambiguous-name escape hatch: same-name rows listed for disambiguation.
+    assert data["same_name_count"] == 1
+
+
+def test_inspect_symbol_unknown_name_reports_not_found(fresh_db):
+    from cairn.dashboard.data import inspect_symbol
+
+    _seed_hubs(fresh_db)
+    assert inspect_symbol(fresh_db, "no_such_symbol") == {
+        "found": False,
+        "name": "no_such_symbol",
+    }


### PR DESCRIPTION
## Summary

The dashboard Graph tab's default view was an arbitrary `LIMIT 50` rowid sample — on any repo where tests dominate, the canvas filled with isolated `test_*` nodes, which is why the tab showed almost no useful information. This PR curates the default view and adds a side panel that answers questions about a selected symbol.

- **Module scope curation** (`viz/query.py`): candidates ranked by degree (fan-in + fan-out) so the 50-node cap lands on structural hubs, not samples; **tests excluded by default** via the impact layer's `is_test_symbol` heuristics, with an explicit "Include tests" toolbar toggle (rides the URL like the other controls; the layout-href macro keeps it). Metadata reports `tests_included` / `truncated` honestly.
- **`/graph/inspect` endpoint** (`dashboard/data.py::inspect_symbol` + `app.py`): one-call answer payload — identity (kind, file:line, docstring, same-name count), resolved callers/callees (capped at 10 with honest truncation flags), and the depth-3 impact view (total + top 15 + affected-test classification reused from `graph.tests.filter_tests`).
- **Side panel** (`graph.html` / `app.js` / `app.css`): selecting a node fetches the inspect payload and renders it (DOM APIs only, no innerHTML with node data); deselecting collapses the panel and the canvas keeps full width (`:has` grid).

## Change type

- [x] Feature / improvement

## Audit checklist

- [x] **Blast radius checked** — `get_callers`/`impact_analysis(get_module_graph)`: 3 callers (dashboard `get_graph`, cli `hooks_viz`, mcp `visualize_graph`), 9 impacted symbols / 5 affected tests, all exercised in the full suite. Signature change is additive (keyword-only `include_tests=False`); MCP/CLI viz now also default to tests-excluded, which is the intended consistent behavior. No public cross-repo API touched.
- [x] **Layering respected** — dashboard read layer already consumed the viz + graph query layers (`get_graph` → `viz_query`; `get_impact_graph` → `graph.queries.impact_analysis`); `inspect_symbol` follows the same seams (lazy imports inside the function, matching `get_impact_graph`'s pattern). Layer-direction tests pass.
- [x] **Graph updated** — `cairn update` hit the known stale-noop; ran full `cairn build` and verified `cairn def inspect_symbol` resolves.
- [x] **Memory recorded** — `record_memory` type=decision: graph-tab curation + panel design, including the common-name-sink follow-up.
- [x] **Fallback/perf paths** — untouched (dashboard read layer only); no fallback or degradation telemetry affected, so `cairn doctor` not triggered per the checklist's condition.
- [x] **Tests** — TDD: 7 new tests written first and watched to fail for the right reasons (TypeError / ImportError / 404 / missing template strings), then implemented to green. Full suite: **2609 passed, 3 skipped**. `pytest -m core`: 26 passed. New tests are hermetic (seeded sqlite via `fresh_db` / `_client` fixtures, no env/PATH dependence).
- [x] **CHANGELOG** — `[Unreleased] / Added` entry added.
- [x] **Gates green** — `pre-commit run --all-files` passed; conventional title; no new mypy/bandit surface (no new deps, SQL fully parameterized).

## Blast-radius note

`get_module_graph(conn, module)` → `get_module_graph(conn, module="", include_tests=False)`: positional callers unaffected; behavior change (tests now excluded by default, ranking by degree) applies to all three callers intentionally — dashboards, `cairn viz`, and the MCP `visualize_graph` module scope now show curated hubs. `metadata` gains two additive keys (`tests_included`, `truncated`); no keys removed.

## Verification

- TDD red→green for all 7 new tests (`tests/test_dashboard_data.py`, `tests/test_dashboard_app.py`).
- Full suite locally: `CAIRN_LIB=/tmp/__no_such_lib__ uv run --extra test pytest -q` → 2609 passed, 3 skipped.
- Live dogfood on the real store: default `/graph` now renders **0 test nodes** (was ~50/50), hubs first (`get_db`, `_node_text`, `embed_all`…), toggle + panel present; `/graph/inspect?name=resolve_edge` returns the correct payload (22 impacted, affected tests listed, matching the MCP `impact_analysis` output).
- Known observation surfaced by the hub view (deliberately out of scope): the resolver's global tier funnels common names into one sink symbol (`append`: 1,196 exact-labeled edges in this store) — candidate for a resolution-quality follow-up.
