### PR TITLE
test(suite): add the infra marker tier and narrow the per-PR gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,11 +174,20 @@ jobs:
         run: |
           # Coverage rides one leg only (3.12, main pushes): collecting it on
           # every matrix leg is redundant signal at ~real minutes each.
+          # The infra tier (bench/dataset/soak tests) is excluded on PR legs
+          # and run by the dedicated step below on every main push — no
+          # addopts on purpose: the bench job's `-k t2` gate runs without -m.
           if [ "${{ matrix.python-version }}" = "3.12" ]; then
-            pytest -q --junitxml=test-results.xml --cov=cairn --cov-report=term --cov-report=xml
+            pytest -q -m "not infra" --junitxml=test-results.xml --cov=cairn --cov-report=term --cov-report=xml
           else
-            pytest -q --junitxml=test-results.xml
+            pytest -q -m "not infra" --junitxml=test-results.xml
           fi
+
+      - name: Run infra tier (main pushes only)
+        # The bench/dataset/soak infrastructure tier: excluded from PR legs
+        # above, but every merge runs it so the tier can never rot.
+        if: github.event_name == 'push' && matrix.python-version == '3.12'
+        run: pytest -q -m infra
 
       - name: Publish test summary
         if: always()

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,7 +47,7 @@ There are two feedback loops:
 
 ```bash
 pytest -m core -q      # fast smoke subset (<3s) — the inner dev loop
-pytest -q              # full suite (~60 test files) — the CI path
+pytest -q              # full suite, default gate + infra tier — CI runs them split
 ```
 
 The `core` marker (declared in `pyproject.toml`) marks **one focused test per

--- a/README.md
+++ b/README.md
@@ -349,7 +349,8 @@ and doc-ingestion pipelines. Contribution and release procedures:
 pip install -e ".[dev]"   # pytest + watchdog + build + ruff
                             # (compiles the vendored Kotlin grammar — needs a C toolchain)
 pytest -m core            # fast <3s smoke subset (one test per core function)
-pytest                    # full suite (the CI path)
+pytest                    # full suite (default gate + infra tier; CI splits them)
+pytest -m infra           # bench/dataset/soak tier alone (CI runs it on main pushes)
 make ci-local             # clean-room CI replication in a Linux container
 ```
 

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -20,11 +20,18 @@ don't skip on "I'm sure it's fine."
 | [`## Cutting a release`](#cutting-a-release) | Conventional commits, the changelog-first rule, the `cz` bump, and the tag-push paths. |
 
 ## Tests
-- [ ] `uv run pytest tests/ -q` — full suite (~1100 tests). CI runs this too
-      (after a `core` smoke pass), but confirm locally before pushing so you
-      aren't waiting on a CI round-trip for a local failure. Note the
-      pass/skip/fail count; compare to the last green run.
-- [ ] No new `xfail` or `skip` slipped in to make a failure "pass."
+- [ ] `uv run pytest tests/ -q` — the full local suite (default gate + infra
+      tier together; a bare `pytest` runs everything by design). CI runs the
+      default gate on PR legs (`-m "not infra"`) and the infra tier
+      (`-m infra`) on every main push. Note the pass/skip/fail count; compare
+      to the last green run.
+- [ ] `uv run pytest tests/ -m infra -q` — when cutting a release or touching
+      the bench/dataset/soak subsystems, run the infra tier explicitly too
+      (PR CI legs skip it).
+- [ ] No new `xfail` or `skip` slipped in to make a failure "pass." Moving a
+      whole file (or class) into the infra tier is deliberate CI selection
+      recorded in the pyproject marker description — per-test
+      skip-quarantining remains forbidden.
 
 ## Build verification (for changes touching indexing/embedding)
 - [ ] `uv run cairn build` succeeds against the real workspace.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -178,7 +178,13 @@ where = ["src"]
 testpaths = ["tests"]
 markers = [
     "core: high-signal smoke tests covering the core query/build/transport path (run with -m core)",
-    "real_env: opts a test out of the suite-wide _hermetic_env fixture (justify in a comment),"
+    "real_env: opts a test out of the suite-wide _hermetic_env fixture (justify in a comment)",
+    # The infra tier is CI selection, NOT a quarantine: every marked test still
+    # runs and must pass on each main push (ci.yml's main-only `-m infra` step);
+    # per-PR legs exclude it via an explicit `-m "not infra"` on the full-suite
+    # step. Deliberately no addopts: a global -m filter would silently deselect
+    # the bench job's `-k t2` gate (ci.yml runs it without -m).
+    "infra: benchmark/dataset/soak infrastructure tests -- excluded from per-PR legs (pytest -m \"not infra\"), run on every main push (pytest -m infra)",
 ]
 
 [tool.ruff]

