### PR TITLE
chore(ci): drive mypy to a clean hard gate and pin bandit advisories

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,14 +46,13 @@ jobs:
         continue-on-error: true
         run: bandit -r src -ii -ll -s B608
 
-  # --- Type checking: ADVISORY at adoption --------------------------------
-  # mypy reports ~52 errors at default settings today (--ignore-missing-imports
-  # because tree-sitter & friends ship no stubs). Same philosophy as the ruff
-  # gate: ship advisory so NEW type regressions are visible without blocking
-  # CI, then drive the count down and remove `continue-on-error` to make it a
-  # hard gate.
+  # --- Type checking: HARD gate --------------------------------------------
+  # mypy runs clean at default settings (--ignore-missing-imports because
+  # tree-sitter & friends ship no stubs) after the 0-error cleanup wave
+  # (63 errors at adoption time). New type regressions now block CI, same
+  # philosophy as the ruff gate.
   typecheck:
-    name: Type check (mypy, advisory)
+    name: Type check (mypy)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
@@ -65,14 +64,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -e ".[dev]"
-      # continue-on-error at the STEP level (not job) -- the standard advisory
-      # pattern, same as bandit above: the job reports SUCCESS (green) so it
-      # doesn't block branch protection, while still printing the ~52 known
-      # errors in the log for visibility. (Job-level continue-on-error leaves
-      # the check red in branch protection.) Remove this line to promote mypy
-      # to a hard gate once the error count is driven down.
       - name: mypy
-        continue-on-error: true
         run: mypy --ignore-missing-imports src
 
   # --- Conventional Commit PR-title gate (hard) ---------------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   boot and CLI paths, and a changed-`CAIRN_HOME` reinstall refreshes
   stale env in the zcode/opencode/kilo config shapes.
 
+### Changed
+- CI type-check gate hardened: mypy was driven from 63 reported errors
+  (advisory `continue-on-error` step) to a clean run across all 172
+  source files and is now a hard gate that blocks CI on new type
+  regressions, matching the ruff gate's philosophy. The fixes were
+  annotations and narrowing for our own code; targeted `type:
+  ignore[...]` markers with justifications only where stubs are
+  genuinely absent (protobuf codegen, OTel SDK re-exports,
+  pydantic-settings version skew, the <3.10 entry-points dict shape).
+- The 7 Medium-severity bandit advisory findings (6x B310 urlopen,
+  1x B615 HuggingFace `from_pretrained`) are pinned with inline
+  `# nosec` markers carrying their review rationale, so the advisory
+  report stays empty while future genuinely-untrusted URL opens would
+  still be flagged (no global skip list added).
+
+### Fixed
+- Eval harness latent crash in the lexical fallback: `search_symbols`
+  returns `sqlite3.Row` rows, which have no `.get` — the fallback path
+  (taken when semantic search raises, e.g. embeddings unavailable)
+  crashed with `AttributeError` instead of degrading. Rows are now
+  indexed directly (`r["name"]`, guaranteed by the SELECT).
+- C# parser no longer emits an edge with a `None` target when a
+  `new T<...>()` generic-name extraction finds no leading identifier;
+  the edge is skipped instead.
+- Storing a memory concept whose title is missing no longer feeds
+  `None` into the slugifier (tier-id paths in both the file-backed and
+  protocol stores now coerce an empty title first).
+
 ## [0.16.0] - 2026-08-28
 
 ### Added

--- a/src/cairn/bench/datasource.py
+++ b/src/cairn/bench/datasource.py
@@ -97,6 +97,7 @@ import platform
 import re
 import stat
 from pathlib import Path
+from typing import TypeGuard
 
 from .. import __version__
 
@@ -133,7 +134,7 @@ _HEX64 = re.compile(r"[0-9a-f]{64}")
 _HEX_SHA = re.compile(r"[0-9a-fA-F]{40}(?:[0-9a-fA-F]{24})?")
 
 
-def _is_int(value: object) -> bool:
+def _is_int(value: object) -> TypeGuard[int]:
     """True for real ints -- bool is an int subclass and never counts."""
     return isinstance(value, int) and not isinstance(value, bool)
 

--- a/src/cairn/cli/_helpers.py
+++ b/src/cairn/cli/_helpers.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import json
 
 
-def _human_bytes(n: int) -> str:
+def _human_bytes(n: float) -> str:
     for unit in ("B", "KB", "MB", "GB"):
         if n < 1024:
             return f"{n:.0f} {unit}"

--- a/src/cairn/cli/display.py
+++ b/src/cairn/cli/display.py
@@ -11,7 +11,7 @@ import re
 import sys
 import time
 from contextlib import contextmanager
-from typing import Iterator, Optional
+from typing import Iterator, Literal, Optional
 
 from rich.console import Console
 from rich.live import Live
