### PR TITLE
feat(dashboard): render mermaid fences live in the wiki detail view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 > releases will be appended here incrementally.
 
 
+## [Unreleased]
+
+### Added
+- Live Mermaid rendering in the dashboard wiki detail view: mermaid fences
+  now render as diagrams client-side (mermaid.js from CDN, strict security
+  level), degrading to the visible code block when offline or JavaScript
+  is unavailable. No new Python dependency — the renderer still emits
+  escaped `pre.mermaid` blocks.
+
 ## [0.16.1] - 2026-08-31
 
 ### Added

--- a/src/cairn/dashboard/markdown.py
+++ b/src/cairn/dashboard/markdown.py
@@ -4,8 +4,10 @@ Pure stdlib (``html`` + ``re``): importing this module must never load the
 server stack — the same guard the dashboard package is held to. Every line
 is HTML-escaped before any construct is rendered, so inline HTML never
 passes through; the whitelisted block constructs are headings, paragraphs,
-unordered lists, and fenced code (mermaid fences render as static code,
-never live diagrams).
+unordered lists, and fenced code. Mermaid fences emit ``<pre class="mermaid">``
+so the wiki detail view's client-side mermaid.js can render them live; with
+JavaScript or the CDN unavailable the fence degrades to a visible code
+block.
 """
 from __future__ import annotations
 
@@ -21,7 +23,7 @@ _LIST_ITEM_RE = re.compile(r"^-\s+(.*)$")
 def _emit_fence(out: List[str], lang: str, lines: List[str]) -> None:
     body = "\n".join(lines)
     if lang == "mermaid":
-        out.append(f'<pre class="language-mermaid">{body}</pre>')
+        out.append(f'<pre class="mermaid">{body}</pre>')
     else:
         out.append(f"<pre><code>{body}</code></pre>")
 

--- a/src/cairn/dashboard/templates/wiki_page.html
+++ b/src/cairn/dashboard/templates/wiki_page.html
@@ -20,3 +20,15 @@
   {% endif %}
 </section>
 {% endblock %}
+{% block scripts %}
+  {#- Mermaid fences render live client-side; offline/no-JS keeps the code
+      block visible (the renderer emits pre.mermaid with escaped text). -#}
+  <script type="module">
+    try {
+      const mermaid = await import("https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs");
+      mermaid.default.initialize({ startOnLoad: true, securityLevel: "strict" });
+    } catch (e) {
+      /* CDN unreachable — fences stay as visible code blocks. */
+    }
+  </script>
+{% endblock %}

--- a/tests/test_dashboard_app.py
+++ b/tests/test_dashboard_app.py
@@ -3728,9 +3728,11 @@ def test_wiki_page_route_renders_markdown_body_and_sources(tmp_path):
     assert "<li>first the catalog</li>" in resp.text
     assert "## How" not in resp.text  # never the raw markdown source
     assert "&lt;two&gt;" in resp.text  # escape-first: no inline-HTML passthrough
-    assert '<pre class="language-mermaid">' in resp.text
+    assert '<pre class="mermaid">' in resp.text
     assert "src/demo/core.py" in resp.text  # the sources list
     assert "demo_main" in resp.text
+    # Live mermaid: the detail view loads mermaid.js client-side.
+    assert 'cdn.jsdelivr.net/npm/mermaid@11' in resp.text
 
 
 def test_wiki_page_route_unknown_page_returns_404(tmp_path):
@@ -3788,5 +3790,5 @@ def test_render_markdown_fenced_code_and_mermaid_fence():
     )
 
     assert "x &lt; 1 &amp;&amp; y &gt; 2" in html
-    assert '<pre class="language-mermaid">' in html
+    assert '<pre class="mermaid">' in html
     assert "A --&gt; B" in html


### PR DESCRIPTION
## Summary
Lifts the D-002 v1 limitation: wiki pages' mermaid fences now render as live diagrams in the detail view, client-side via mermaid.js (CDN, pinned major, strict security level). Offline or no-JS degrades to the previous behavior — the visible code block. No new Python dependency.

## Change type
- [x] Feature / improvement

## Audit checklist
- [x] **Blast radius checked** — `render_markdown` callers: wiki detail data function + its tests; the emission change is class-name only, content still fully escaped.
- [x] **Layering respected** — renderer stays pure stdlib (import-guard unchanged); the script lives only in the wiki detail template's `scripts` block.
- [x] **Graph updated** — N/A (will run post-merge).
- [x] **Memory recorded** — D-002 v1 limitation noted in specs archive; this PR lifts it.
- [x] **Fallback/perf paths** — the fallback IS the old behavior (code block); no Python-path change.
- [x] **Tests** — pins updated to `pre.mermaid` + new script-presence assertion; `tests/test_dashboard_app.py tests/test_dashboard_data.py` → 191 passed.
- [x] **CHANGELOG** — `[Unreleased]` Added entry.
- [x] **Gates green** — ruff clean, pre-commit passed; CI on this PR.

## Verification
`CAIRN_LIB=/tmp/__no_such_lib__ uv run --extra test pytest tests/test_dashboard_app.py tests/test_dashboard_data.py -q` → 191 passed. Manual: a wiki page with a ```mermaid fence renders as a diagram in the browser; blocking the CDN leaves the code block.