### PR TITLE
ci: run packaging canary on main only and shrink PR test matrix to floor+ceiling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,9 +150,13 @@ jobs:
       fail-fast: false
       matrix:
         # pyproject declares >=3.10; cover the supported CPython range.
-        # 3.14 is declared in classifiers but very new -- wheel gaps for
-        # tree-sitter/sqlite-vec would fail loudly here, not silently pass.
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        # PRs run the floor+ceiling legs only (3.10/3.14 -- where
+        # version-specific and tree-sitter/sqlite-vec wheel-gap breakage
+        # lives); every push to main runs the FULL matrix, so a merge is
+        # always fully covered before a release tag can be cut. 3.14 is
+        # declared in classifiers but very new -- wheel gaps fail loudly
+        # here, not silently pass.
+        python-version: ${{ github.event_name == 'push' && fromJSON('["3.10", "3.11", "3.12", "3.13", "3.14"]') || fromJSON('["3.10", "3.14"]') }}
 
     steps:
       - uses: actions/checkout@v5
@@ -175,7 +179,14 @@ jobs:
         run: pytest -m core -q
 
       - name: Run full test suite
-        run: pytest -q --junitxml=test-results.xml --cov=cairn --cov-report=term --cov-report=xml
+        run: |
+          # Coverage rides one leg only (3.12, main pushes): collecting it on
+          # every matrix leg is redundant signal at ~real minutes each.
+          if [ "${{ matrix.python-version }}" = "3.12" ]; then
+            pytest -q --junitxml=test-results.xml --cov=cairn --cov-report=term --cov-report=xml
+          else
+            pytest -q --junitxml=test-results.xml
+          fi
 
       - name: Publish test summary
         if: always()
@@ -207,7 +218,7 @@ jobs:
           EOF
 
       - name: Coverage summary
-        if: always()
+        if: always() && matrix.python-version == '3.12'
         run: |
           python - <<'EOF' >> "$GITHUB_STEP_SUMMARY"
           import xml.etree.ElementTree as ET
@@ -254,8 +265,15 @@ jobs:
       - name: Verify DS-v2 ground-truth seal (558 expectations, both corpora)
         run: python benchmarks/datasource/ds2/verify_dataset.py
 
+  # Packaging canary, MAIN PUSHES ONLY: verifies `python -m build` (sdist +
+  # wheel) stays green on every merge so packaging breakage surfaces between
+  # releases, never at tag time (release.yml builds the real multi-platform
+  # wheels there). PRs skip it deliberately -- their wheel-build cost buys no
+  # signal the test legs don't already give, and the canary still runs on the
+  # merge commit itself.
   build:
     name: Build wheel + sdist
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     needs: test
     steps:


### PR DESCRIPTION
## Summary

Cuts PR CI cost roughly in half while keeping every merge fully gated:

- **`build` ("Build wheel + sdist") → main pushes only** (`if: github.event_name == 'push'`). It's a packaging canary (one `python -m build` leg + wheel-import check); its value is catching packaging breakage on a *merge*, not on a PR. The real multi-platform wheel build was already tag-only via release.yml.
- **Test matrix → PRs run 2 legs** (3.10 floor + 3.14 ceiling, where version-specific and tree-sitter/sqlite-vec wheel-gap breakage lives); **main pushes run the full 5-leg matrix**, so a merge is always fully covered before a release tag can be cut.
- **Coverage rides one leg only** (3.12, which only exists on main pushes) — collecting it on every matrix leg was redundant signal at real minutes each.

Deliberately NOT done: moving the multi-Python matrix to tag-only. Version-specific breakage must surface at merge time, not at release time — tags are the worst moment to discover a 3.10-only failure.

## Change type

- [x] CI / chore

## Audit checklist

- [x] **Blast radius checked** — workflow-only change; no symbols touched (`explore`/`impact_analysis` n/a). Downstream consumers of the gates: branch protection requires the checks by name; job names unchanged, so required-check mappings (if any) keep matching. `build` now reports *skipped* on PRs — acceptable for a non-required advisory leg; flag at merge if it is required.
- [x] **Layering respected** — n/a (no source change).
- [x] **Graph updated** — `cairn update` n/a (no code change).
- [x] **Memory recorded** — covered by PR discussion; no durable decision beyond the file's own comments (rationale lives inline in ci.yml).
- [x] **Fallback/perf paths** — n/a.
- [x] **Tests** — CI YAML has no local harness; validated structurally (yaml.safe_load round-trip of matrix expression, `if:` conditions, job graph) + pre-commit `check yaml`. The PR's own check run is the behavioral proof: it should show exactly **2 Test legs and no Build job**.
- [x] **CHANGELOG** — no entry: CI plumbing, no user-facing behavior.
- [x] **Gates green** — pre-commit run on the changed file; conventional title.

## Blast-radius note

None — single workflow file. One behavioral nuance called out: on PRs the `build` check disappears (skipped jobs don't render as checks). If branch protection lists it as *required*, PRs would block; if that happens the fix is removing it from the required list or switching the condition to the skip-not-required pattern.

## Verification

- `uv run python -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` + assertion of the matrix expr / job conditions (passed).
- `uv run pre-commit run --files .github/workflows/ci.yml` (passed).
- This PR's checks page demonstrates the new shape end to end.
