### PR TITLE
fix(compass): bridge repo prefix in detect_gaps coverage matching

### DIFF
--- a/src/cairn/compass/gaps.py
+++ b/src/cairn/compass/gaps.py
@@ -15,20 +15,31 @@ def detect_gaps(conn: sqlite3.Connection, bundle: OKFBundle) -> List[str]:
     compass concept covers it (by matching its `resource` field).
     """
     all_modules = _get_all_modules(conn)
-    covered = set()
+    repo_ids = {r["id"] for r in conn.cursor().execute("SELECT id FROM repos")}
+    # Compass resources are repo-relative (generator's `module_path`); the
+    # generator records the owning repo as the concept's first tag. An
+    # untagged compass matches any repo.
+    covered = []
     for cid in bundle.list_concepts(prefix="compass/"):
         try:
             concept = bundle.read_concept(cid)
             if concept.resource:
-                covered.add(concept.resource)
+                repo = concept.tags[0] if concept.tags and concept.tags[0] in repo_ids else None
+                covered.append((repo, concept.resource))
         except Exception:
             continue
     gaps = []
     for mod in all_modules:
-        # A module is covered if any compass resource matches it exactly or is
-        # a path-segment-prefix of it (or vice-versa). Require segment boundary
-        # so a compass for `app/foo` does NOT cover `app/foobar`.
-        if not any(mod == c or mod.startswith(c + "/") or c.startswith(mod + "/") for c in covered):
+        repo_id, _, rel = mod.partition("/")
+        # A module is covered if any same-repo (or untagged) compass resource
+        # matches its repo-relative path exactly or is a path-segment-prefix
+        # of it (or vice-versa). Require segment boundary so a compass for
+        # `app/foo` does NOT cover `app/foobar`.
+        if not any(
+            c_repo in (None, repo_id)
+            and (rel == c or rel.startswith(c + "/") or c.startswith(rel + "/"))
+            for c_repo, c in covered
+        ):
             gaps.append(mod)
     return gaps
 

--- a/tests/test_compass_gaps.py
+++ b/tests/test_compass_gaps.py
@@ -1,0 +1,125 @@
+"""detect_gaps coverage matching: module ids vs compass resource fields.
+
+Modules from _get_all_modules are repo-qualified (`{repo_id}/{path}`) while
+compass concepts store their `resource` repo-relative (generator.py's
+`module_path` is documented repo-relative). The comparison must bridge the
+repo prefix; a compass tagged with one repo must not cover a same-named
+module in a different repo.
+"""
+from __future__ import annotations
+
+import sqlite3
+
+import pytest
+
+from cairn.compass.gaps import detect_gaps
+from cairn.okf.bundle import OKFBundle
+from cairn.okf.concept import OKFConcept
+
+COVERED_FILE = "/work/agent_runtime/app/services/jobs.py"
+
+
+@pytest.fixture
+def conn():
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    conn.execute(
+        "CREATE TABLE repos (id TEXT PRIMARY KEY, name TEXT, path TEXT, "
+        "language TEXT, git_remote TEXT, indexed_at TIMESTAMP)"
+    )
+    conn.execute(
+        "CREATE TABLE files (id TEXT PRIMARY KEY, repo_id TEXT, path TEXT, "
+        "language TEXT, hash TEXT, line_count INTEGER, indexed_at TIMESTAMP)"
+    )
+    conn.execute(
+        "CREATE TABLE symbols (id TEXT PRIMARY KEY, file_id TEXT, name TEXT, "
+        "qualified_name TEXT, kind TEXT, line_start INTEGER)"
+    )
+    conn.execute(
+        "INSERT INTO repos (id, name, path) VALUES "
+        "('agent_runtime', 'agent_runtime', '/work/agent_runtime'), "
+        "('other_repo', 'other_repo', '/work/other_repo')"
+    )
+    for repo in ("agent_runtime", "other_repo"):
+        fid = f"{repo}:jobs"
+        conn.execute(
+            "INSERT INTO files (id, repo_id, path, language) VALUES "
+            "(?, ?, ?, 'python')",
+            (fid, repo, f"/work/{repo}/app/services/jobs.py"),
+        )
+        for i in range(5):
+            conn.execute(
+                "INSERT INTO symbols (id, file_id, name, kind) "
+                "VALUES (?, ?, ?, 'function')",
+                (f"{fid}:sym{i}", fid, f"sym{i}", ),
+            )
+    extra_fid = "agent_runtime:extra"
+    conn.execute(
+        "INSERT INTO files (id, repo_id, path, language) VALUES "
+        "(?, 'agent_runtime', ?, 'python')",
+        (extra_fid, "/work/agent_runtime/app/services_extra/impl.py"),
+    )
+    for i in range(5):
+        conn.execute(
+            "INSERT INTO symbols (id, file_id, name, kind) "
+            "VALUES (?, ?, ?, 'function')",
+            (f"{extra_fid}:sym{i}", extra_fid, f"sym{i}", ),
+        )
+    conn.commit()
+    return conn
+
+
+def _compass(knowledge, resource, *, repo=None):
+    tags = [repo] if repo else []
+    OKFBundle(str(knowledge)).write_concept(
+        OKFConcept(
+            type="Compass",
+            title="test compass",
+            resource=resource,
+            tags=tags,
+            concept_id="compass/" + resource.replace("/", "-").replace(".", "-"),
+            body="Navigation guide.",
+        )
+    )
+
+
+def test_compass_resource_repo_relative_covers_repo_qualified_module(conn, tmp_path):
+    # The reported bug: resource `app/services/jobs.py` vs module
+    # `agent_runtime/app/services/jobs.py` never matched, so every module
+    # stayed a gap forever.
+    _compass(tmp_path / "k", "app/services/jobs.py", repo="agent_runtime")
+    assert detect_gaps(conn, OKFBundle(str(tmp_path / "k"))) == [
+        "agent_runtime/app/services_extra/impl.py",
+        "other_repo/app/services/jobs.py",
+    ]
+
+
+def test_compass_covers_by_segment_prefix_and_respects_boundary(conn, tmp_path):
+    knowledge = tmp_path / "k"
+    # `app/services` is a path-segment prefix of app/services/jobs.py
+    # (covers both repos' modules only via the repo tag — it is tagged
+    # agent_runtime here) but NOT of app/services_extra/impl.py: the
+    # segment boundary keeps `services` from matching `services_extra`.
+    _compass(knowledge, "app/services", repo="agent_runtime")
+    assert detect_gaps(conn, OKFBundle(str(knowledge))) == [
+        "agent_runtime/app/services_extra/impl.py",
+        "other_repo/app/services/jobs.py",
+    ]
+
+
+def test_compass_from_other_repo_does_not_cover_same_named_module(conn, tmp_path):
+    # Both repos have app/services/jobs.py; a compass tagged for
+    # other_repo covers only other_repo's module.
+    _compass(tmp_path / "k", "app/services/jobs.py", repo="other_repo")
+    assert detect_gaps(conn, OKFBundle(str(tmp_path / "k"))) == [
+        "agent_runtime/app/services/jobs.py",
+        "agent_runtime/app/services_extra/impl.py",
+    ]
+
+
+def test_untagged_compass_covers_any_repo(conn, tmp_path):
+    # Compasses without a resolvable repo tag keep repo-agnostic matching.
+    _compass(tmp_path / "k", "app/services/jobs.py")
+    assert detect_gaps(conn, OKFBundle(str(tmp_path / "k"))) == [
+        "agent_runtime/app/services_extra/impl.py"
+    ]


### PR DESCRIPTION
## Summary

`cairn compass gaps` reported every module as uncovered (a user session watched the count stay at 398 while compasses promoted and validated). Root cause: `detect_gaps` compared repo-qualified module ids (`{repo_id}/{path}` from `_get_all_modules`) against compass `resource` fields, which the generator stores repo-relative (`module_path`, generator.py:67) — none of the three comparisons could ever match. The fix compares the module's repo-relative path and scopes coverage to same-repo compasses via the concept's repo tag (first tag, per the generator), with repo-agnostic fallback for untagged compasses.

## Change type

- [ ] Feature / improvement
- [x] Bugfix
- [ ] Refactor (no behavior change)
- [ ] Docs / chore / CI

## Audit checklist

Author — confirm before requesting review (procedure: `docs/review-checklist.md`):

- [x] **Blast radius checked** — `detect_gaps` has exactly one caller (`cli/compass.py:212`, the `compass gaps` command, output-only); no other symbol touched
- [x] **Layering respected** — change confined to compass/gaps.py matching logic; no boundary crossings
- [x] **Graph updated** — `cairn update` runs post-merge per workflow; no schema/graph change involved
- [x] **Memory recorded** — cairn memory + session memory updated with the bug class (repo-qualified vs repo-relative id spaces)
- [x] **Fallback/perf paths** — no fallback/perf path altered (pure comparison logic; the untagged-compass fallback is new but pinned)
- [x] **Tests** — new `tests/test_compass_gaps.py` (4 pins, red-first on the reported mismatch): exact repo-relative match, segment-boundary prefix (`app/services` covers `app/services/jobs.py`, not `app/services_extra/impl.py`), cross-repo non-coverage, untagged fallback. Neighbors green: compass critic/router/tasks 29 passed; core fast loop 26 passed
- [x] **CHANGELOG** — `[Unreleased]` entry added on this branch? — not yet; will note: bugfix entry queued for the next CHANGELOG pass (currently riding the wiki-enhancements `[Unreleased]` section on PR #86; adding here would conflict)
- [x] **Gates green** — pre-commit all-files green; PR title conventional; pip-audit/mypy/bandit ride CI

## Blast-radius note

Single consumer (`cairn compass gaps` CLI, display-only). No public-API change; `detect_gaps` signature unchanged. Live-store sanity: this workspace (0 compasses) still reports all-module gaps — the fix does not fabricate coverage where none exists.

## Verification

- Red-first: all 4 pins failed against the old comparison (every module a gap), green after the fix
- `CAIRN_LIB=/tmp/__no_such_lib__ uv run --extra test pytest tests/test_compass_gaps.py -q` → 4 passed
- Compass neighbors (`test_compass_critic.py`, `test_gitignore_and_router_fixes.py`, `test_router_eval.py`, `test_tasks_safety.py`) → 29 passed
- `pytest -m core -q` → 26 passed / 2717 deselected

## Post-merge

CHANGELOG bugfix line joins the next `[Unreleased]` batch (avoiding a conflict with PR #86's section).