### PR TITLE
chore(deps): sync uv.lock to cairn-intel 0.16.2

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -202,7 +202,7 @@ filecache = [
 
 [[package]]
 name = "cairn-intel"
-version = "0.16.1"
+version = "0.16.2"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Self-referential lock entry missed in the 0.16.2 cut (same post-release housekeeping as the 0.15.0 sync). Lock-only; no code change.