--- a/scripts/ci-local.sh
+++ b/scripts/ci-local.sh
@@ -143,9 +143,11 @@ case "$JOB" in
     python scripts/run_skill_evals.py
     log "core smoke subset (CI: Run core smoke subset)"
     python -m pytest -m core -q
-    log "full suite (CI: Run full test suite)"
-    python -m pytest -q --junitxml=test-results.xml \
+    log "full suite (CI: Run full test suite, PR-leg shape: infra tier excluded)"
+    python -m pytest -q -m "not infra" --junitxml=test-results.xml \
       --cov=cairn --cov-report=term --cov-report=xml
+    log "infra tier (CI: Run infra tier, main-push shape)"
+    python -m pytest -q -m infra
     log "suite green (results: test-results.xml, coverage.xml)"
     ;;
 

--- a/specs/context/tech.md
+++ b/specs/context/tech.md
@@ -35,9 +35,13 @@ Stack, build/test runners, and gates. Cited from pyproject.toml,
 ## Tests
 - pytest; `testpaths = ["tests"]` so bare runs never collect the vendored
   benchmark corpora (pyproject.toml:169-178).
-- Markers (pyproject.toml:179-182): `core` — fast one-test-per-function smoke
+- Markers (pyproject.toml:179-192): `core` — fast one-test-per-function smoke
   subset (`pytest -m core -q`, <3s); `real_env` — opts a test out of the
