### PR TITLE
test: pin timestamp in to_file_no_temp_residue (second-boundary flake)

### DIFF
--- a/tests/test_okf_concept.py
+++ b/tests/test_okf_concept.py
@@ -113,11 +113,14 @@ This is original content that must be preserved."""
 def test_to_file_no_temp_residue(tmp_path):
     """Verify that no temp residue is left after a successful write."""
     # Create a concept
+    # Pinned timestamp: to_markdown() stamps now() when unset, so an unset
+    # timestamp makes this assertion a coin flip on the second boundary.
     concept = OKFConcept(
         type="test",
         title="Test Concept",
         description="A test concept",
         tags=["test"],
+        timestamp="2026-01-01T00:00:00Z",
         body="# Test Body\n\nThis is test content.",
     )
 


### PR DESCRIPTION
## Summary
`to_markdown()` stamps `now()` when the concept's timestamp is unset, making this test's final-content assertion a coin flip on the second boundary — it failed the 3.14 CI leg on #81 and passed on rerun. Pins the timestamp so the comparison is deterministic.

## Change type
- [x] Bugfix

## Audit checklist
- [x] **Blast radius checked** — test-only change; no src symbols touched.
- [x] **Layering respected** — N/A. - [x] **Graph updated** — N/A (no code change).
- [x] **Memory recorded** — flake noted in the pipeline memory earlier today.
- [x] **Fallback/perf paths** — N/A. - [x] **Tests** — `tests/test_okf_concept.py` 6 passed.
- [x] **CHANGELOG** — test-only fix, no entry needed. - [x] **Gates green** — CI on this PR.

## Verification
Diagnosis verified at `src/cairn/okf/concept.py:180` (`ts = self.timestamp or datetime.now(...)`); the pinned test passes deterministically.