### PR TITLE
chore(specs): refresh fidelity subprocess-anchor line pins

### DIFF
--- a/specs/context/tech.md
+++ b/specs/context/tech.md
@@ -45,7 +45,7 @@ Stack, build/test runners, and gates. Cited from pyproject.toml,
 - Hermetic by default: `tests/conftest.py:47-67` points HOME/CAIRN_HOME into a
   per-test tmp sandbox. Tests that exercise env propagation across a REAL
   process boundary use subprocess + `env={"CAIRN_HOME": ...}` (e.g.
-  tests/test_install_uninstall_fidelity.py:501, 544, 563;
+  tests/test_install_uninstall_fidelity.py:509, 552, 571;
   tests/test_cli_init_rail.py:34-96; tests/test_uninstall_cmd.py:39-81).
 - Conventions observable in the suite: one test file per feature area
   (`test_doctor.py`, `test_clients.py`, `test_install_uninstall_fidelity.py`,


### PR DESCRIPTION
Three-number touch-up: the #91 review round restored two fidelity tests, shifting the subprocess env= anchors +8; tech.md re-measured (509/552/571, verified by grep on merged main). Docs/chore only; all three parent PRs (#89/#90/#91) are merged.