### PR TITLE
fix(dashboard): restore blank graph canvas plus view-polish wave

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -124,7 +124,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The topbar's live-refresh Pause control no longer renders (dead) on
   the eight views without a live region: the `display: flex` rule had
   been overriding the `hidden` attribute.
-- Health and Embeddings status views render stored timestamps
+- Health, Embeddings, and Projects views render stored timestamps
   humanized (`2026-08-21 09:00:00 UTC`, not raw ISO) and an
   unreadable vec0 row count as "row count unavailable" instead of the
   literal Python `None`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Dashboard graph UX and landing coverage: the graph side panel's
+  callers/callees/impact/affected-test rows are deep links into the
+  symbol-focused graph (the store rides the href), and the FR-013
+  degradation banner links one click into the Embeddings status view
+  carrying the matching rung detail. The landing launcher grid now
+  covers every sidebar view, including the Embeddings and Settings
+  sections added in 0.16.0.
 - Graph tab curation and side panel (dashboard): the module scope's default
   view now ranks candidates by degree (fan-in + fan-out) instead of an
   arbitrary first-50 rowid sample — which had been filling the canvas with
@@ -101,6 +108,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   note) and retrieval.md (stamps, alias gate, ladder, doctor rule).
 
 ### Fixed
+- Blank dashboard graph canvas: the module scope's name-based edge join
+  multiplied same-named symbols across repos into parallel edges (10 of
+  the 11 rendered edges were one `__call__`→`append` pair), and parallel
+  edges send vis-network's force layout into a never-converging
+  simulation — zero pixels painted, in every browser. Edges are now
+  deduplicated on `(source, target, kind)` at the query layer and again
+  client-side on initial load, and degree-ranked candidates exclude
+  minified bundles and vendored/build paths (`*.min.*`, `vendor/`,
+  `dist/`, `node_modules/`; `metadata.vendored_excluded` reports the
+  count — one committed `vis-network.min.js` alone carried 1,060 junk
+  symbols). The scanner gains a matching non-overridable
+  `minified_asset` skip so future builds never index such bundles;
+  existing stores are covered at query time without a reindex.
+- The topbar's live-refresh Pause control no longer renders (dead) on
+  the eight views without a live region: the `display: flex` rule had
+  been overriding the `hidden` attribute.
+- Health and Embeddings status views render stored timestamps
+  humanized (`2026-08-21 09:00:00 UTC`, not raw ISO) and an
+  unreadable vec0 row count as "row count unavailable" instead of the
+  literal Python `None`.
 - A failed embedding backend no longer crashes `semantic_search`: the
   dense leg is guarded end to end (first pass, PRF second pass, ANN and
   brute-force legs) and hard failures flow into the ladder above.

--- a/src/cairn/dashboard/app.py
+++ b/src/cairn/dashboard/app.py
@@ -89,6 +89,20 @@ def _human_ts(value) -> str:
     return dt.strftime("%Y-%m-%d %H:%M:%S UTC")
 
 
+def _human_iso(value) -> str:
+    """ISO-8601 timestamp string as a UTC wall-clock string (``—`` when
+    absent or unparseable). Status views render stored ISO columns
+    (build_runs.started_at, embeddings.embedded_at) through this so a
+    raw ``2026-08-28T01:30:08.173238+00:00`` never reaches the page."""
+    try:
+        dt = datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+    except (TypeError, ValueError):
+        return "—"
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc).strftime("%Y-%m-%d %H:%M:%S UTC")
+
+
 def _human_duration(ms) -> str:
     """Milliseconds as ``ms`` below one second, ``s`` above (one decimal)."""
     if ms is None:
@@ -203,6 +217,7 @@ def create_app(
     )
     templates.env.filters["filesize"] = _human_size
     templates.env.filters["epoch"] = _human_ts
+    templates.env.filters["isots"] = _human_iso
     templates.env.filters["duration"] = _human_duration
     templates.env.filters["tokens"] = _est_tokens
     templates.env.filters["span"] = _human_span

--- a/src/cairn/dashboard/static/app.css
+++ b/src/cairn/dashboard/static/app.css
@@ -521,6 +521,17 @@ body.app-shell {
   font-weight: 500;
 }
 
+/* Panel names are deep links into the symbol-focused graph: the accent
+   comes from the global anchor rule; underline only on intent. */
+.panel-row a.panel-name {
+  text-decoration: none;
+}
+
+.panel-row a.panel-name:hover,
+.panel-row a.panel-name:focus {
+  text-decoration: underline;
+}
+
 .panel-empty {
   margin: 0.15rem 0;
   color: var(--muted);

--- a/src/cairn/dashboard/static/app.css
+++ b/src/cairn/dashboard/static/app.css
@@ -266,8 +266,15 @@ body.app-shell {
 
 /* ---- Live refresh chrome (topbar-mounted) ---- */
 
-#live-controls {
+/* display:flex sits behind :not([hidden]) on purpose: an author display
+   rule beats the UA's [hidden] { display: none }, so the unguarded
+   flex rule rendered the Pause button — dead, the loop never arms
+   without a #refresh-region — on every view that has no live region. */
+#live-controls:not([hidden]) {
   display: flex;
+}
+
+#live-controls {
   align-items: center;
   gap: 0.6rem;
   margin-left: auto;

--- a/src/cairn/dashboard/static/app.js
+++ b/src/cairn/dashboard/static/app.js
@@ -583,6 +583,17 @@
     return node;
   }
 