-  suite-wide hermetic-env fixture (must justify in a comment).
+  suite-wide hermetic-env fixture (must justify in a comment); `infra` —
+  bench/dataset/soak tier, excluded from per-PR CI legs (`-m "not infra"`),
+  run on every main push. No addopts on purpose: the bench job's `-k t2`
+  gate invokes pytest without `-m`; a global filter would silently empty it
+  (test_suite_hygiene pins the tier's shape).
 - Hermetic by default: `tests/conftest.py:47-67` points HOME/CAIRN_HOME into a
   per-test tmp sandbox. Tests that exercise env propagation across a REAL
   process boundary use subprocess + `env={"CAIRN_HOME": ...}` (e.g.

--- a/specs/context/tech.md
+++ b/specs/context/tech.md
@@ -35,12 +35,12 @@ Stack, build/test runners, and gates. Cited from pyproject.toml,
 ## Tests
 - pytest; `testpaths = ["tests"]` so bare runs never collect the vendored
   benchmark corpora (pyproject.toml:169-178).
-- Markers (pyproject.toml:179-192): `core` — fast one-test-per-function smoke
+- Markers (pyproject.toml:179-188): `core` — fast one-test-per-function smoke
   subset (`pytest -m core -q`, <3s); `real_env` — opts a test out of the
   suite-wide hermetic-env fixture (must justify in a comment); `infra` —
   bench/dataset/soak tier, excluded from per-PR CI legs (`-m "not infra"`),
   run on every main push. No addopts on purpose: the bench job's `-k t2`
-  gate invokes pytest without `-m`; a global filter would silently empty it
+  gate invokes pytest without `-m`; a global filter would silently shrink it
   (test_suite_hygiene pins the tier's shape).
 - Hermetic by default: `tests/conftest.py:47-67` points HOME/CAIRN_HOME into a
   per-test tmp sandbox. Tests that exercise env propagation across a REAL

--- a/tests/test_agent_suite.py
+++ b/tests/test_agent_suite.py
@@ -17,6 +17,9 @@ from cairn.bench.agent_suite import (
     run_agent_suite,
 )
 from cairn.bench.corpus import generate_corpus
+import pytest
+
+pytestmark = pytest.mark.infra
 
 # 6 modules + __init__.py = 7 files -- small enough that build+embed+tasks
 # stay well under a second, large enough that every task finds its target.

--- a/tests/test_bench.py
+++ b/tests/test_bench.py
@@ -25,6 +25,9 @@ from cairn.bench import (
     TimingResult,
     MemoryResult,
 )
+import pytest
+
+pytestmark = pytest.mark.infra
 
 
 # --- timing primitives ---------------------------------------------------

--- a/tests/test_bench_datasource.py
+++ b/tests/test_bench_datasource.py
@@ -155,6 +155,7 @@ class TestTreeHash:
 
 # --- integration with the real corpus generator ---------------------------
 
+@pytest.mark.infra
 class TestGeneratedCorpus:
     def test_same_params_same_hash_across_roots(self, tmp_path):
         """The substrate FR-001 pins: two regenerations of the same corpus
@@ -194,6 +195,7 @@ def _valid_manifest() -> dict:
     }
 
 
+@pytest.mark.infra
 class TestManifestIO:
     def test_round_trip_save_load(self, tmp_path):
         path = tmp_path / "manifest.json"
@@ -227,6 +229,7 @@ class TestManifestIO:
 
 # --- manifest validation ---------------------------------------------------
 
+@pytest.mark.infra
 class TestValidateManifest:
     def test_valid_manifest_has_no_errors(self):
         assert validate_manifest(_valid_manifest()) == []
@@ -328,6 +331,7 @@ def _valid_t3() -> dict:
     }
 
 
+@pytest.mark.infra
 class TestValidateManifestT3:
     def test_valid_t3_section_has_no_errors(self):
         manifest = _valid_manifest()

--- a/tests/test_bench_stamping.py
+++ b/tests/test_bench_stamping.py
@@ -24,6 +24,9 @@ from cairn.bench.datasource import (
     runner_class,
     save_manifest,
 )
+import pytest
+
+pytestmark = pytest.mark.infra
 
 _HEX64 = re.compile(r"[0-9a-f]{64}")
 

--- a/tests/test_dashboard_live_soak.py
+++ b/tests/test_dashboard_live_soak.py
@@ -32,6 +32,8 @@ from html.parser import HTMLParser
 
 import pytest
 
+pytestmark = pytest.mark.infra
+
 # Fixed era (2025-08-20 00:00:00 UTC -- the suite's seeded-fixture era):
 # deterministic timestamps, one row per second, so every stored row owns a
 # distinct rendered timestamp and a (tool, timestamp) pair identifies it.

--- a/tests/test_dashboard_scale.py
+++ b/tests/test_dashboard_scale.py
@@ -19,9 +19,9 @@ is noisy):
 
       CAIRN_SCALE_STRICT=1 uv run pytest tests/test_dashboard_scale.py
 
-  The repo registers no timing/slow pytest marker (pyproject.toml
-  declares only ``core`` and ``real_env``), so this module-local env gate
-  is the fallback the plan sanctioned. It is read at IMPORT time because
+  The ``infra`` marker selects this module out of per-PR CI legs; it is
+  a tier selection, not a strictness switch — the module-local env gate
+  below is the strictness mechanism and stays. It is read at IMPORT time because
   the suite-wide ``_hermetic_env`` autouse fixture (tests/conftest.py)
   deletes every ``CAIRN_*`` env var per test -- a test-body read would
   always see it unset. Ungated runs (CI) still assert a generous 10s
@@ -35,6 +35,8 @@ import sqlite3
 import time
 
 import pytest
+
+pytestmark = pytest.mark.infra
 
 # Read at module import -- see module docstring (_hermetic_env clears
 # CAIRN_* per test, so this cannot live inside a test body).

--- a/tests/test_dashboard_workspaces.py
+++ b/tests/test_dashboard_workspaces.py
@@ -29,8 +29,8 @@ CI runners is noisy):
 
       CAIRN_WORKSPACES_STRICT=1 uv run pytest tests/test_dashboard_workspaces.py
 
-  The repo registers no timing/slow pytest marker, so this module-local
-  env gate is the fallback. It is read at IMPORT time because the
+  The ``infra`` marker selects this module out of per-PR CI legs; the
+  module-local env gate below is the strictness mechanism and stays. It is read at IMPORT time because the
   suite-wide ``_hermetic_env`` autouse fixture (tests/conftest.py)
   deletes every ``CAIRN_*`` env var per test -- a test-body read would
   always see it unset. Ungated runs (CI) still assert a generous 20s
@@ -49,6 +49,8 @@ import time
 from pathlib import Path
 
 import pytest
+
+pytestmark = pytest.mark.infra
 
 # Read at module import -- see module docstring (_hermetic_env clears
 # CAIRN_* per test, so this cannot live inside a test body).

--- a/tests/test_fetch_t3_corpus.py
+++ b/tests/test_fetch_t3_corpus.py
@@ -30,6 +30,8 @@ from pathlib import Path
 
 import pytest
 
+pytestmark = pytest.mark.infra
+
 REPO_ROOT = Path(__file__).resolve().parents[1]
 SCRIPT = REPO_ROOT / "scripts" / "fetch_t3_corpus.py"
 REAL_MANIFEST = REPO_ROOT / "benchmarks" / "datasource" / "manifest.json"

--- a/tests/test_recording_overhead.py
+++ b/tests/test_recording_overhead.py
@@ -15,6 +15,9 @@ import statistics
 import time
 
 from cairn.mcp_server.metric_buffering import instrument
+import pytest
+
+pytestmark = pytest.mark.infra
 
 
 def _work(n: int = 30000) -> str:

--- a/tests/test_suite_hygiene.py
+++ b/tests/test_suite_hygiene.py
@@ -87,3 +87,54 @@ def test_agent_cli_names_covered_by_fixture():
         f"detect.py probes {sorted(probed)} but _hermetic_env only blocks "
         f"{sorted(blocked)} -- add {sorted(missing)} to _AGENT_CLIS in conftest.py"
     )
+
+
+def test_infra_tier_shape_stays_guarded():
+    """The infra marker tier must stay whole-file/class-shaped and off the t2 gate.
+
+    The bench job runs ``pytest tests/ -q -k t2`` with NO ``-m`` filter, so an
+    infra mark cannot deselect it today -- but a t2-named test inside an
+    infra-marked module would break the moment anyone adds a global ``-m``
+    filter (addopts), and a per-test infra mark would recreate the forbidden
+    skip-quarantine shape (release-checklist bans per-test skips/xfails).
+    Static AST checks keep the tier auditable:
+    """
+    import tomllib
+
+    pyproject = tomllib.loads((TESTS_DIR.parent / "pyproject.toml").read_text(encoding="utf-8"))
+    ini = pyproject["tool"]["pytest"]["ini_options"]
+    assert any(str(m).startswith("infra:") for m in ini.get("markers", [])), (
+        "infra marker unregistered in pyproject.toml"
+    )
+    assert "addopts" not in ini, (
+        "addopts with a -m filter would silently deselect the bench job's "
+        "-k t2 gate (it invokes pytest without -m)"
+    )
+    violations = []
+    for path, src in _iter_test_sources():
+        tree = ast.parse(src)
+        marked_module = any(
+            isinstance(n, ast.Assign)
+            and any(
+                isinstance(t, ast.Name) and t.id == "pytestmark"
+                for t in n.targets
+            )
+            for n in tree.body
+        )
+        for node in ast.walk(tree):
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                is_test = node.name.startswith("test")
+                has_infra_mark = any(
+                    isinstance(d, ast.Call)
+                    and isinstance(d.func, ast.Attribute)
+                    and d.func.attr == "infra"
+                    for d in node.decorator_list
+                )
+                if is_test and has_infra_mark:
+                    violations.append(f"{path.name}:{node.lineno} per-test infra mark")
+                if is_test and marked_module and "t2" in node.name:
+                    violations.append(f"{path.name}:{node.lineno} t2-named test in infra module")
+    assert not violations, (
+        "infra tier shape violations (per-test marks are quarantine-shaped; "
+        f"t2-named tests must never sit in an infra module): {violations}"
+    )

--- a/tests/test_suite_hygiene.py
+++ b/tests/test_suite_hygiene.py
@@ -110,15 +110,32 @@ def test_infra_tier_shape_stays_guarded():
         "addopts with a -m filter would silently deselect the bench job's "
         "-k t2 gate (it invokes pytest without -m)"
     )
+    def _is_infra_mark(node):
+        return (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "infra"
+        )
+
     violations = []
     for path, src in _iter_test_sources():
         tree = ast.parse(src)
+        # marked iff pytestmark actually carries pytest.mark.infra (a
+        # usefixtures-only pytestmark is NOT tier membership) or any
+        # top-level class carries the infra decorator
         marked_module = any(
             isinstance(n, ast.Assign)
+            and any(isinstance(t, ast.Name) and t.id == "pytestmark" for t in n.targets)
             and any(
-                isinstance(t, ast.Name) and t.id == "pytestmark"
-                for t in n.targets
+                _is_infra_mark(d) or (
+                    isinstance(d, ast.Attribute) and d.attr == "infra"
+                )
+                for d in ([n.value] if not isinstance(n.value, (ast.List, ast.Tuple)) else n.value.elts)
             )
+            for n in tree.body
+        ) or any(
+            isinstance(n, ast.ClassDef)
+            and any(_is_infra_mark(d) for d in n.decorator_list)
             for n in tree.body
         )
         for node in ast.walk(tree):

--- a/tests/test_suite_hygiene.py
+++ b/tests/test_suite_hygiene.py
@@ -15,6 +15,7 @@ permanent tripwire).
 from __future__ import annotations
 
 import ast
+import re
 from pathlib import Path
 
 TESTS_DIR = Path(__file__).resolve().parent
@@ -99,14 +100,13 @@ def test_infra_tier_shape_stays_guarded():
     skip-quarantine shape (release-checklist bans per-test skips/xfails).
     Static AST checks keep the tier auditable:
     """
-    import tomllib
-
-    pyproject = tomllib.loads((TESTS_DIR.parent / "pyproject.toml").read_text(encoding="utf-8"))
-    ini = pyproject["tool"]["pytest"]["ini_options"]
-    assert any(str(m).startswith("infra:") for m in ini.get("markers", [])), (
+    pyproject = (TESTS_DIR.parent / "pyproject.toml").read_text(encoding="utf-8")
+    assert re.search(r'^\s*"infra:', pyproject, re.M), (
         "infra marker unregistered in pyproject.toml"
     )
-    assert "addopts" not in ini, (
+    # line-anchored: an addopts ASSIGNMENT is the hazard; the explanatory
+    # comments legitimately mention the word
+    assert not re.search(r"^\s*addopts\s*=", pyproject, re.M), (
         "addopts with a -m filter would silently deselect the bench job's "
         "-k t2 gate (it invokes pytest without -m)"
     )

--- a/tests/test_upgrade.py
+++ b/tests/test_upgrade.py
@@ -16,6 +16,8 @@ from click.testing import CliRunner
 from cairn.cli import main
 from cairn.cli import upgrade as upgrade_mod
 
+pytestmark = pytest.mark.infra
+
 
 # --- Fixtures --------------------------------------------------------------
 

--- a/tests/test_verify_datasource.py
+++ b/tests/test_verify_datasource.py
@@ -71,6 +71,7 @@ def _mint_manifest(path, corpus_root, sizes, *, seed=0xC0DE, complexity="low"):
     return manifest
 
 
+@pytest.mark.infra
 class TestHappyPath:
     def test_all_declared_sizes_verify_ok(self, tmp_path):
         _mint_manifest(tmp_path / "m.json", tmp_path / "corpora", [3, 5])
@@ -93,6 +94,7 @@ class TestHappyPath:
         assert report.recipe["complexity"] == "low"
 
 
+@pytest.mark.infra
 class TestDrift:
     def test_flipped_byte_in_generated_file_exits_nonzero(self, tmp_path):
         """TC-003 via content: mint the pin from a corpus with one flipped
@@ -163,6 +165,7 @@ class TestDrift:
         assert first.results[0].actual_hash == second.results[0].actual_hash
 
 
+@pytest.mark.infra
 class TestTreeHashNoiseExclusion:
     """tree_hash must not see machine build-noise dropped inside a corpus tree.
 
@@ -241,6 +244,7 @@ class TestTreeHashNoiseExclusion:
             assert tree_hash(source) == pin, name
 
 
+@pytest.mark.infra
 class TestManifestFailureClass:
     def test_schema_error_is_distinct_from_drift(self, tmp_path):
         manifest = _mint_manifest(tmp_path / "m.json", tmp_path / "corpora", [4])
@@ -260,6 +264,7 @@ class TestManifestFailureClass:
         assert vd.main(["--manifest", str(tmp_path / "absent.json")]) == vd.EXIT_MANIFEST
 
 
+@pytest.mark.infra
 class TestJsonOutput:
     def test_shape_is_machine_readable(self, tmp_path, capsys):
         _mint_manifest(tmp_path / "m.json", tmp_path / "corpora", [4])
@@ -428,6 +433,7 @@ class TestDs2Budget:
         assert not by_path["benchmarks/datasource/t2"].breached
 
 
+@pytest.mark.infra
 class TestBudgetCli:
     """FR-002/AC4 wire layer: --budget mode, default-run wiring, exit codes.
     vd.REPO_ROOT is monkeypatched to a scratch tree so main() measures the
@@ -505,6 +511,7 @@ class TestBudgetCli:
             vd.main(["--size", "100", "--budget", "--manifest", str(tmp_path / "m.json")])
 
 
+@pytest.mark.infra
 class TestEndToEnd:
     def test_real_manifest_size_100_verifies_over_the_wire(self):
         """The committed pin, the real CLI surface, a real subprocess: exit 0

--- a/tests/test_warm_time_harness.py
+++ b/tests/test_warm_time_harness.py
@@ -15,6 +15,9 @@ import json
 import subprocess
 import sys
 from pathlib import Path
+import pytest
+
+pytestmark = pytest.mark.infra
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 SCRIPT = REPO_ROOT / "scripts" / "measure_warm_time.py"

--- a/tests/test_watcher_service.py
+++ b/tests/test_watcher_service.py
@@ -38,6 +38,8 @@ from cairn.graph import scanner as scanner_mod
 from cairn.graph.schema import _apply_schema
 from cairn.graph.watcher import FileWatcherService, _DebouncingHandler
 
+pytestmark = pytest.mark.infra
+
 
 # ---------------------------------------------------------------------------
 # Helpers: corpus, DB, fake watchdog, event objects


### PR DESCRIPTION
## Summary

Test-suite reduction, part 2 of 3 (decided with the maintainer: hybrid mechanism — delete closed-campaign/duplicate tests outright, marker-gate slow-but-valuable infra tests). Introduces an explicit `infra` tier: bench/dataset/soak infrastructure tests (164 collected) move out of the per-PR gate and run instead on every main push via a dedicated CI step. Bare local `pytest` still runs everything — the narrowing happens only where CI says so.

Design points:
- **No `addopts`**, deliberately: the bench job invokes `pytest tests/ -q -k t2` with no `-m`, and a global marker filter would silently deselect its tests. A new `test_suite_hygiene` tripwire pins this invariant (addopts must never appear in `[tool.pytest.ini_options]`) plus the tier's shape: infra marks are whole-file `pytestmark` or class-level only — per-test marks recreate the forbidden skip-quarantine shape.
- The tripwire caught a real conflict during development: `test_verify_datasource.py` (initially whole-file marked) contains 3 t2-named tests the bench gate selects by name — it is now class-marked, with `TestSizeBudgets`/`TestDs2Budget` left default-gated. Likewise `TestTreeHash` in `test_bench_datasource.py` (the DS-v2 seal's `tree_hash` pin) stays in the default gate.
- README testing block, `docs/release-checklist.md` (also drops the stale "~1100 tests" count; frames the tier as deliberate selection, per-test skips remain banned), and `specs/context/tech.md` markers section updated; the dashboard scale/workspaces docstrings' "repo registers no timing marker" apologies refreshed.

## Change type

- [ ] Feature / improvement
- [ ] Bugfix
- [ ] Refactor (no behavior change)
- [x] Docs / chore / CI

## Audit checklist

- [x] **Blast radius checked** — selection-layer change only; no src/ file touched; the bench `-k t2` gate verified to still collect 6 tests; `-m core` still 26 green
- [x] **Layering respected** — pytest config + CI + docs only
- [x] **Graph updated** — no source change; nothing to reindex
- [x] **Memory recorded** — tier design recorded at merge
- [x] **Fallback/perf paths** — n/a
- [x] **Tests** — default gate 2,623 passed / 2 skipped / 4 failed (the documented local-env `test_ensure_semantic_deps` set, D-026 — CI's clean env runs them green); infra tier 164 passed in 17s; hygiene tripwires 4 passed
- [x] **CHANGELOG** — n/a for now (test-infra-only change; folds into the suite-reduction entry with part 3)
- [x] **Gates green** — pre-commit all-files green; PR title conventional

## Blast-radius note

The infra tier runs on every main push (3.12 leg) — not nightly, not optional — so a break in those files still fails CI at merge time. Files whose tests left the PR gate: test_bench, test_bench_stamping, test_agent_suite, test_fetch_t3_corpus, test_warm_time_harness, test_dashboard_{live_soak,scale,workspaces}, test_recording_overhead, + class subsets of test_bench_datasource/test_verify_datasource.

## Verification

- `pytest -q -m "not infra"` → 2,623 passed / 164 deselected (4 env-only failures, D-026)
- `pytest -q -m infra` → 164 passed
- `pytest -m core -q` → 26 passed; `pytest tests/ -q -k t2 --collect-only` → 6 collected
- `pre-commit run --all-files` → green

Part 1 (#89, eval campaign retirement) and part 3 (duplicate/subsumption prune) are file-disjoint siblings.