### PR TITLE
fix(dashboard): link the wiki view in the sidebar and landing grid

### DIFF
--- a/src/cairn/dashboard/templates/base.html
+++ b/src/cairn/dashboard/templates/base.html
@@ -131,6 +131,10 @@
         <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><ellipse cx="12" cy="5" rx="9" ry="3"/><path d="M21 12c0 1.7-4 3-9 3s-9-1.3-9-3"/><path d="M3 5v14c0 1.7 4 3 9 3s9-1.3 9-3V5"/></svg>
         <span>Memory</span>
       </a>
+      <a href="/wiki{{ nav_query }}"{% if path.startswith('/wiki') %} class="active" aria-current="page"{% endif %}>
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20V2H6.5A2.5 2.5 0 0 0 4 4.5z"/><path d="M4 19.5A2.5 2.5 0 0 0 6.5 22H20v-5"/></svg>
+        <span>Wiki</span>
+      </a>
       <a href="/tasks{{ nav_query }}"{% if path.startswith('/tasks') %} class="active" aria-current="page"{% endif %}>
         <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M9 11l3 3L22 4"/><path d="M21 12v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11"/></svg>
         <span>Tasks</span>

--- a/src/cairn/dashboard/templates/index.html
+++ b/src/cairn/dashboard/templates/index.html
@@ -52,6 +52,11 @@
       <span class="launcher-title">Memory</span>
       <span class="launcher-blurb">Recent tribal knowledge</span>
     </a>
+    <a class="launcher-card" href="{{ links.url('/wiki') }}">
+      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20V2H6.5A2.5 2.5 0 0 0 4 4.5z"/><path d="M4 19.5A2.5 2.5 0 0 0 6.5 22H20v-5"/></svg>
+      <span class="launcher-title">Wiki</span>
+      <span class="launcher-blurb">Generated project pages</span>
+    </a>
     <a class="launcher-card" href="{{ links.url('/tasks') }}">
       <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M9 11l3 3L22 4"/><path d="M21 12v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11"/></svg>
       <span class="launcher-title">Task queue</span>

--- a/tests/test_dashboard_app.py
+++ b/tests/test_dashboard_app.py
@@ -98,8 +98,8 @@ def test_create_app_serves_landing_and_static(tmp_path):
     # Every sidebar view is reachable from the launcher grid, including
     # the two newest sections.
     for href in ("/workspaces", "/projects", "/graph", "/history", "/tokens",
-                 "/chains", "/health", "/memory", "/tasks", "/embeddings",
-                 "/settings"):
+                 "/chains", "/health", "/memory", "/wiki", "/tasks",
+                 "/embeddings", "/settings"):
         assert f'href="{href}"' in landing.text, href
 
     css = client.get("/static/app.css")
@@ -3674,6 +3674,19 @@ def test_wiki_routes_registered_with_pinned_names(tmp_path):
 def test_wiki_templates_ship_with_the_dashboard():
     assert (_templates_dir() / "wiki.html").is_file()
     assert (_templates_dir() / "wiki_page.html").is_file()
+
+
+def test_wiki_is_linked_in_sidebar_and_launcher(tmp_path):
+    """FR-009 follow-up: the wiki view is discoverable — a sidebar nav entry
+    plus a landing launcher card, mirroring every other view."""
+    client = _wiki_client(tmp_path)
+
+    page = client.get("/wiki")
+    landing = client.get("/")
+
+    assert page.status_code == 200
+    assert 'href="/wiki' in page.text      # sidebar link on the view itself
+    assert 'href="/wiki' in landing.text   # launcher card on the landing grid
 
 
 def test_wiki_route_lists_pages_with_state_badges(tmp_path):


### PR DESCRIPTION
## Summary
The wiki routes, templates, and tests landed in #79, but no task's file list included `base.html` — so /wiki was reachable only by typing the URL. This adds the sidebar nav entry and the landing launcher card, mirroring every other view.

## Change type
- [x] Bugfix

## Audit checklist
- [x] **Blast radius checked** — template-only change; no symbols touched; `explore` shows no callers of templates.
- [x] **Layering respected** — view-layer only.
- [x] **Graph updated** — N/A (no code symbols changed).
- [x] **Memory recorded** — the scope-miss lesson goes into the pipeline memory.
- [x] **Fallback/perf paths** — N/A.
- [x] **Tests** — new discoverability test (sidebar + launcher) + landing coverage loop extended with /wiki; `tests/test_dashboard_app.py` 109 passed.
- [x] **CHANGELOG** — bugfix against an unreleased feature; folds into the existing 0.16.1 wiki entry (no new entry needed).
- [x] **Gates green** — pre-commit passed on commit; CI on this PR.

## Verification
`CAIRN_LIB=/tmp/__no_such_lib__ uv run --extra test pytest tests/test_dashboard_app.py -q` → 109 passed.