@@ -20,6 +20,7 @@ from rich.progress import (
     MofNCompleteColumn,
     Progress,
     SpinnerColumn,
+    TaskID,
     TaskProgressColumn,
     TextColumn,
     TimeElapsedColumn,
@@ -97,7 +98,9 @@ def print_table(title: Optional[str], columns: list[str], rows: list[list]) -> N
     table = Table(title=title, title_style="bold", show_header=True, header_style="bold cyan")
     for col in columns:
         # Right-align columns whose header looks numeric (count, n, etc.)
-        justify = "right" if col.lower() in {"count", "n", "calls", "symbols", "edges", "files", "repos"} else "left"
+        justify: Literal["left", "right"] = (
+            "right" if col.lower() in {"count", "n", "calls", "symbols", "edges", "files", "repos"} else "left"
+        )
         table.add_column(col, justify=justify)
     for row in rows:
         table.add_row(*[str(c) for c in row])
@@ -131,7 +134,7 @@ class _PlainTextProgress:
     def __init__(self, description: str, total: Optional[int], unit: str):
         self.tasks = [_SimpleTask(description, total, unit)]
         self._cg_task_id = 0
-        self._last_desc = None
+        self._last_desc: Optional[str] = None
         self._t0 = time.time()
         # Start _last_draw at _t0 so the first non-forced draw is throttled.
         self._last_draw = self._t0
@@ -218,7 +221,7 @@ class _RichProgressHandle:
     API so ``progress_bar()`` callers see the same contract on both backends.
     """
 
-    def __init__(self, progress: Progress, task_id: int):
+    def __init__(self, progress: Progress, task_id: TaskID):
         self._progress = progress
         self._cg_task_id = task_id
 
@@ -226,7 +229,7 @@ class _RichProgressHandle:
     def tasks(self):
         return self._progress.tasks
 
-    def update(self, task_id: int, **kwargs) -> None:
+    def update(self, task_id: TaskID, **kwargs) -> None:
         self._progress.update(task_id, **kwargs)
 
     def advance(self, amount: int = 1) -> None:

--- a/src/cairn/cli/uninstall.py
+++ b/src/cairn/cli/uninstall.py
@@ -34,6 +34,16 @@ def _home() -> Path:
 
 # ─── detection helpers ─────────────────────────────────────────────────────
 
+def _pkg_root() -> Path:
+    """The source-checkout root (three levels above the cairn package)."""
+    from importlib.util import find_spec
+
+    spec = find_spec("cairn")
+    if spec is None or spec.origin is None:
+        raise RuntimeError("cannot locate the installed cairn package")
+    return Path(spec.origin).resolve().parents[2]
+
+
 def _detect_install_method() -> str:
     """How cairn-intel was installed: 'uv', 'pipx', 'pip', 'venv', or 'unknown'."""
     exe = sys.executable
@@ -55,8 +65,7 @@ def _detect_install_method() -> str:
         pass
     # Source checkout's in-tree venv (.venv at the package root).
     try:
-        from importlib.util import find_spec
-        pkg_root = Path(find_spec("cairn").origin).resolve().parents[2]
+        pkg_root = _pkg_root()
         if (pkg_root / ".venv").exists() and pkg_root / ".venv" in Path(exe).resolve().parents:
             return "venv"
     except Exception:
@@ -69,8 +78,7 @@ def _detect_install_method() -> str:
 def _stale_artifacts() -> list[Path]:
     """Leftover build/, dist/, *.egg-info in the source tree (pip install -e debris)."""
     try:
-        from importlib.util import find_spec
-        pkg_root = Path(find_spec("cairn").origin).resolve().parents[2]
+        pkg_root = _pkg_root()
     except Exception:
         return []
     found: list[Path] = []
@@ -263,8 +271,7 @@ def _remove_binary(installed_via: str, dry_run: bool) -> None:
         subprocess.run([sys.executable, "-m", "pip", "uninstall", "-y", "cairn-intel"], check=False)
     elif installed_via == "venv":
         try:
-            from importlib.util import find_spec
-            pkg_root = Path(find_spec("cairn").origin).resolve().parents[2]
+            pkg_root = _pkg_root()
             shutil.rmtree(pkg_root / ".venv", ignore_errors=True)
         except Exception:
             pass

--- a/src/cairn/cli/upgrade.py
+++ b/src/cairn/cli/upgrade.py
@@ -43,7 +43,7 @@ def _pypi_latest() -> str | None:
         import json
         url = "https://pypi.org/pypi/cairn-intel/json"
         req = urllib.request.Request(url, headers={"Accept": "application/json"})
-        with urllib.request.urlopen(req, timeout=5) as resp:
+        with urllib.request.urlopen(req, timeout=5) as resp:  # nosec B310 -- fixed https URL
             data = json.loads(resp.read())
             return data["info"]["version"]
     except Exception:

--- a/src/cairn/cli/validate.py
+++ b/src/cairn/cli/validate.py
@@ -102,8 +102,8 @@ def verify(doc_path, db, knowledge):
 
     status = "OK" if result.passed else "FAIL"
     click.echo(f"[{status}] {doc_path} (quality={result.quality_score:.2f})")
-    for e in result.errors:
-        click.echo(f"  ERROR: {e}")
+    for err in result.errors:
+        click.echo(f"  ERROR: {err}")
     for w in result.warnings:
         click.echo(f"  warn: {w}")
     # Non-zero exit on blocking errors so scripts/CI can detect a failed verify.

--- a/src/cairn/compass/generator.py
+++ b/src/cairn/compass/generator.py
@@ -204,7 +204,7 @@ def _quick_commands(module_path: str, repo: Optional[str]) -> List[str]:
 def _template_body(symbols, key_files, cross_deps, quick_commands, module_path=None) -> str:
     lines = ["# What Does This Module Do?"]
     if symbols:
-        kinds = {}
+        kinds: dict[str, int] = {}
         for s in symbols:
             kinds[s.get("kind", "?")] = kinds.get(s.get("kind", "?"), 0) + 1
         kind_summary = ", ".join(f"{k}({v})" for k, v in sorted(kinds.items(), key=lambda x: -x[1])[:5])

--- a/src/cairn/compass/router.py
+++ b/src/cairn/compass/router.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 import re
 import sqlite3
-from typing import Dict, List
+from typing import Any, Dict, List
 
 from ..graph.queries import (
     find_definition,
@@ -151,7 +151,7 @@ def _query_graph(query: str, token: str, conn: sqlite3.Connection) -> Dict:
         return _query_graph_hybrid(conn, tokens)
 
     # Fallback: original single-CamelCase-token lookup (backward compat).
-    out = {}
+    out: Dict[str, Any] = {}
     if token:
         defs = find_definition(conn, token)
         callers = get_callers(conn, token)
@@ -235,7 +235,7 @@ def _query_graph_hybrid(conn: sqlite3.Connection, tokens: List[str]) -> Dict:
 
 
 def _search_wiki(query: str, bundle: OKFBundle) -> List[str]:
-    return [c.title for c in bundle.search(query, limit=3) if c.type.startswith("Wiki")]
+    return [c.title or "" for c in bundle.search(query, limit=3) if c.type.startswith("Wiki")]
 
 
 def _get_compass(token: str, bundle: OKFBundle) -> List[str]:
@@ -244,7 +244,7 @@ def _get_compass(token: str, bundle: OKFBundle) -> List[str]:
         try:
             c = bundle.read_concept(cid)
             if token and (token in (c.resource or "") or token in cid):
-                out.append(c.title)
+                out.append(c.title or "")
         except Exception:
             continue
     return out
@@ -258,13 +258,13 @@ def _search_memory(query: str, bundle: OKFBundle, conn: sqlite3.Connection) -> L
     """
     from ..memory.promotion import search_memory
 
-    return [c.title for c in search_memory(conn, bundle, query)[:3]]
+    return [c.title or "" for c in search_memory(conn, bundle, query)[:3]]
 
 
 def _search_knowledge(query: str, bundle: OKFBundle) -> List[str]:
     """Search knowledge documents."""
     return [
-        c.title for c in bundle.search(query, limit=5)
+        c.title or "" for c in bundle.search(query, limit=5)
         if c.concept_id.startswith("knowledge/")
     ]
 

--- a/src/cairn/dashboard/data.py
+++ b/src/cairn/dashboard/data.py
@@ -533,6 +533,7 @@ def get_health(conn: sqlite3.Connection, db_path: Optional[str] = None) -> Dict:
 
     probes = _serve_probes() or {}
     model = probes.get("ann_model")
+    model_name = model if isinstance(model, str) else None
     try:
         embedding_rows = embed_count(conn)
     except sqlite3.Error:
@@ -542,10 +543,12 @@ def get_health(conn: sqlite3.Connection, db_path: Optional[str] = None) -> Dict:
         # vec0 table by design, which is doctor's "no embeddings to index
         # yet", not a missing index -- reported as None rather than False.
         # An unknown model (probes still warming) is moot the same way.
-        index_present: Optional[bool] = (
-            index_exists(conn, model) if embedding_rows and model else None
-        )
-        index_rows = index_row_count(conn, model) if index_present else None
+        index_present: Optional[bool] = None
+        index_rows: Optional[int] = None
+        if embedding_rows and model_name:
+            index_present = index_exists(conn, model_name)
+            if index_present:
+                index_rows = index_row_count(conn, model_name)
     except sqlite3.Error:
         index_present, index_rows = None, None
 
@@ -995,7 +998,7 @@ def get_session_chains(
         grouped.setdefault(row["session_id"], []).append(row)
 
     sessions: List[dict] = []
-    for session_id, calls in grouped.items():
+    for sid, calls in grouped.items():
         chains: List[dict] = []
         last_ts: Optional[float] = None
         for row in calls:
@@ -1007,7 +1010,7 @@ def get_session_chains(
                 and (ts - last_ts) > SESSION_GAP_S
             )
             if split or not chains:
-                chains.append({"session_id": session_id, "calls": []})
+                chains.append({"session_id": sid, "calls": []})
             chain = chains[-1]
             chain["calls"].append(
                 {

--- a/src/cairn/dashboard/tokenizer.py
+++ b/src/cairn/dashboard/tokenizer.py
@@ -42,7 +42,8 @@ def _probe_tokenizer() -> Optional[Any]:
     except ImportError:
         return None
     try:
-        return AutoTokenizer.from_pretrained(_tokenizer_model(), local_files_only=True)
+        # Cache probe only: local_files_only=True means nothing is ever fetched.
+        return AutoTokenizer.from_pretrained(_tokenizer_model(), local_files_only=True)  # nosec B615
     except Exception:
         return None
 

--- a/src/cairn/eval.py
+++ b/src/cairn/eval.py
@@ -1764,13 +1764,15 @@ def evaluate_l1_query(
         results = qmod.semantic_search(conn, query, limit=k, params=params)
         retrieved_names = [r.get("name", "") for r in results]
     except Exception:
+        # search_symbols returns sqlite3.Row rows (no .get) whose SELECT
+        # always includes ``name`` -- index directly.
         results = qmod.search_symbols(conn, query, limit=k)
-        retrieved_names = [r.get("name", "") for r in results]
+        retrieved_names = [r["name"] for r in results]
 
     if not retrieved_names:
         # Fallback to search_symbols if semantic search returned no candidates
         results = qmod.search_symbols(conn, query, limit=k)
-        retrieved_names = [r.get("name", "") for r in results]
+        retrieved_names = [r["name"] for r in results]
 
     rank = 0
     for idx, name in enumerate(retrieved_names, start=1):

--- a/src/cairn/graph/builder.py
+++ b/src/cairn/graph/builder.py
@@ -552,7 +552,7 @@ def _build_graph_impl(
             if scip_available():
                 # repo_id for the importer: consistent with files.repo_id
                 # (repo basename for multi-repo, or the single repo's id).
-                for lang, idx_path in scip_languages.items():
+                for lang, scip_idx in scip_languages.items():
                     # Determine the repo id to attribute SCIP symbols to. Use
                     # the first repo seen (typical single-repo case); for
                     # multi-repo the index is still imported under one id.
@@ -562,7 +562,7 @@ def _build_graph_impl(
                         # path to (repo_id, repo-relative) so SCIP rows share
                         # file identity with the scanner/incremental paths.
                         s = import_scip_file(
-                            conn, idx_path, repo_id=repo_for_scip, fmt="proto",
+                            conn, scip_idx, repo_id=repo_for_scip, fmt="proto",
                             ws_root=ws_root,
                         )
                         scip_import_stats[lang] = s

--- a/src/cairn/graph/embed_ladder.py
+++ b/src/cairn/graph/embed_ladder.py
@@ -509,7 +509,7 @@ def _fetch_model_listing() -> Optional[List[str]]:
         headers["Authorization"] = f"Bearer {api_key}"
     try:
         req = urllib.request.Request(f"{base}/models", headers=headers)
-        with urllib.request.urlopen(req, timeout=embeddings._PROBE_TIMEOUT_S) as resp:
+        with urllib.request.urlopen(req, timeout=embeddings._PROBE_TIMEOUT_S) as resp:  # nosec B310 -- base is config-controlled
             if resp.status != 200:
                 return None
             body = resp.read()
@@ -550,7 +550,7 @@ def _embed_with_model(texts: Sequence[str], model_id: str) -> Tuple[List[bytes],
         headers["Authorization"] = f"Bearer {api_key}"
     payload = json.dumps({"model": model_id, "input": list(texts)}).encode("utf-8")
     req = urllib.request.Request(f"{base}/embeddings", data=payload, headers=headers)
-    with urllib.request.urlopen(req, timeout=timeout) as resp:
+    with urllib.request.urlopen(req, timeout=timeout) as resp:  # nosec B310 -- base is config-controlled
         body = json.loads(resp.read().decode("utf-8"))
     data = body["data"]
     data.sort(key=lambda d: d["index"])  # preserve input order

--- a/src/cairn/graph/embeddings.py
+++ b/src/cairn/graph/embeddings.py
@@ -595,7 +595,7 @@ def _run_server_probe() -> bool:
         headers["Authorization"] = f"Bearer {api_key}"
     try:
         req = urllib.request.Request(f"{base}/models", headers=headers)
-        with urllib.request.urlopen(req, timeout=_PROBE_TIMEOUT_S) as resp:
+        with urllib.request.urlopen(req, timeout=_PROBE_TIMEOUT_S) as resp:  # nosec B310 -- base is config-controlled
             if resp.status != 200:
                 return False
             body = resp.read()
@@ -1020,7 +1020,7 @@ def _embed_openai(texts: Sequence[str]) -> Tuple[List[bytes], int]:
         data=payload,
         headers={"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"},
     )
-    with urllib.request.urlopen(req, timeout=60) as resp:
+    with urllib.request.urlopen(req, timeout=60) as resp:  # nosec B310 -- fixed https URL
         body = json.loads(resp.read().decode("utf-8"))
     data = body["data"]
     data.sort(key=lambda d: d["index"])  # preserve input order
@@ -1102,7 +1102,7 @@ def _embed_server(texts: Sequence[str]) -> Tuple[List[bytes], int]:
         last_error = ""
         for attempt in range(max_retries + 1):
             try:
-                with urllib.request.urlopen(req, timeout=timeout) as resp:
+                with urllib.request.urlopen(req, timeout=timeout) as resp:  # nosec B310 -- base is config-controlled
                     raw = resp.read()
                 break
             except urllib.error.HTTPError as e:

--- a/src/cairn/graph/scanner.py
+++ b/src/cairn/graph/scanner.py
@@ -93,7 +93,7 @@ def resolve_file_language(suffix: str, abs_path: str) -> str:
     lang = EXTENSION_MAP.get(suffix)
     if lang == "header":
         return detect_header_language(abs_path)
-    return lang
+    return lang or ""
 
 # Layer A: directories to never descend into. Applied even without a .gitignore.
 # Covers build output, VCS, deps, caches, and IDE state so the graph is
@@ -562,4 +562,4 @@ def infer_repo_language(files: List[FileInfo]) -> Optional[str]:
         counts[f.language] = counts.get(f.language, 0) + 1
     if not counts:
         return None
-    return max(counts, key=counts.get)
+    return max(counts, key=lambda name: counts[name])

--- a/src/cairn/graph/stats.py
+++ b/src/cairn/graph/stats.py
@@ -9,7 +9,7 @@ stays public (no underscore).
 from __future__ import annotations
 
 import sqlite3
-from typing import List
+from typing import List, Tuple
 
 from .schema import note_contention
 
@@ -59,12 +59,12 @@ def get_stats(conn: sqlite3.Connection) -> dict:
     return stats
 
 
-def get_tree(conn: sqlite3.Connection, repo: str, prefix: str = "") -> List[sqlite3.Row]:
+def get_tree(conn: sqlite3.Connection, repo: str, prefix: str = "") -> List[Tuple[str, int]]:
     """Return directory/package structure with symbol counts for a repo."""
     return group_by_top_level(conn, repo)
 
 
-def group_by_top_level(conn: sqlite3.Connection, repo: str) -> List[sqlite3.Row]:
+def group_by_top_level(conn: sqlite3.Connection, repo: str) -> List[Tuple[str, int]]:
     """Group a repo's symbols by their top-level source directory."""
     cur = conn.cursor()
     # files.path is repo-relative; fetch repos.path to strip it if a DB row

--- a/src/cairn/graph/traversal.py
+++ b/src/cairn/graph/traversal.py
@@ -219,12 +219,16 @@ def impact_analysis(
                 # accepts cycles=[] (documented) -- the escape hatch for
                 # benchmarks and debugging.
                 if use_index is True or not closure_has_seed_cycle(conn, seed_ids):
-                    return impact_from_closure(conn, seed_ids, max_depth, limit)
+                    closure_result = impact_from_closure(conn, seed_ids, max_depth, limit)
+                    # closure_available() said yes; a None here means the
+                    # closure unexpectedly cannot serve -- fall through to DFS.
+                    if closure_result is not None:
+                        return closure_result
 
     allowed = None if include_service_edges else STRUCTURAL_EDGE_KINDS
     visited: set[str] = set()   # globally visited symbol ids — prevents re-traversal
     on_path: set[str] = set()   # current DFS path symbol ids — cycle detection
-    results = []
+    results: list[dict] = []
     cycles_seen: set[str] = set()
     cycles = []
     truncated = False

--- a/src/cairn/knowledge/ingest/adapters.py
+++ b/src/cairn/knowledge/ingest/adapters.py
@@ -169,7 +169,7 @@ def _effective_rules(
 
 
 def _skip_reason(
-    rel: PurePosixPath, rules: Tuple[SkipRule, ...] = SKIP_LIST
+    rel: Union[PurePosixPath, Path], rules: Tuple[SkipRule, ...] = SKIP_LIST
 ) -> str | None:
     """First matching rule's reason for a repo-relative doc path, if any."""
     parts = rel.parts
@@ -280,5 +280,11 @@ class FedBinaryAdapter:
             if reason is not None:
                 self.skipped.append((relpath, reason))
                 logger.info("Skipping %s: %s", relpath, reason)
+                continue
+            if markdown is None:
+                # Defensive: the contract is (markdown, None) or (None,
+                # reason); a pathological (None, None) skips rather than
+                # yields a None document.
+                self.skipped.append((relpath, "conversion returned no markdown"))
                 continue
             yield (FED_REPO, relpath, markdown, CONVERTED_ORIGIN)

--- a/src/cairn/knowledge/ingest/parser.py
+++ b/src/cairn/knowledge/ingest/parser.py
@@ -124,9 +124,9 @@ def _as_tags(value: object) -> list[str]:
         value = value.strip()
         if len(value) >= 2 and value[0] == "[" and value[-1] == "]":
             value = value[1:-1]
-        items = value.split(",")
+        items = list(value.split(","))
     elif isinstance(value, (list, tuple)):
-        items = value
+        items = list(value)
     else:
         return []
     return [str(item).strip() for item in items if str(item).strip()]

--- a/src/cairn/mcp_server/_server_core.py
+++ b/src/cairn/mcp_server/_server_core.py
@@ -20,7 +20,7 @@ from mcp.server.fastmcp import FastMCP
 # release; older versions (e.g. 2.14.x) don't define it and never emit it.
 # Import defensively so this module loads on both old and new versions.
 try:
-    from pydantic_settings.exceptions import IncompleteFieldDefinitionWarning
+    from pydantic_settings.exceptions import IncompleteFieldDefinitionWarning  # type: ignore[import-not-found, attr-defined]
 except ImportError:  # pragma: no cover - depends on installed version
     IncompleteFieldDefinitionWarning = None  # type: ignore[assignment,misc]
 

--- a/src/cairn/mcp_server/tools_memory.py
+++ b/src/cairn/mcp_server/tools_memory.py
@@ -42,6 +42,7 @@ def memory_digest(limit: int = 10) -> str:
     try:
         for c in mems:
             score = c.extensions.get("memory_score", "?")
+            refs_verified: float | str
             try:
                 refs_verified = round(_graph_verification(c, conn), 3)
             except Exception:
@@ -131,6 +132,7 @@ def recall_memory(query: str, tier: str = "", include_superseded: bool = False) 
             from cairn.refs import extract_file_refs, extract_symbol_refs
             body = c.body or ""
             n_refs = len(extract_file_refs(body)) + len(extract_symbol_refs(body))
+            refs_verified: float | str
             try:
                 refs_verified = round(_graph_verification(c, conn), 3)
             except Exception:

--- a/src/cairn/memory/store.py
+++ b/src/cairn/memory/store.py
@@ -104,7 +104,7 @@ def store_memory(concept: OKFConcept, bundle: OKFBundle, tier: Optional[str] = N
     is unlinked to prevent orphan files on re-tiering.
     """
     t = tier or concept.extensions.get("memory_tier", "drafts")
-    slug = slugify(concept.title) or "memory"
+    slug = slugify(concept.title or "") or "memory"
     ts = datetime.now(timezone.utc).strftime("%Y-%m-%d")
     if t == "raw":
         # Raw tier keeps the date prefix (so decay can purge by age) but now

--- a/src/cairn/memory/store_protocol.py
+++ b/src/cairn/memory/store_protocol.py
@@ -124,9 +124,9 @@ class InMemoryMemoryStore:
         if t == "raw":
             from datetime import datetime, timezone
             ts = datetime.now(timezone.utc).strftime("%Y-%m-%d")
-            return f"{TIER_DIRS['raw']}/{ts}-{_slugify(concept.title)}"
+            return f"{TIER_DIRS['raw']}/{ts}-{_slugify(concept.title or '')}"
         suffix = uuid.uuid4().hex[:6]
-        return f"{TIER_DIRS.get(t, 'memory/drafts')}/{_slugify(concept.title)}-{suffix}"
+        return f"{TIER_DIRS.get(t, 'memory/drafts')}/{_slugify(concept.title or '')}-{suffix}"
 
     def add(self, concept: OKFConcept, tier: Optional[str] = None,
             old_id: Optional[str] = None) -> str:

--- a/src/cairn/okf/bundle.py
+++ b/src/cairn/okf/bundle.py
@@ -143,7 +143,7 @@ class OKFBundle:
 
     def list_concepts(self, prefix: Optional[str] = None) -> List[str]:
         """List all concept IDs (relative paths without .md), optional prefix filter."""
-        ids = []
+        ids: List[str] = []
         if not self.root.is_dir():
             return ids
         for md in self.root.rglob("*.md"):

--- a/src/cairn/parsers/_registry.py
+++ b/src/cairn/parsers/_registry.py
@@ -93,7 +93,7 @@ def _load_plugin_capsule(language: str):
     except TypeError:
         # Python <3.10: entry_points() returns a dict keyed by group.
         all_eps = importlib.metadata.entry_points()
-        eps = all_eps.get(_PLUGIN_ENTRY_POINT_GROUP, [])  # type: ignore[arg-type]  # <3.10 dict shape
+        eps = all_eps.get(_PLUGIN_ENTRY_POINT_GROUP, [])  # type: ignore[arg-type, attr-defined]  # <3.10 dict shape; typeshed (varies by mypy version) types the no-arg call as EntryPoints
     for ep in eps:
         if ep.name == language:
             try:

--- a/src/cairn/parsers/_registry.py
+++ b/src/cairn/parsers/_registry.py
@@ -93,7 +93,7 @@ def _load_plugin_capsule(language: str):
     except TypeError:
         # Python <3.10: entry_points() returns a dict keyed by group.
         all_eps = importlib.metadata.entry_points()
-        eps = all_eps.get(_PLUGIN_ENTRY_POINT_GROUP, [])
+        eps = all_eps.get(_PLUGIN_ENTRY_POINT_GROUP, [])  # type: ignore[arg-type]  # <3.10 dict shape
     for ep in eps:
         if ep.name == language:
             try:

--- a/src/cairn/parsers/csharp.py
+++ b/src/cairn/parsers/csharp.py
@@ -277,12 +277,14 @@ class CSharpParser(BaseParser, TreeSitterParserBase):
                         line=node.start_point[0] + 1,
                     )
                 if child.type == "generic_name":
-                    return Edge(
-                        source_name=self._current_edge_owner(),
-                        kind="calls",
-                        target_name=self._extract_generic_name(child, source),
-                        line=node.start_point[0] + 1,
-                    )
+                    generic = self._extract_generic_name(child, source)
+                    if generic:
+                        return Edge(
+                            source_name=self._current_edge_owner(),
+                            kind="calls",
+                            target_name=generic,
+                            line=node.start_point[0] + 1,
+                        )
             return None
         # invocation_expression: callee is the first child.
         callee_node = node.children[0] if node.children else None

--- a/src/cairn/parsers/dart.py
+++ b/src/cairn/parsers/dart.py
@@ -94,7 +94,7 @@ class DartParser(BaseParser, TreeSitterParserBase):
         # Parsers are cached singletons reused across files, so reset all
         # per-file accumulators here -- otherwise scope/edges from file N
         # bleed into file N+1's ParsedFile.
-        self._pending_edges: List[Edge] = []
+        self._pending_edges = []
         self._scope = []
         self._callable_scope = []
 

--- a/src/cairn/parsers/kotlin.py
+++ b/src/cairn/parsers/kotlin.py
@@ -71,10 +71,10 @@ class KotlinParser(BaseParser, TreeSitterParserBase):
         self._callable_scope = []
         # In-file receiver-type tracker: a stack of {var_name: type_name}
         # scopes, one per enclosing function.
-        self._var_types: List[dict] = [{}]
+        self._var_types = [{}]
         # {type_name: {field_name: type_name}}, populated by _prescan_field_types
         # before the main walk.
-        self._field_types: dict = {}
+        self._field_types = {}
         self._prescan_field_types(tree.root_node, source)
 
         self._walk(tree.root_node, source, pf)

--- a/src/cairn/parsers/objc.py
+++ b/src/cairn/parsers/objc.py
@@ -80,7 +80,7 @@ class ObjCParser(BaseParser, TreeSitterParserBase):
         self._file_stem = file_path.stem
         # Parsers are cached singletons reused across files, so reset all
         # per-file accumulators here.
-        self._pending_edges: List[Edge] = []
+        self._pending_edges = []
         self._scope = []
         self._callable_scope = []
 

--- a/src/cairn/parsers/php.py
+++ b/src/cairn/parsers/php.py
@@ -135,9 +135,9 @@ class PhpParser(BaseParser, TreeSitterParserBase):
                 pf.imports.append(imp)
             return
         if t in _REQUIRE_NODES:
-            imp = self._parse_require_import(node, source)
-            if imp:
-                pf.imports.append(imp)
+            req = self._parse_require_import(node, source)
+            if req:
+                pf.imports.append(req)
             return
 
         # Type declarations: class / interface / trait / enum / anonymous_class.

--- a/src/cairn/parsers/scip_importer.py
+++ b/src/cairn/parsers/scip_importer.py
@@ -657,7 +657,7 @@ def import_scip_bytes(
     if not _PROTOBUF_AVAILABLE:
         raise ImportError(_install_hint())
     try:
-        index = _scip.Index.FromString(data)  # type: ignore[union-attr]
+        index = _scip.Index.FromString(data)  # type: ignore[union-attr, attr-defined]  # protobuf codegen has no stubs
     except _ProtoDecodeError as e:  # type: ignore[arg-type]
         raise ValueError(f"data is not a valid SCIP protobuf Index: {e}") from e
     return _import_protobuf(conn, index, repo_id, ws_root=ws_root)

--- a/src/cairn/parsers/typescript.py
+++ b/src/cairn/parsers/typescript.py
@@ -410,7 +410,7 @@ class _JSFamilyParser(BaseParser, TreeSitterParserBase):
             is_func_value = value is not None and value.type in (
                 "arrow_function", "function_expression"
             )
-            if is_func_value:
+            if is_func_value and value is not None:
                 if is_top and name:
                     pf.symbols.append(
                         Symbol(
@@ -553,7 +553,7 @@ class _JSFamilyParser(BaseParser, TreeSitterParserBase):
         if name_node is None:
             return None
         if name_node.type == "identifier":
-            name = self._node_text(name_node, source).strip()
+            name: str | None = self._node_text(name_node, source).strip()
         elif name_node.type == "member_expression":
             # <UI.Card/> -> resolve to the property name "Card" (matches how
             # _extract_callee treats member_expression calls, and what the

--- a/src/cairn/retrieval/vector_scan.py
+++ b/src/cairn/retrieval/vector_scan.py
@@ -122,11 +122,11 @@ def cosine_scan(
         # the precomputed unit query, divided by the row norm (the old
         # ``dot(q,v)/(qn*vn)`` form is algebraically identical; scores agree
         # to float epsilon, pinned by the differential tests).
-        q = struct.unpack(f"<{len(q_blob) // 4}f", q_blob)
-        qn = _l2norm(q)
-        if qn == 0.0:
+        q_vec = struct.unpack(f"<{len(q_blob) // 4}f", q_blob)
+        q_norm = _l2norm(q_vec)
+        if q_norm == 0.0:
             return []
-        q_unit = [x / qn for x in q]
+        q_unit_seq = [x / q_norm for x in q_vec]
         scored: List[Tuple[float, T]] = []
         for vec_blob, dim, payload in rows:
             if dim != q_dim:
@@ -135,7 +135,7 @@ def cosine_scan(
             vn = math.sqrt(sum(map(_MUL, v, v)))
             if vn == 0.0:
                 continue
-            score = sum(map(_MUL, q_unit, v)) / vn
+            score = sum(map(_MUL, q_unit_seq, v)) / vn
             if score >= threshold:
                 scored.append((score, payload))
         scored.sort(key=lambda x: -x[0])

--- a/src/cairn/telemetry/otel.py
+++ b/src/cairn/telemetry/otel.py
@@ -234,7 +234,7 @@ def _get_logger() -> Any:
         from opentelemetry.exporter.otlp.proto.http.log_exporter import (  # type: ignore[import-not-found]
             OTLPLogExporter,
         )
-        from opentelemetry.sdk._logs import (  # type: ignore[import-not-found]
+        from opentelemetry.sdk._logs import (  # type: ignore[import-not-found, attr-defined]
             LoggerProvider,
             LogRecord,
         )
@@ -260,7 +260,9 @@ def _get_logger() -> Any:
         tracker = _TrackingExporter(
             OTLPLogExporter(endpoint=endpoint(), timeout=_EXPORT_TIMEOUT_S)
         )
-        provider.add_log_record_processor(SimpleLogRecordProcessor(tracker))
+        # _TrackingExporter is duck-typed on purpose (see its docstring); the
+        # stub-visible protocol mismatch is expected, not a regression.
+        provider.add_log_record_processor(SimpleLogRecordProcessor(tracker))  # type: ignore[arg-type]
         _otlp_tracker = tracker
         _otlp_logger = provider.get_logger("cairn.telemetry")
         _log_record_cls = LogRecord

--- a/src/cairn/viz/query.py
+++ b/src/cairn/viz/query.py
@@ -13,8 +13,8 @@ from typing import Dict, Sequence
 def get_symbol_graph(conn: sqlite3.Connection, name: str, depth: int = 1) -> Dict:
     """A symbol + its immediate callers and callees."""
     cur = conn.cursor()
-    nodes = {}
-    edges = []
+    nodes: dict[str, dict] = {}
+    edges: list[dict] = []
 
     # The focal symbol.
     focal = cur.execute(
@@ -72,8 +72,8 @@ def get_symbol_neighbors(conn: sqlite3.Connection,
     """
     requested = list(dict.fromkeys(n for n in names if n and n.strip()))
     cur = conn.cursor()
-    nodes = {}
-    edges = []
+    nodes: dict[str, dict] = {}
+    edges: list[dict] = []
     truncated = False
     if requested:
         placeholders = ",".join("?" * len(requested))
@@ -124,8 +124,8 @@ def get_impact_graph(conn: sqlite3.Connection, name: str, max_depth: int = 3) ->
     from ..graph.queries import impact_analysis
 
     result = impact_analysis(conn, name, max_depth=max_depth)
-    nodes = {}
-    edges = []
+    nodes: dict[str, dict] = {}
+    edges: list[dict] = []
     _add_node(nodes, name, "focus", "", "")
     for r in result["impacted"]:
         _add_node(nodes, r["symbol"], "caller", r["file"], r["repo"])
@@ -141,8 +141,8 @@ def get_deps_graph(conn: sqlite3.Connection) -> Dict:
 
     cur = conn.cursor()
     repos = [r["id"] for r in cur.execute("SELECT id FROM repos").fetchall()]
-    nodes = {}
-    edges = []
+    nodes: dict[str, dict] = {}
+    edges: list[dict] = []
     for repo in repos:
         _add_node(nodes, repo, "repo", "", repo)
         deps = cross_repo_deps(conn, repo)
@@ -157,8 +157,8 @@ def get_repo_graph(conn: sqlite3.Connection, repo: str, max_nodes: int = 30) -> 
     from ..graph.queries import group_by_top_level
 
     buckets = group_by_top_level(conn, repo)
-    nodes = {}
-    edges = []
+    nodes: dict[str, dict] = {}
+    edges: list[dict] = []
     for key, count in buckets[:max_nodes]:
         label = f"{key} ({count})"
         _add_node(nodes, label, "module", "", repo)
@@ -211,8 +211,8 @@ def get_module_graph(
     from ..graph.tests import is_test_symbol
 
     cur = conn.cursor()
-    nodes = {}
-    edges = []
+    nodes: dict[str, dict] = {}
+    edges: list[dict] = []
     seen_edges = set()
     vendored_excluded = 0
     rows = cur.execute(


### PR DESCRIPTION
## Summary

Follow-up to CI run 33324358016's annotations: all 63 mypy errors (advisory at the time, drifted +8 since adoption) are fixed across 31 files and the type-check step is promoted to a **hard gate**; the 7 Medium-severity bandit advisories are pinned with inline `# nosec` markers carrying their review rationale. One latent crash was found and fixed on the way (eval lexical fallback: `sqlite3.Row` has no `.get`).

## Change type

- [ ] Feature / improvement
- [x] Bugfix
- [x] Refactor (no behavior change)
- [x] Docs / chore / CI

## Audit checklist

Author — confirm before requesting review (procedure: `docs/review-checklist.md`):

- [x] **Blast radius checked** — `cairn impact group_by_top_level` (the only changed public signature: annotation corrected `List[Row]` → `List[Tuple[str, int]]`, runtime identical) → callers are viz/query + dashboard tests, all in the green run. `resolve_file_language` has a single caller (pre-filtered suffixes). No public API added/removed → no `cross_repo_deps` needed.
- [x] **Layering respected** — all edits are in-place type fixes; no module boundaries crossed, no new dependencies between layers.
- [x] **Graph updated** — `cairn update` reindexed the 31 changed files.
- [x] **Memory recorded** — 2 entries: the hard-gate/type-ignore policy (decision) and the `sorted()`-names-`Iterable[Row]` = wrong-return-annotation diagnostic pattern.
- [x] **Fallback/perf paths** — `cairn doctor` exit 0. The vector-scan pure-Python fallback only renamed locals (no logic change); the eval fallback changed to fix a crash there.
- [x] **Tests** — targeted suite over every test file importing a changed module: **1499 passed, 2 skipped, 0 failed** (76s). The four slow experiment suites (eval_kfold/eval_sweep/router_eval/t2_snapshot) are left to the CI matrix.
- [x] **CHANGELOG** — `[Unreleased]` Changed/Fixed entries added.
- [x] **Gates green** — pre-commit ran clean on all 8 commits; mypy: `Success: no issues found in 172 source files` in **both** the CI dev-extras env and a full all-extras install; bandit `-ii -ll` exits 0 with zero findings; PR title conventional.

## Blast-radius note

Signature-visible changes: `group_by_top_level`/`get_tree` return annotations corrected (callers already tuple-unpacked), `_is_int` became `TypeGuard[int]` (private), `_skip_reason` widened to accept `Path` (private), `_RichProgressHandle` now typed with rich `TaskID` (duck-type contract unchanged — `system.py`/`embed.py`/`knowledge.py` callers verified). `# type: ignore` added only where stubs are genuinely absent (protobuf codegen, OTel `sdk._logs` re-exports, pydantic-settings version skew, <3.10 entry-points dict), each with an inline justification.

## Verification

- `uv run --extra dev mypy --ignore-missing-imports src` → 0 errors (CI-exact env); same under `--all-extras` (63 → 0; the all-extras run is the superset — it sees numpy/OTel/pydantic-settings stubs CI's dev env treats as Any).
- `uv run --extra dev bandit -r src -ii -ll -s B608` → exit 0, zero findings.
- `uv run --all-extras pytest` on the 80 test files importing changed modules → 1499 passed, 2 skipped.
- Full local suite was attempted first and abandoned at 80 CPU-minutes (dominated by the eval experiment suites — not a hang; process was progressing); those suites run in CI's Test matrix, which is the authoritative gate for this PR.