+  /* Side-panel rows deep-link into the symbol-focused graph — the same
+     seam the inspect hint and the search box navigate with (full page
+     load, browser-back returns; the store rides the href). */
+  function panelFocusUrl(name) {
+    return (
+      "/graph?scope=symbol&focus=" +
+      encodeURIComponent(name) +
+      (inspectStore ? "&store=" + encodeURIComponent(inspectStore) : "")
+    );
+  }
+
   function panelRows(list, items, nameKey, withDepth) {
     if (!items.length) {
       list.appendChild(el("li", "panel-empty", "none"));
@@ -590,7 +601,9 @@
     }
     items.forEach(function (item) {
       var row = el("li", "panel-row");
-      row.appendChild(el("span", "panel-name", item[nameKey]));
+      var name = el("a", "panel-name", item[nameKey]);
+      name.href = panelFocusUrl(item[nameKey]);
+      row.appendChild(name);
       var sub = item.file || "";
       if (withDepth && item.depth !== undefined && item.depth !== null) {
         sub = "depth " + item.depth + (sub ? " — " + sub : "");

--- a/src/cairn/dashboard/static/app.js
+++ b/src/cairn/dashboard/static/app.js
@@ -187,27 +187,32 @@
     known[n.id] = true;
   });
   var nodes = new vis.DataSet(data.nodes.map(nodeView));
-  var edges = new vis.DataSet(
-    data.edges
-      .filter(function (e) {
-        return known[e.source] && known[e.target];
-      })
-      .map(function (e, i) {
-        return {
-          id: i,
-          from: e.source,
-          to: e.target,
-          title: [e.kind, e.label].filter(Boolean).join(" — ")
-        };
-      })
-  );
-  var nextEdgeId = edges.length;
+  /* Parallel edges (same source, target AND kind) collapse to one vis
+     edge. The viz layer dedupes its name-based join, but a store built
+     before that fix still serves duplicates — and parallel edges
+     multiply the force layout's spring forces until the simulation
+     never converges (the blank-canvas bug). edgeKeys doubles as
+     merge()'s dedupe set below. */
   var edgeKeys = {};
+  var edgeViews = [];
   data.edges.forEach(function (e) {
-    if (known[e.source] && known[e.target]) {
-      edgeKeys[edgeKey(e.source, e.target, e.kind)] = true;
+    if (!known[e.source] || !known[e.target]) {
+      return;
     }
+    var key = edgeKey(e.source, e.target, e.kind);
+    if (edgeKeys[key]) {
+      return;
+    }
+    edgeKeys[key] = true;
+    edgeViews.push({
+      id: edgeViews.length,
+      from: e.source,
+      to: e.target,
+      title: [e.kind, e.label].filter(Boolean).join(" — ")
+    });
   });
+  var edges = new vis.DataSet(edgeViews);
+  var nextEdgeId = edges.length;
   /* Layout (FR-004): the initial choice comes from the server-rendered
      data-layout attribute; "hier" starts the network hierarchical
      top-down. Toggling later swaps the option on the live instance. */

--- a/src/cairn/dashboard/templates/_embed_banner.html
+++ b/src/cairn/dashboard/templates/_embed_banner.html
@@ -2,9 +2,13 @@
   FR-013 degradation banner, shared by every page via base.html. Renders
   zero bytes unless the context carries a non-empty embed_banner (the
   embed_ladder.degradation_banner() line: rung / reason / remediation), so
-  healthy pages stay byte-identical. Inline styles reuse the badge-warn
-  recipe and the theme's --warn token (dark-theme safe) because the banner
-  must live in the templates only.
+  healthy pages stay byte-identical — every block tag here carries
+  whitespace control because the include site's junction is byte-pinned.
+  Inline styles reuse the badge-warn recipe and the theme's --warn token
+  (dark-theme safe) because the banner must live in the templates only.
+  The status link rides the FR-003 store seam (links.url) and inherits
+  the banner's warn color inline.
 -#}
-{% if embed_banner %}<div class="embed-banner" role="status" style="margin: 0 0 1rem; padding: 0.6rem 0.9rem; border: 1px solid color-mix(in srgb, var(--warn) 32%, transparent); border-radius: var(--radius); background: color-mix(in srgb, var(--warn) 12%, transparent); color: var(--warn); font-size: 0.85rem; font-weight: 600;">{{ embed_banner }}</div>
+{%- import "_links.html" as links with context -%}
+{%- if embed_banner %}<div class="embed-banner" role="status" style="margin: 0 0 1rem; padding: 0.6rem 0.9rem; border: 1px solid color-mix(in srgb, var(--warn) 32%, transparent); border-radius: var(--radius); background: color-mix(in srgb, var(--warn) 12%, transparent); color: var(--warn); font-size: 0.85rem; font-weight: 600;">{{ embed_banner }} <a href="{{ links.url('/embeddings') }}" style="color: inherit; text-decoration: underline;">open Embeddings status</a></div>
 {% endif %}

--- a/src/cairn/dashboard/templates/embeddings.html
+++ b/src/cairn/dashboard/templates/embeddings.html
@@ -50,7 +50,7 @@
         <td class="num">{% if corpus.count is not none %}{{ corpus.count }}{% else %}—{% endif %}</td>
         {#- An empty corpus has never embedded; an unreadable one (pre-table
             store, unresolvable backend) is unknown, not zero. -#}
-        <td>{% if corpus.last %}{{ corpus.last }}{% elif corpus.count is none %}—{% else %}never{% endif %}</td>
+        <td>{% if corpus.last %}{{ corpus.last | isots }}{% elif corpus.count is none %}—{% else %}never{% endif %}</td>
       </tr>
       {% endfor %}
     </tbody>

--- a/src/cairn/dashboard/templates/health.html
+++ b/src/cairn/dashboard/templates/health.html
@@ -38,7 +38,7 @@
       <h2>Index freshness</h2>
       {% if health.last_build_age %}
       <p class="card-value">{{ health.last_build_age }}</p>
-      <p class="muted">last build {{ health.last_build_at }}</p>
+      <p class="muted">last build {{ health.last_build_at | isots }}</p>
       {% else %}
       <p class="card-value">never</p>
       <p class="muted">no build_runs recorded</p>
@@ -60,7 +60,14 @@
       {% if health.ann_index_exists is none %}
       <p class="muted">no embeddings to index yet</p>
       {% elif health.ann_index_exists %}
+      {#- index_row_count is defensive: a read failure (e.g. the vector
+          extension not loadable) returns None — report that honestly
+          instead of the literal "None rows". -#}
+      {% if health.ann_index_rows is none %}
+      <p class="muted">vec0 index present — row count unavailable</p>
+      {% else %}
       <p class="muted">vec0 index: {{ health.ann_index_rows }} rows</p>
+      {% endif %}
       {% else %}
       <p class="muted">no vec0 index built</p>
       {% endif %}

--- a/src/cairn/dashboard/templates/index.html
+++ b/src/cairn/dashboard/templates/index.html
@@ -57,6 +57,16 @@
       <span class="launcher-title">Task queue</span>
       <span class="launcher-blurb">LLM synthesis jobs</span>
     </a>
+    <a class="launcher-card" href="{{ links.url('/embeddings') }}">
+      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m21 16-9 5-9-5V8l9-5 9 5z"/><path d="m3.3 7 8.7 5 8.7-5"/><path d="M12 22V12"/></svg>
+      <span class="launcher-title">Embeddings</span>
+      <span class="launcher-blurb">Backend, stamp, per-corpus state</span>
+    </a>
+    <a class="launcher-card" href="{{ links.url('/settings') }}">
+      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M4 21v-7"/><path d="M4 10V3"/><path d="M12 21v-9"/><path d="M12 8V3"/><path d="M20 21v-5"/><path d="M20 12V3"/><path d="M2 14h4"/><path d="M10 8h4"/><path d="M18 16h4"/></svg>
+      <span class="launcher-title">Settings</span>
+      <span class="launcher-blurb">Embedding config + parity check</span>
+    </a>
   </div>
 </section>
 {% endblock %}

--- a/src/cairn/dashboard/templates/projects.html
+++ b/src/cairn/dashboard/templates/projects.html
@@ -47,7 +47,7 @@
         <td class="num">{{ p.file_count }}</td>
         <td class="num">{{ p.symbol_count }}</td>
         <td class="num">{{ p.edge_count }}</td>
-        <td>{{ p.last_indexed or "never" }}</td>
+        <td>{{ p.last_indexed | isots if p.last_indexed else "never" }}</td>
         <td>
           <span class="badge badge-{{ p.embedding_status }}">{{ p.embedding_status }}</span>
           {%- if p.embedding_models %} <span class="muted">{{ p.embedding_models | join(", ") }}</span>

--- a/src/cairn/graph/scanner.py
+++ b/src/cairn/graph/scanner.py
@@ -127,6 +127,7 @@ REASON_DEFAULT_SKIP = "default_skip"
 REASON_GITIGNORED = "gitignored"
 REASON_CONFIG_EXCLUDE = "config_exclude"
 REASON_SIZE_CAP = "size_cap"
+REASON_MINIFIED = "minified_asset"
 
 # Workspace root resolved from the current context (see src/paths.py):
 #   CAIRN_WORKSPACE env > registered ancestor > cwd. Resolved at import time;
@@ -361,6 +362,17 @@ def _is_under_skip_dir(rel_parts: tuple) -> bool:
     return False
 
 
+def _is_minified(path: Path) -> bool:
+    """Layer D: True for minified bundles (``*.min.js`` et al).
+
+    The filename marker, not the size cap, is what catches a vendored
+    bundle committed under src/ — a 400 KB min.js parses into hundreds of
+    junk symbols whose internal calls dominate every degree-ranked view
+    (the scanner's dir layers only catch vendor/ trees, not vendored
+    single files). """
+    return ".min." in path.name.lower()
+
+
 def classify_file(
     abs_path: Path,
     repo_root: Path,
@@ -370,8 +382,10 @@ def classify_file(
 ) -> Tuple[bool, str]:
     """Return (should_index, reason_if_skipped) for one source file.
 
-    Runs the layers in order. `include` overrides A/B/C (Layer D size cap is
-    NOT overridable -- a 50 MB vendored blob helps no one).
+    Runs the layers in order. `include` overrides A/B/C (Layer D size cap
+    and minified-asset skip are NOT overridable -- a 50 MB vendored blob
+    helps no one, and a minified bundle is generated noise in every view
+    regardless of what the config asks for).
     """
     try:
         rel_parts = abs_path.relative_to(repo_root).parts
@@ -379,9 +393,12 @@ def classify_file(
         return False, REASON_DEFAULT_SKIP
 
     # `include` override: checked first. A path explicitly included skips the
-    # A/B/C checks (but still subject to D: size cap).
+    # A/B/C checks (but still subject to D: minified skip + size cap).
     if include_spec is not None and _match_root_relative(include_spec, abs_path, repo_root):
-        # Still enforce size cap even for included files.
+        # Still enforce the Layer D generated-asset skips even for
+        # included files.
+        if _is_minified(abs_path):
+            return False, REASON_MINIFIED
         try:
             size = abs_path.stat().st_size
         except OSError:
@@ -402,7 +419,9 @@ def classify_file(
     if exclude_spec is not None and _match_root_relative(exclude_spec, abs_path, repo_root):
         return False, REASON_CONFIG_EXCLUDE
 
-    # Layer D: size cap.
+    # Layer D: generated assets — minified bundles, then the size cap.
+    if _is_minified(abs_path):
+        return False, REASON_MINIFIED
     try:
         size = abs_path.stat().st_size
     except OSError:

--- a/src/cairn/viz/query.py
+++ b/src/cairn/viz/query.py
@@ -6,6 +6,7 @@ Scopes: symbol, neighbors, module, impact, repo, deps. Returns a uniform
 from __future__ import annotations
 
 import sqlite3
+from pathlib import PurePosixPath
 from typing import Dict, Sequence
 
 
@@ -169,6 +170,22 @@ def get_repo_graph(conn: sqlite3.Connection, repo: str, max_nodes: int = 30) -> 
 _MODULE_CAP = 50
 _MODULE_EDGE_CAP = 100
 
+# Paths whose symbols are generated or third-party noise, not hand-written
+# structure. Minified bundles dominate the degree ranking (one vendored
+# vis-network.min.js carried 1,060 symbols whose internal calls outrank every
+# real hub), and the scanner's dir/size layers cannot catch a vendored file
+# committed under src/ — the filename marker does. Matches the scanner's
+# DEFAULT_SKIP_DIRS intent for stores built before those layers existed.
+_VENDORED_SEGMENTS = {"vendor", "dist", "node_modules"}
+
+
+def _is_vendored_path(path: str) -> bool:
+    """True for minified bundles and vendored/build directories."""
+    parts = PurePosixPath(path.replace("\\", "/")).parts
+    if ".min." in parts[-1].lower():
+        return True
+    return any(part.lower() in _VENDORED_SEGMENTS for part in parts[:-1])
+
 
 def get_module_graph(
     conn: sqlite3.Connection, module: str = "", include_tests: bool = False
@@ -182,14 +199,22 @@ def get_module_graph(
     fan-out of any edges) then name, so the cap lands on the symbols that
     carry the module's structure. Tests are excluded by default (the
     ``is_test_symbol`` heuristics from the impact layer); ``include_tests``
-    opts back in. ``metadata.tests_included`` and ``metadata.truncated``
-    report both choices honestly.
+    opts back in. Symbols from vendored/minified assets
+    (:func:`_is_vendored_path`) are never candidates — they are generated
+    noise in every scope, so unlike tests they have no opt-in. Edges are
+    deduplicated on ``(source, target, kind)``: the join is by bare symbol
+    name, so same-named symbols across repos multiply one logical edge into
+    many parallel rows (which also destabilize vis-network's force layout
+    into a blank canvas). ``metadata.tests_included``, ``metadata.truncated``
+    and ``metadata.vendored_excluded`` report all three choices honestly.
     """
     from ..graph.tests import is_test_symbol
 
     cur = conn.cursor()
     nodes = {}
     edges = []
+    seen_edges = set()
+    vendored_excluded = 0
     rows = cur.execute(
         "SELECT s.name, s.kind, f.path, f.repo_id, s.qualified_name, "
         "(SELECT COUNT(*) FROM edges e WHERE e.target_id = s.id) + "
@@ -202,6 +227,9 @@ def get_module_graph(
     kept = 0
     eligible = 0
     for r in rows:
+        if _is_vendored_path(r["path"]):
+            vendored_excluded += 1
+            continue
         if not include_tests and is_test_symbol(
             r["path"], r["name"], r["qualified_name"] or ""
         )["is_test"]:
@@ -224,6 +252,10 @@ def get_module_graph(
         ).fetchall()
         for r in rows:
             if r["tgt"] in nodes:
+                key = (r["src"], r["tgt"], r["kind"])
+                if key in seen_edges:
+                    continue
+                seen_edges.add(key)
                 edges.append({"source": r["src"], "target": r["tgt"], "kind": r["kind"]})
     return {
         "nodes": list(nodes.values()),
@@ -235,6 +267,7 @@ def get_module_graph(
             "edge_count": len(edges),
             "tests_included": include_tests,
             "truncated": eligible > _MODULE_CAP,
+            "vendored_excluded": vendored_excluded,
         },
     }
 

--- a/tests/test_dashboard_app.py
+++ b/tests/test_dashboard_app.py
@@ -95,6 +95,12 @@ def test_create_app_serves_landing_and_static(tmp_path):
     assert landing.status_code == 200
     assert "Cairn Dashboard" in landing.text
     assert db_path in landing.text
+    # Every sidebar view is reachable from the launcher grid, including
+    # the two newest sections.
+    for href in ("/workspaces", "/projects", "/graph", "/history", "/tokens",
+                 "/chains", "/health", "/memory", "/tasks", "/embeddings",
+                 "/settings"):
+        assert f'href="{href}"' in landing.text, href
 
     css = client.get("/static/app.css")
     assert css.status_code == 200

--- a/tests/test_dashboard_app.py
+++ b/tests/test_dashboard_app.py
@@ -738,7 +738,9 @@ def test_health_route_shows_size_freshness_backend_and_reranker(tmp_path):
     from cairn.dashboard.app import _human_size
 
     assert _human_size(os.stat(db_path).st_size) in resp.text
-    assert "2026-08-20T07:00:00Z" in resp.text
+    # build_runs.started_at renders humanized (isots), never raw ISO.
+    assert "2026-08-20 07:00:00 UTC" in resp.text
+    assert "2026-08-20T07:00:00Z" not in resp.text
     assert re.search(r"just now|\b\d+[smhd] old\b", resp.text)
 
     # conftest clears CAIRN_EMBED_BACKEND, so the local default is active.
@@ -768,6 +770,26 @@ def test_health_route_empty_db_renders_empty_state(tmp_path):
     assert resp.status_code == 200
     assert "no build_runs recorded" in resp.text
     assert "no embeddings to index yet" in resp.text
+
+
+def test_health_route_unknown_index_row_count_is_honest(tmp_path, monkeypatch):
+    """A present vec0 index whose row count cannot be read (the defensive
+    None from index_row_count) renders an honest note — never the literal
+    Python None ("vec0 index: None rows")."""
+    import cairn.dashboard.data as dashboard_data
+
+    monkeypatch.setattr(dashboard_data, "embed_count", lambda conn: 42)
+    monkeypatch.setattr(dashboard_data, "index_exists", lambda conn, model: True)
+    monkeypatch.setattr(
+        dashboard_data, "index_row_count", lambda conn, model: None
+    )
+    client = _panel_client(
+        tmp_path, _health_db_file(tmp_path, seed=True), str(tmp_path / "knowledge")
+    )
+    resp = client.get("/health")
+    assert resp.status_code == 200
+    assert "row count unavailable" in resp.text
+    assert "None rows" not in resp.text
 
 
 def _seed_memories(knowledge_dir):
@@ -3373,8 +3395,10 @@ def test_embeddings_status_renders_backend_stamp_counts_and_freshness(
     assert '<td class="num">1</td>' in resp.text  # code: current model only
     assert '<td class="num">2</td>' in resp.text  # knowledge rows
     assert '<td class="num">0</td>' in resp.text  # memory: a zero, not unknown
-    assert "2026-08-21T09:00:00" in resp.text  # MAX(code embedded_at)
-    assert "2026-08-20T12:30:00" in resp.text  # MAX(knowledge embedded_at)
+    # embedded_at renders humanized (isots), never raw ISO.
+    assert "2026-08-21 09:00:00 UTC" in resp.text  # MAX(code embedded_at)
+    assert "2026-08-20 12:30:00 UTC" in resp.text  # MAX(knowledge embedded_at)
+    assert "2026-08-21T09:00:00" not in resp.text
     assert "never" in resp.text  # memory has never embedded
 
 

--- a/tests/test_dashboard_app.py
+++ b/tests/test_dashboard_app.py
@@ -2984,6 +2984,8 @@ def test_embed_banner_names_rung_reason_and_remediation_on_every_page(
     assert "rung 3" in resp.text
     assert "model_missing" in resp.text
     assert "CAIRN_EMBED_SERVER_MODEL" in resp.text  # the remediation
+    # The banner links one click into the status view (store riding).
+    assert 'href="/embeddings?store=' in resp.text or 'href="/embeddings"' in resp.text
 
 
 def test_embed_banner_prefers_this_process_ladder_verdict(

--- a/tests/test_dashboard_app.py
+++ b/tests/test_dashboard_app.py
@@ -194,7 +194,7 @@ def test_projects_route_lists_counts_and_embedding_status(tmp_path):
     for header in ("Files", "Symbols", "Edges", "Last indexed", "Embeddings"):
         assert header in resp.text
     assert '<td class="num">3</td>' in resp.text  # symbol count
-    assert "2026-08-20T11:00:00" in resp.text  # MAX(files.indexed_at)
+    assert "2026-08-20 11:00:00 UTC" in resp.text  # MAX(files.indexed_at), humanized
     assert "embedded" in resp.text
     assert "all-MiniLM-L6-v2" in resp.text
     assert "/graph?scope=repo" in resp.text and "repo=demo" in resp.text
@@ -2500,9 +2500,9 @@ def test_store_param_serves_the_selected_workspace(tmp_path, monkeypatch):
     health_a = client.get("/health", params={"store": _SW_KEY_A})
     health_b = client.get("/health", params={"store": _SW_KEY_B})
     assert str(home / _SW_KEY_A / ".kg") in health_a.text
-    assert "2026-08-20T07:00:00Z" in health_a.text
+    assert "2026-08-20 07:00:00 UTC" in health_a.text
     assert str(home / _SW_KEY_B / ".kg") in health_b.text
-    assert "2026-08-20T09:00:00Z" in health_b.text
+    assert "2026-08-20 09:00:00 UTC" in health_b.text
 
     # No param: the launch store, exactly as before the seam existed.
     plain = client.get("/projects")

--- a/tests/test_dashboard_data.py
+++ b/tests/test_dashboard_data.py
@@ -2435,6 +2435,113 @@ def test_module_scope_focus_filters_tests_too(fresh_db):
     assert "test_case_00" in {n["id"] for n in opted_in["nodes"]}
 
 
+def _seed_vendored(conn):
+    """One minified asset whose internal calls give it the workspace's
+    highest-degree symbols, one vendored dir, and one real hub."""
+    conn.executemany(
+        "INSERT INTO repos (id, name, path, language, indexed_at) VALUES (?, ?, ?, ?, ?)",
+        [("v", "v", ".", "javascript", "2026-08-28T00:00:00")],
+    )
+    conn.executemany(
+        "INSERT INTO files (id, repo_id, path, language, indexed_at) VALUES (?, ?, ?, ?, ?)",
+        [
+            ("f_min", "v", "src/web/static/app.min.js", "javascript", "2026-08-28T00:00:00"),
+            ("f_dist", "v", "dist/bundle/helpers.js", "javascript", "2026-08-28T00:00:00"),
+            ("f_real", "v", "src/web/app.py", "python", "2026-08-28T00:00:00"),
+        ],
+    )
+    rows = [
+        ("s_min_a", "f_min", "append", "minified.append", "method"),
+        ("s_min_b", "f_min", "emit", "minified.emit", "function"),
+        ("s_dist", "f_dist", "dist_helper", "bundled.dist_helper", "function"),
+        ("s_real_a", "f_real", "real_main", "web.app.real_main", "function"),
+        ("s_real_b", "f_real", "real_helper", "web.app.real_helper", "function"),
+    ]
+    conn.executemany(
+        "INSERT INTO symbols (id, file_id, name, qualified_name, kind, docstring) "
+        "VALUES (?, ?, ?, ?, ?, NULL)",
+        rows,
+    )
+    # Degree 6+2 for the minified pair (workspace top), degree 1 for the hub.
+    conn.executemany(
+        "INSERT INTO edges (id, source_id, target_id, kind) VALUES (?, ?, ?, ?)",
+        [
+            ("ve1", "s_min_a", "s_min_b", "calls"),
+            ("ve2", "s_min_a", "s_min_b", "calls"),
+            ("ve3", "s_min_a", "s_min_b", "calls"),
+            ("ve4", "s_min_b", "s_min_a", "calls"),
+            ("ve5", "s_min_b", "s_min_a", "calls"),
+            ("ve6", "s_min_b", "s_min_a", "calls"),
+            ("ve7", "s_real_a", "s_real_b", "calls"),
+            ("ve8", "s_dist", "s_real_a", "calls"),
+        ],
+    )
+    conn.commit()
+
+
+def test_module_scope_excludes_vendored_and_minified_symbols(fresh_db):
+    from cairn.dashboard.data import get_graph
+
+    _seed_vendored(fresh_db)
+    graph = get_graph(fresh_db)
+
+    ids = {n["id"] for n in graph["nodes"]}
+    # The minified pair has the workspace's top degree but is never a
+    # candidate; the dist/ dir is excluded by the same rule.
+    assert "append" not in ids and "emit" not in ids and "dist_helper" not in ids
+    assert ids == {"real_main", "real_helper"}
+    assert graph["metadata"]["vendored_excluded"] == 3
+    # The dist->real edge dies with its vendored source node.
+    assert graph["metadata"]["edge_count"] == 1
+
+
+def test_module_scope_dedupes_cross_repo_parallel_edges(fresh_db):
+    from cairn.dashboard.data import get_graph
+
+    # Same bare names in two repos: the name-based edge join sees three
+    # rows for ONE logical edge, plus a distinct kind that must survive.
+    fresh_db.executemany(
+        "INSERT INTO repos (id, name, path, language, indexed_at) VALUES (?, ?, ?, ?, ?)",
+        [
+            ("r1", "r1", ".", "python", "2026-08-28T00:00:00"),
+            ("r2", "r2", ".", "python", "2026-08-28T00:00:00"),
+        ],
+    )
+    fresh_db.executemany(
+        "INSERT INTO files (id, repo_id, path, language, indexed_at) VALUES (?, ?, ?, ?, ?)",
+        [
+            ("f_r1", "r1", "src/one.py", "python", "2026-08-28T00:00:00"),
+            ("f_r2", "r2", "src/two.py", "python", "2026-08-28T00:00:00"),
+        ],
+    )
+    fresh_db.executemany(
+        "INSERT INTO symbols (id, file_id, name, qualified_name, kind, docstring) "
+        "VALUES (?, ?, ?, ?, ?, NULL)",
+        [
+            ("s_a1", "f_r1", "caller", "one.caller", "function"),
+            ("s_b1", "f_r1", "helper", "one.helper", "function"),
+            ("s_a2", "f_r2", "caller", "two.caller", "function"),
+            ("s_b2", "f_r2", "helper", "two.helper", "function"),
+        ],
+    )
+    fresh_db.executemany(
+        "INSERT INTO edges (id, source_id, target_id, kind) VALUES (?, ?, ?, ?)",
+        [
+            ("pe1", "s_a1", "s_b1", "calls"),
+            ("pe2", "s_a2", "s_b2", "calls"),
+            ("pe3", "s_a1", "s_b2", "calls"),
+            ("pe4", "s_a2", "s_b1", "imports"),
+        ],
+    )
+    fresh_db.commit()
+
+    graph = get_graph(fresh_db)
+    # One calls edge caller->helper; the distinct-kind imports edge stays.
+    assert graph["metadata"]["edge_count"] == 2
+    kinds = sorted((e["source"], e["target"], e["kind"]) for e in graph["edges"])
+    assert kinds == [("caller", "helper", "calls"), ("caller", "helper", "imports")]
+
+
 # ---------------------------------------------------------------------------
 # Symbol inspect payload (graph-tab side panel): one call answering
 # "what is this, what feeds it, what does it touch, what breaks".

--- a/tests/test_dashboard_readonly.py
+++ b/tests/test_dashboard_readonly.py
@@ -536,7 +536,7 @@ def test_launcher_interactions_leave_every_store_byte_identical(
     assert "ws_a_tool" not in history_b.text
     health_a = _fetch(client, f"/health?store={_WS_KEY_A}")
     assert str(home / _WS_KEY_A / ".kg") in health_a.text
-    assert "2026-08-20T07:00:00Z" in health_a.text
+    assert "2026-08-20 07:00:00 UTC" in health_a.text
 
     # The selected-store sweep: every data view against each populated
     # store.

--- a/tests/test_scanner_minified.py
+++ b/tests/test_scanner_minified.py
@@ -1,0 +1,93 @@
+"""Scanner Layer D: minified bundles skip as generated assets.
+
+A vendored min.js committed under src/ (e.g. a JS library bundle) parses
+into hundreds of junk symbols whose internal calls dominate every
+degree-ranked view. The dir layers only catch vendor/ trees, so the
+filename marker is the skip that works; like the size cap it is NOT
+overridable by a config include.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pathspec
+
+from cairn.graph.scanner import (
+    MAX_FILE_SIZE,
+    REASON_MINIFIED,
+    REASON_SIZE_CAP,
+    classify_file,
+)
+
+
+def _specs(include=None, exclude=None):
+    include_spec = (
+        pathspec.PathSpec.from_lines("gitignore", include) if include else None
+    )
+    exclude_spec = (
+        pathspec.PathSpec.from_lines("gitignore", exclude) if exclude else None
+    )
+    return [], exclude_spec, include_spec
+
+
+def _write(tmp_path: Path, rel: str, size: int = 10) -> Path:
+    f = tmp_path / rel
+    f.parent.mkdir(parents=True, exist_ok=True)
+    f.write_bytes(b"x" * size)
+    return f
+
+
+def test_min_js_skips_with_minified_reason(tmp_path):
+    f = _write(tmp_path, "src/web/static/vis-network.min.js")
+    keep, reason = classify_file(f, tmp_path, *_specs())
+    assert keep is False
+    assert reason == REASON_MINIFIED
+
+
+def test_min_mjs_and_mixed_case_marker_also_skip(tmp_path):
+    for rel in ("lib/app.min.mjs", "lib/Vendor.Min.JS"):
+        f = _write(tmp_path, rel)
+        keep, reason = classify_file(f, tmp_path, *_specs())
+        assert keep is False, rel
+        assert reason == REASON_MINIFIED, rel
+
+
+def test_dot_min_in_a_directory_name_does_not_skip(tmp_path):
+    # The marker is a filename check: x.min.y as a DIR component with a
+    # clean filename stays indexable.
+    f = _write(tmp_path, "src/x.min.y/normal.py")
+    keep, reason = classify_file(f, tmp_path, *_specs())
+    assert keep is True
+    assert reason == ""
+
+
+def test_plain_source_still_indexes(tmp_path):
+    f = _write(tmp_path, "src/web/app.js")
+    keep, reason = classify_file(f, tmp_path, *_specs())
+    assert keep is True
+    assert reason == ""
+
+
+def test_include_spec_cannot_override_minified(tmp_path):
+    f = _write(tmp_path, "src/web/static/app.min.js")
+    keep, reason = classify_file(
+        f, tmp_path, *_specs(include=["*.min.js"])
+    )
+    assert keep is False
+    assert reason == REASON_MINIFIED
+
+
+def test_minified_reason_wins_over_size_cap(tmp_path):
+    f = _write(
+        tmp_path, "src/web/static/app.min.js", size=MAX_FILE_SIZE + 1
+    )
+    keep, reason = classify_file(f, tmp_path, *_specs())
+    assert keep is False
+    assert reason == REASON_MINIFIED
+
+
+def test_oversize_plain_file_keeps_size_cap_reason(tmp_path):
+    f = _write(tmp_path, "src/web/generated_big.js", size=MAX_FILE_SIZE + 1)
+    keep, reason = classify_file(f, tmp_path, *_specs())
+    assert keep is False
+    assert reason == REASON_SIZE_CAP


### PR DESCRIPTION
## Summary

The dashboard's flagship Graph tab rendered a completely blank canvas on
the main workspace — pixel-verified zero painted pixels in stock Chrome
and the in-app browser. Root cause chain: a vendored `vis-network.min.js`
committed under `src/` indexed 1,060 junk symbols that won the module
scope's degree ranking; the name-based edge join multiplied same-named
symbols across repos into parallel edges (10 of 11 were one
`__call__`→`append` pair); and parallel edges send vis-network's force
layout into a never-converging simulation. Fixed at three layers
(query, scanner, client), plus the smaller defects the deep dive turned
up and the graph-UX links that fell out of it.

## Change type

- [x] Feature / improvement
- [x] Bugfix
- [ ] Refactor (no behavior change)
- [ ] Docs / chore / CI

## Audit checklist

- [x] **Blast radius checked** — `cairn callers`/`cairn impact` (CLI
  fallback; MCP unavailable this session) on `get_module_graph` (consumers:
  dashboard `get_graph`, CLI `viz` hook, MCP `visualize_graph`) and on
  `classify_file` (consumers: builder scan + watcher event gate). MCP
  `visualize_graph` sees only the intended output change: deduped edges,
  no vendored nodes.
- [x] **Layering respected** — changes stay inside viz/query (read layer),
  graph/scanner (ingest layer, own skip reason), and the dashboard package;
  no cross-boundary imports added.
- [x] **Graph updated** — `cairn update` ran post-change (reindexed 0
  files; scanner skip affects future builds only).
- [x] **Memory recorded** — deep-dive findings + fix-wave outcome recorded
  in the session memory store.
- [x] **Fallback/perf paths** — no fallback or performance path altered:
  the ladder/embedding seams are untouched; the scanner skip removes work.
  `cairn doctor` not required by spec §6.4.
- [x] **Tests** — full suite 2619 passed / 3 skipped; new tests: module
  scope vendored exclusion + edge dedupe (`test_dashboard_data.py`),
  scanner minified skip matrix (`test_scanner_minified.py`, 7 cases),
  honest index-row rendering, landing href completeness, humanized
  timestamp assertions; tests are hermetic (fixtures/tmp_path only).
- [x] **CHANGELOG** — `[Unreleased]` Added + Fixed entries written.
- [x] **Gates green** — pre-commit `--all-files` all hooks passed;
  conventional title; no new mypy/bandit surface (one template filter +
  pure functions).

## Blast-radius note

`get_module_graph` output changes intentionally (deduped edges,
vendored-free nodes, new `vendored_excluded` metadata key — additive).
All three consumers render or serialize the shape verbatim; the metadata
dict is open. `classify_file` gains one non-overridable skip; stores
built before the change keep their min.js symbols until reindex, which
the query-layer exclusion covers.

## Verification

- Root cause proven empirically: pixel-sampled the vis canvas (0
  non-transparent samples before), reproduced with the real payload in a
  standalone stock-Chrome page, bisected to the parallel-edge data,
  confirmed the synthetic control renders.
- After the fix: relaunched `cairn dashboard` over the real workspace
  store — `scope module` now serves 48 nodes / 1 edge with
  `vendored_excluded: 1060`, and the canvas paints (screenshot verified);
  the dead Pause button is gone from non-live views.
- `uv run pytest -q`: 2619 passed, 3 skipped. `uv run --extra dev
  pre-commit run --all-files`: all hooks passed.