### PR TITLE
feat(dashboard): global workspace selector, terrain redesign, and wiki navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 > releases will be appended here incrementally.
 
 
-## [Unreleased]
+## [0.17.0] - 2026-09-02
 
 ### Added
 - Dashboard shell: a global workspace selector in the topbar of every view

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Dashboard shell: a global workspace selector in the topbar of every view
+  (server-rendered from the store registry, populated stores only, labeled
+  by workspace path) — switching rewrites the `?store=` param on the
+  current URL and reloads, so the tab stays and every view re-renders on
+  the selected workspace, with the existing localStorage stickiness
+  re-persisting the choice; a `Ctrl/Cmd+K` command palette searching
+  views, workspaces, and live symbol suggestions through the same
+  `/graph/suggest` endpoint the graph typeahead uses; and a collapsible
+  sidebar (persisted pre-paint like the theme) with the nav grouped
+  Explore / Knowledge / Activity / System — Workspaces still leads
+  ungrouped — rendered from one `NAV_SECTIONS` source shared with the
+  palette so the two can never drift.
+- Dashboard wiki navigation: canonical repo-qualified page URLs
+  (`/wiki/{repo}/{page_id}`) fix the multi-repo collision where every
+  repo's `overview` page but one was unreachable — the old one-segment
+  URL survives as a 307 redirect carrying the selected store. The catalog
+  groups pages by repo with state-filter pills and a search box
+  (title/page-id/description); detail pages carry a breadcrumb, an
+  in-page table of contents (heading anchors emitted by the renderer,
+  h2/h3 outline provably matching them), prev/next links walking the
+  repo's promoted pages in plan order, and graph cross-links — inline
+  markdown links render under a strict scheme allowlist
+  (`http(s)://`, `/`, `#`; `javascript:`/`data:` stay literal text) and
+  backticked refs the page itself vouches for (frontmatter sources plus
+  plan seeds, both already graph-verified by the critic gate) link into
+  `/graph?scope=symbol&focus=…` with the selected store riding.
 - Wiki trust context and outward surfaces: every promoted wiki page now
   records the workspace HEAD commit sha it was generated at (in the
   concept's extensions and the manifest row), and both `cairn wiki status`
@@ -47,6 +73,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   consumer side of the wiki visible to new workspaces.
 
 ### Changed
+- Dashboard visual redesign ("Terrain"): the GitNexus teal tokens give
+  way to a warm sandstone light mode, deep ink-brown dark mode, and a
+  burnt-amber primary — same token names in both theme blocks, so the
+  pinned theme contract holds unchanged. Component pass: transparent
+  table headers with a strong rule, monospace code chips, the active nav
+  item carries an accent inset bar, and the new wiki surfaces (catalog,
+  article prose at a 46rem measure, TOC rail, pager) get their styles.
 - Test suite reduced by ~470 cases with the core regression net intact, in
   three reviewable parts: the closed retrieval-quality campaign machinery
   retired lockstep with its CLI flags (see Removed); bench/dataset/soak
@@ -94,6 +127,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the closed verdict (scripts recoverable from git history).
 
 ### Fixed
+- Dashboard forms silently dropped the selected workspace: GET filter
+  forms (history/tasks/graph) lose the action URL's query string on
+  submit and the settings POST actions carried no store at all, so
+  applying a filter or saving settings on a selected store reverted to
+  the launch store one hop later — and for the POSTs, the stickiness
+  redirect could land back on a POST-only route (405). Every form now
+  carries a hidden store input and `settings_save` resolves the body
+  store through the same validation seam.
 - `cairn compass gaps` reported every module as uncovered: `detect_gaps`
   compared repo-qualified module ids against repo-relative compass
   `resource` fields, so the match could never succeed. Coverage now

--- a/README.md
+++ b/README.md
@@ -193,8 +193,12 @@ dispatch hops — polymorphism that grep fundamentally cannot see.
 - **Local dashboard** — `cairn dashboard` opens a loopback web console at
   `127.0.0.1:8765`: interactive graph with symbol search, recorded
   tool-call history and token usage (MCP + CLI, mode-labeled estimates),
-  session chains, health/memory panels, machine-wide workspace switching,
-  CSV/JSON export of any filtered view, an Embeddings status view (probe
+  session chains, health/memory panels, a global workspace selector in the
+  topbar (every view follows the selection), a `Ctrl/Cmd+K` command palette
+  (views, workspaces, symbol search), repo-scoped wiki navigation (grouped
+  catalog with filters and search, breadcrumbs, in-page TOCs, prev/next,
+  graph cross-links), a collapsible grouped sidebar, CSV/JSON export of any
+  filtered view, an Embeddings status view (probe
   health, fallback state, per-knob config sources) with the degradation
   banner, and a Settings page that persists embedding-backend configuration
   to `~/.cairn/config.json`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "cairn-intel"
-version = "0.16.3"
+version = "0.17.0"
 description = "Local codebase intelligence system: structural graph + compass + wiki + agent memory"
 readme = "README.md"
 license = "MIT"
@@ -232,7 +232,7 @@ select = ["F"]
 # The custom template (.cz_templates/keepachangelog.j2) renders that draft in
 # the existing `## [X.Y.Z] - YYYY-MM-DD` format rather than commitizen's
 # default `## X.Y.Z (YYYY-MM-DD)`.
-version = "0.16.3"
+version = "0.17.0"
 version_scheme = "pep440"
 tag_format = "v$version"
 update_changelog_on_bump = false

--- a/src/cairn/__init__.py
+++ b/src/cairn/__init__.py
@@ -1,3 +1,3 @@
 """Cairn: local codebase intelligence system."""
-__version__ = "0.16.3"
+__version__ = "0.17.0"
 __package_name__ = "cairn-intel"

--- a/src/cairn/dashboard/app.py
+++ b/src/cairn/dashboard/app.py
@@ -785,7 +785,9 @@ def create_app(
         )
         repo = request.path_params["repo"]
         page_id = request.path_params["page_id"]
-        page = get_wiki_page(selected_knowledge, page_id, repo=repo)
+        page = get_wiki_page(
+            selected_knowledge, page_id, repo=repo, store_key=store_key
+        )
         if page is None:
             return _wiki_not_found()
         promoted = [

--- a/src/cairn/dashboard/app.py
+++ b/src/cairn/dashboard/app.py
@@ -706,36 +706,111 @@ def create_app(
         )
 
     def wiki(request: Request) -> Response:
+        # Catalog filters, read like every other view's params: absent or
+        # blank means no filter; ``state`` outside PAGE_STATES falls back to
+        # no filter (silent fallback, matching the scope/window fallbacks).
+        from ..wiki.manifest import PAGE_STATES
+
+        repo = request.query_params.get("repo", "").strip() or None
+        state = request.query_params.get("state", "").strip() or None
+        query = request.query_params.get("q", "").strip()
         _, selected_knowledge, store_key = resolve_selection(
             request, db_path, knowledge_dir
         )
-        pages = get_wiki_pages(selected_knowledge)
+        pages = get_wiki_pages(selected_knowledge, repo=repo)
+        if state in PAGE_STATES:
+            pages = [p for p in pages if p["state"] == state]
+        if query:
+            needle = query.lower()
+            pages = [
+                p
+                for p in pages
+                if needle in p["title"].lower()
+                or needle in p["page_id"].lower()
+                or needle in (p.get("description") or "").lower()
+            ]
         return render(
             request,
             "wiki.html",
-            {"pages": pages, "store_key": store_key},
+            {
+                "pages": pages,
+                "page_states": PAGE_STATES,
+                "filters": {"repo": repo or "", "state": state or "", "q": query},
+                "store_key": store_key,
+            },
+        )
+
+    def _wiki_not_found() -> Response:
+        from starlette.responses import HTMLResponse
+
+        return HTMLResponse(
+            "<html><head><title>cairn dashboard</title></head><body>"
+            "<h1>Wiki page not found</h1>"
+            "<p>No rendered article exists for this page id.</p>"
+            '<p><a href="/wiki">Back to the wiki</a></p>'
+            "</body></html>",
+            status_code=404,
         )
 
     def wiki_page(request: Request) -> Response:
-        _, selected_knowledge, store_key = resolve_selection(
+        """Legacy one-segment URL: a permanent redirect to the repo-qualified
+        canonical URL (bookmarks and recorded links keep working), or the
+        same 404 as before when no readable concept matches."""
+        from urllib.parse import quote
+
+        from starlette.responses import RedirectResponse
+
+        _, selected_knowledge, _ = resolve_selection(
             request, db_path, knowledge_dir
         )
         page = get_wiki_page(selected_knowledge, request.path_params["page_id"])
         if page is None:
-            from starlette.responses import HTMLResponse
+            return _wiki_not_found()
+        target = "/wiki/{}/{}".format(
+            quote(page["repo"], safe=""), quote(page["page_id"], safe="")
+        )
+        store = request.query_params.get("store", "").strip()
+        if store:
+            target += "?store=" + quote(store, safe="")
+        return RedirectResponse(target, status_code=307)
 
-            return HTMLResponse(
-                "<html><head><title>cairn dashboard</title></head><body>"
-                "<h1>Wiki page not found</h1>"
-                "<p>No rendered article exists for this page id.</p>"
-                '<p><a href="/wiki">Back to the wiki</a></p>'
-                "</body></html>",
-                status_code=404,
-            )
+    def wiki_page_repo(request: Request) -> Response:
+        # The canonical URL: repo-qualified, so multi-repo workspaces can
+        # reach every page even when repos plan colliding page ids (every
+        # repo plans an "overview"). prev/next walk the repo's promoted
+        # pages in manifest (plan) order — non-promoted rows have no
+        # readable concept, so linking to them would be a dead end.
+        _, selected_knowledge, store_key = resolve_selection(
+            request, db_path, knowledge_dir
+        )
+        repo = request.path_params["repo"]
+        page_id = request.path_params["page_id"]
+        page = get_wiki_page(selected_knowledge, page_id, repo=repo)
+        if page is None:
+            return _wiki_not_found()
+        promoted = [
+            p
+            for p in get_wiki_pages(selected_knowledge, repo=repo)
+            if p["promoted"]
+        ]
+        index = next(
+            (i for i, p in enumerate(promoted) if p["page_id"] == page_id), None
+        )
+        prev_page = promoted[index - 1] if index not in (None, 0) else None
+        next_page = (
+            promoted[index + 1]
+            if index is not None and index + 1 < len(promoted)
+            else None
+        )
         return render(
             request,
             "wiki_page.html",
-            {"page": page, "store_key": store_key},
+            {
+                "page": page,
+                "prev": prev_page,
+                "next": next_page,
+                "store_key": store_key,
+            },
         )
 
     def _settings_context(
@@ -990,6 +1065,10 @@ def create_app(
         Route("/memory", memory, name="memory"),
         Route("/tasks", tasks, name="tasks"),
         Route("/wiki", wiki, name="wiki"),
+        # Repo-qualified canonical URL first; the one-segment legacy route
+        # follows as a redirect (a single path param never matches two
+        # segments, so the two never shadow each other).
+        Route("/wiki/{repo}/{page_id}", wiki_page_repo, name="wiki_page_repo"),
         Route("/wiki/{page_id}", wiki_page, name="wiki_page"),
         Route("/embeddings", embeddings_status, name="embeddings"),
         Route("/settings", settings, name="settings"),

--- a/src/cairn/dashboard/app.py
+++ b/src/cairn/dashboard/app.py
@@ -257,7 +257,7 @@ def create_app(
         symbol_suggest,
     )
     from .workspaces import enumerate_stores, probe_stores
-    from .shell import selector_context
+    from .shell import shell_context
     from .. import paths
     from ..graph import embed_ladder, embeddings
     from ..paths import default_knowledge_path
@@ -312,12 +312,11 @@ def create_app(
         directory scan per render."""
         context["embed_banner"] = embed_banner()
         if "shell" not in context:
-            context["shell"] = {
-                "selector": selector_context(
-                    enumerate_stores(Path(paths.CAIRN_HOME)),
-                    context.get("store_key", ""),
-                )
-            }
+            context["shell"] = shell_context(
+                enumerate_stores(Path(paths.CAIRN_HOME)),
+                context.get("store_key", ""),
+                request.url.path,
+            )
         return templates.TemplateResponse(
             request, name, context, status_code=status_code
         )

--- a/src/cairn/dashboard/app.py
+++ b/src/cairn/dashboard/app.py
@@ -311,7 +311,10 @@ def create_app(
         )
 
     def resolve_selection(
-        request: Request, db_path: str | None, knowledge_dir: str | None
+        request: Request,
+        db_path: str | None,
+        knowledge_dir: str | None,
+        form=None,
     ) -> tuple[str | None, str, str]:
         """This request's ``(db, knowledge_root, store_key)`` (FR-003, D-001).
 
@@ -322,8 +325,15 @@ def create_app(
         path (no arbitrary-file-open vector). An unknown, empty, or missing
         key raises MissingDatabaseError so the app-level handler renders
         the missing-DB page: the friendly missing state, never an error.
+
+        ``form`` is the already-parsed body of a POST whose form carries the
+        hidden store input (settings): the body store is a fallback for the
+        query param only — one seam, two transports, same validation.
         """
         store_key = request.query_params.get("store", "").strip()
+        if not store_key and form is not None:
+            raw = form.get("store")
+            store_key = (str(raw) if raw is not None else "").strip()
         if not store_key:
             return db_path, knowledge_dir or str(default_knowledge_path()), ""
         home = Path(paths.CAIRN_HOME)
@@ -772,7 +782,9 @@ def create_app(
     # handlers above stay plain-def (threadpool) — this route touches no SQL.
     async def settings_save(request: Request) -> Response:
         form = await request.form()
-        _, _, store_key = resolve_selection(request, db_path, knowledge_dir)
+        _, _, store_key = resolve_selection(
+            request, db_path, knowledge_dir, form=form
+        )
         submitted = {
             key: str(form.get(key) or "").strip()
             for key in SETTINGS_KEYS

--- a/src/cairn/dashboard/app.py
+++ b/src/cairn/dashboard/app.py
@@ -771,7 +771,7 @@ def create_app(
 
         from starlette.responses import RedirectResponse
 
-        _, selected_knowledge, _ = resolve_selection(
+        _, selected_knowledge, store_key = resolve_selection(
             request, db_path, knowledge_dir
         )
         page = get_wiki_page(selected_knowledge, request.path_params["page_id"])
@@ -780,9 +780,8 @@ def create_app(
         target = "/wiki/{}/{}".format(
             quote(page["repo"], safe=""), quote(page["page_id"], safe="")
         )
-        store = request.query_params.get("store", "").strip()
-        if store:
-            target += "?store=" + quote(store, safe="")
+        if store_key:
+            target += "?store=" + quote(store_key, safe="")
         return RedirectResponse(target, status_code=307)
 
     def wiki_page_repo(request: Request) -> Response:
@@ -1117,6 +1116,8 @@ def create_app(
             f"<p>No graph database found at <code>{escape(str(exc))}</code>.</p>"
             "<p>Run <code>cairn build</code> to index this workspace, "
             "then refresh.</p>"
+            '<p><a href="/workspaces">Open the workspaces overview</a> '
+            "to pick an available store.</p>"
             "</body></html>"
         )
 

--- a/src/cairn/dashboard/app.py
+++ b/src/cairn/dashboard/app.py
@@ -257,6 +257,7 @@ def create_app(
         symbol_suggest,
     )
     from .workspaces import enumerate_stores, probe_stores
+    from .shell import selector_context
     from .. import paths
     from ..graph import embed_ladder, embeddings
     from ..paths import default_knowledge_path
@@ -304,8 +305,19 @@ def create_app(
     def render(
         request: Request, name: str, context: dict, status_code: int = 200
     ) -> Response:
-        """TemplateResponse carrying the banner context on every page."""
+        """TemplateResponse carrying the banner and shell context on every
+        page. The selector's options come from enumerate_stores (stat-only,
+        never probed — probe_stores and its 100-open budget stay exclusive
+        to the workspaces overview) and cost one registry read plus one
+        directory scan per render."""
         context["embed_banner"] = embed_banner()
+        if "shell" not in context:
+            context["shell"] = {
+                "selector": selector_context(
+                    enumerate_stores(Path(paths.CAIRN_HOME)),
+                    context.get("store_key", ""),
+                )
+            }
         return templates.TemplateResponse(
             request, name, context, status_code=status_code
         )

--- a/src/cairn/dashboard/data.py
+++ b/src/cairn/dashboard/data.py
@@ -20,7 +20,7 @@ if TYPE_CHECKING:
     from cairn.okf.concept import OKFConcept
 
 from cairn.bench.agent_suite import CHARS_PER_TOKEN
-from cairn.dashboard.markdown import render_markdown
+from cairn.dashboard.markdown import render_markdown_with_toc
 from cairn.dashboard.tokenizer import (
     HEURISTIC_MODE,
     active_tokenizer_mode,
@@ -717,22 +717,57 @@ def get_wiki_pages(knowledge_dir: str, repo: Optional[str] = None) -> List[dict]
     return pages
 
 
+def _symbol_graph_href(symbol: str, store_suffix: str) -> str:
+    """Deep link to the symbol's graph view (the existing /graph seam:
+    scope=symbol&focus=..., store riding last when selected)."""
+    from urllib.parse import quote
+
+    return f"/graph?scope=symbol&focus={quote(symbol, safe='')}{store_suffix}"
+
+
+def _wiki_ref_map(concept, row: dict, store_suffix: str) -> dict:
+    """``code-span text -> graph deep link`` for the refs this page itself
+    vouches for: frontmatter sources plus the manifest plan's symbol seeds
+    (both already verified against the graph by the promotion gate). Only
+    mapped spans become links, so an arbitrary backticked word can never
+    link to a symbol the graph never resolved."""
+    refs: Dict[str, str] = {}
+    for entry in concept.sources or []:
+        symbol = entry.get("symbol") if isinstance(entry, dict) else None
+        if symbol:
+            refs.setdefault(str(symbol), _symbol_graph_href(str(symbol), store_suffix))
+    seeds = row.get("seeds") or {}
+    for symbol in seeds.get("symbols") or []:
+        refs.setdefault(str(symbol), _symbol_graph_href(str(symbol), store_suffix))
+    return refs
+
+
 def get_wiki_page(
-    knowledge_dir: str, page_id: str, repo: Optional[str] = None
+    knowledge_dir: str,
+    page_id: str,
+    repo: Optional[str] = None,
+    store_key: str = "",
 ) -> Optional[dict]:
     """One wiki page: manifest row plus the rendered concept body.
 
-    ``html`` is the body through the escape-first markdown renderer;
-    ``sources`` is the concept's frontmatter list verbatim; ``staleness``
-    compares the recorded commit sha with the repo's current HEAD
-    (fresh/stale/unknown, HEAD resolved once per repo per call). None when
-    no manifest row for ``page_id`` (``repo`` narrows the match when
-    several repos plan the same page id) has a readable concept. The
-    returned ``repo`` names the owning repo — the caller needs it for the
-    repo-qualified URL ``/wiki/{repo}/{page_id}``.
+    ``html`` is the body through the escape-first markdown renderer and
+    ``toc`` its h2/h3 outline (anchors match the emitted heading ids);
+    ``ref_hrefs`` maps the page's vouched symbol refs (sources + plan
+    seeds) to graph deep links — the body's backticked spans and the
+    sources list linkify through it, with the selected store riding when
+    ``store_key`` is set. ``sources`` is the concept's frontmatter list
+    verbatim; ``staleness`` compares the recorded commit sha with the
+    repo's current HEAD (fresh/stale/unknown, HEAD resolved once per repo
+    per call). None when no manifest row for ``page_id`` (``repo`` narrows
+    the match when several repos plan the same page id) has a readable
+    concept. The returned ``repo`` names the owning repo — the caller
+    needs it for the repo-qualified URL ``/wiki/{repo}/{page_id}``.
     """
+    from urllib.parse import quote
+
     from cairn.wiki.manifest import load_manifest
 
+    store_suffix = f"&store={quote(store_key, safe='')}" if store_key else ""
     bundle = OKFBundle(knowledge_dir)
     heads: Dict[str, Optional[str]] = {}
     for key, row in load_manifest(knowledge_dir)["pages"].items():
@@ -746,12 +781,16 @@ def get_wiki_page(
             continue
         if key_repo not in heads:
             heads[key_repo] = get_repo_head(key_repo)
+        ref_hrefs = _wiki_ref_map(concept, row, store_suffix)
+        html, toc = render_markdown_with_toc(concept.body, ref_hrefs)
         return {
             "repo": key_repo,
             "page_id": page_id,
             "title": row.get("title") or concept.title or page_id,
             "state": row.get("state", ""),
-            "html": render_markdown(concept.body),
+            "html": html,
+            "toc": toc,
+            "ref_hrefs": ref_hrefs,
             "sources": concept.sources or [],
             "staleness": _wiki_staleness(
                 _recorded_sha(concept, row), heads[key_repo]

--- a/src/cairn/dashboard/data.py
+++ b/src/cairn/dashboard/data.py
@@ -13,6 +13,7 @@ import sqlite3
 import threading
 import time
 from datetime import datetime, timezone
+from html import escape as html_escape
 from pathlib import Path
 from typing import TYPE_CHECKING, Dict, List, Optional, Tuple
 
@@ -674,6 +675,33 @@ def _wiki_staleness(recorded_sha: Optional[str], head: Optional[str]) -> str:
     return "fresh" if recorded_sha == head else "stale"
 
 
+def _wiki_rows(
+    knowledge_dir: str, repo: Optional[str] = None, page_id: Optional[str] = None
+):
+    """Lazy ``(repo, page_id, manifest_row, concept, head)`` tuples over
+    the manifest — the one traversal ``get_wiki_pages`` and
+    ``get_wiki_page`` share (concept ids, per-repo HEAD caching, and the
+    staleness inputs live here once). ``concept`` is None when the row's
+    concept is absent or unreadable; ``head`` is the repo's current HEAD
+    (resolved once per repo per call)."""
+    from cairn.wiki.manifest import load_manifest
+
+    bundle = OKFBundle(knowledge_dir)
+    heads: Dict[str, Optional[str]] = {}
+    for key, row in load_manifest(knowledge_dir)["pages"].items():
+        key_repo, key_page = _split_page_key(key)
+        if repo and key_repo != repo:
+            continue
+        if page_id and key_page != page_id:
+            continue
+        concept = _read_wiki_concept(
+            bundle, f"wiki/pages/{key_repo}/{key_page}"
+        )
+        if key_repo not in heads:
+            heads[key_repo] = get_repo_head(key_repo)
+        yield key_repo, key_page, row, concept, heads[key_repo]
+
+
 def get_wiki_pages(knowledge_dir: str, repo: Optional[str] = None) -> List[dict]:
     """Wiki manifest pages joined with their ``wiki/pages/`` concepts.
 
@@ -682,25 +710,15 @@ def get_wiki_pages(knowledge_dir: str, repo: Optional[str] = None) -> List[dict]
     ``promoted`` is derived from the row's own
     ``wiki/pages/{repo}/{page_id}`` concept being readable, never the
     stored state, and ``staleness`` compares the recorded commit sha with
-    the repo's current HEAD (fresh/stale/unknown). HEAD is resolved once
-    per repo per call. A missing manifest (or knowledge dir) yields an
-    empty list; ``repo`` selects one repo's rows. Row order is manifest
-    order (plan order) — the catalog groups by ``repo`` on top of it.
+    the repo's current HEAD (fresh/stale/unknown). A missing manifest (or
+    knowledge dir) yields an empty list; ``repo`` selects one repo's rows.
+    Row order is manifest order (plan order) — the catalog groups by
+    ``repo`` on top of it.
     """
-    from cairn.wiki.manifest import load_manifest
-
-    bundle = OKFBundle(knowledge_dir)
-    heads: Dict[str, Optional[str]] = {}
     pages: List[dict] = []
-    for key, row in load_manifest(knowledge_dir)["pages"].items():
-        key_repo, page_id = _split_page_key(key)
-        if repo and key_repo != repo:
-            continue
-        concept = _read_wiki_concept(
-            bundle, f"wiki/pages/{key_repo}/{page_id}"
-        )
-        if key_repo not in heads:
-            heads[key_repo] = get_repo_head(key_repo)
+    for key_repo, page_id, row, concept, head in _wiki_rows(
+        knowledge_dir, repo=repo
+    ):
         pages.append(
             {
                 "repo": key_repo,
@@ -709,9 +727,7 @@ def get_wiki_pages(knowledge_dir: str, repo: Optional[str] = None) -> List[dict]
                 "description": row.get("description") or "",
                 "state": row.get("state", ""),
                 "promoted": concept is not None,
-                "staleness": _wiki_staleness(
-                    _recorded_sha(concept, row), heads[key_repo]
-                ),
+                "staleness": _wiki_staleness(_recorded_sha(concept, row), head),
             }
         )
     return pages
@@ -730,15 +746,23 @@ def _wiki_ref_map(concept, row: dict, store_suffix: str) -> dict:
     vouches for: frontmatter sources plus the manifest plan's symbol seeds
     (both already verified against the graph by the promotion gate). Only
     mapped spans become links, so an arbitrary backticked word can never
-    link to a symbol the graph never resolved."""
+    link to a symbol the graph never resolved. Keys carry the same
+    html.escape(quote=False) the rendered body went through, so the
+    renderer's post-escape span lookup matches."""
     refs: Dict[str, str] = {}
     for entry in concept.sources or []:
         symbol = entry.get("symbol") if isinstance(entry, dict) else None
         if symbol:
-            refs.setdefault(str(symbol), _symbol_graph_href(str(symbol), store_suffix))
+            key = html_escape(str(symbol), quote=False)
+            refs.setdefault(
+                key, _symbol_graph_href(str(symbol), store_suffix)
+            )
     seeds = row.get("seeds") or {}
     for symbol in seeds.get("symbols") or []:
-        refs.setdefault(str(symbol), _symbol_graph_href(str(symbol), store_suffix))
+        key = html_escape(str(symbol), quote=False)
+        refs.setdefault(
+            key, _symbol_graph_href(str(symbol), store_suffix)
+        )
     return refs
 
 
@@ -757,30 +781,20 @@ def get_wiki_page(
     sources list linkify through it, with the selected store riding when
     ``store_key`` is set. ``sources`` is the concept's frontmatter list
     verbatim; ``staleness`` compares the recorded commit sha with the
-    repo's current HEAD (fresh/stale/unknown, HEAD resolved once per repo
-    per call). None when no manifest row for ``page_id`` (``repo`` narrows
-    the match when several repos plan the same page id) has a readable
-    concept. The returned ``repo`` names the owning repo — the caller
-    needs it for the repo-qualified URL ``/wiki/{repo}/{page_id}``.
+    repo's current HEAD (fresh/stale/unknown). None when no manifest row
+    for ``page_id`` (``repo`` narrows the match when several repos plan
+    the same page id) has a readable concept. The returned ``repo`` names
+    the owning repo — the caller needs it for the repo-qualified URL
+    ``/wiki/{repo}/{page_id}``.
     """
     from urllib.parse import quote
 
-    from cairn.wiki.manifest import load_manifest
-
-    store_suffix = f"&store={quote(store_key, safe='')}" if store_key else ""
-    bundle = OKFBundle(knowledge_dir)
-    heads: Dict[str, Optional[str]] = {}
-    for key, row in load_manifest(knowledge_dir)["pages"].items():
-        key_repo, key_page = _split_page_key(key)
-        if key_page != page_id or (repo and key_repo != repo):
-            continue
-        concept = _read_wiki_concept(
-            bundle, f"wiki/pages/{key_repo}/{key_page}"
-        )
+    for key_repo, key_page, row, concept, head in _wiki_rows(
+        knowledge_dir, repo=repo, page_id=page_id
+    ):
         if concept is None:
             continue
-        if key_repo not in heads:
-            heads[key_repo] = get_repo_head(key_repo)
+        store_suffix = f"&store={quote(store_key, safe='')}" if store_key else ""
         ref_hrefs = _wiki_ref_map(concept, row, store_suffix)
         html, toc = render_markdown_with_toc(concept.body, ref_hrefs)
         return {
@@ -792,9 +806,7 @@ def get_wiki_page(
             "toc": toc,
             "ref_hrefs": ref_hrefs,
             "sources": concept.sources or [],
-            "staleness": _wiki_staleness(
-                _recorded_sha(concept, row), heads[key_repo]
-            ),
+            "staleness": _wiki_staleness(_recorded_sha(concept, row), head),
         }
     return None
 

--- a/src/cairn/dashboard/data.py
+++ b/src/cairn/dashboard/data.py
@@ -677,13 +677,15 @@ def _wiki_staleness(recorded_sha: Optional[str], head: Optional[str]) -> str:
 def get_wiki_pages(knowledge_dir: str, repo: Optional[str] = None) -> List[dict]:
     """Wiki manifest pages joined with their ``wiki/pages/`` concepts.
 
-    One plain dict per manifest row carrying ``page_id``, ``title``,
-    ``state``, ``promoted``, and ``staleness``; ``promoted`` is derived
-    from the row's own ``wiki/pages/{repo}/{page_id}`` concept being
-    readable, never the stored state, and ``staleness`` compares the
-    recorded commit sha with the repo's current HEAD (fresh/stale/unknown).
-    HEAD is resolved once per repo per call. A missing manifest (or
-    knowledge dir) yields an empty list; ``repo`` selects one repo's rows.
+    One plain dict per manifest row carrying ``repo``, ``page_id``,
+    ``title``, ``description``, ``state``, ``promoted``, and ``staleness``;
+    ``promoted`` is derived from the row's own
+    ``wiki/pages/{repo}/{page_id}`` concept being readable, never the
+    stored state, and ``staleness`` compares the recorded commit sha with
+    the repo's current HEAD (fresh/stale/unknown). HEAD is resolved once
+    per repo per call. A missing manifest (or knowledge dir) yields an
+    empty list; ``repo`` selects one repo's rows. Row order is manifest
+    order (plan order) — the catalog groups by ``repo`` on top of it.
     """
     from cairn.wiki.manifest import load_manifest
 
@@ -701,8 +703,10 @@ def get_wiki_pages(knowledge_dir: str, repo: Optional[str] = None) -> List[dict]
             heads[key_repo] = get_repo_head(key_repo)
         pages.append(
             {
+                "repo": key_repo,
                 "page_id": page_id,
                 "title": row.get("title") or page_id,
+                "description": row.get("description") or "",
                 "state": row.get("state", ""),
                 "promoted": concept is not None,
                 "staleness": _wiki_staleness(
@@ -723,7 +727,9 @@ def get_wiki_page(
     compares the recorded commit sha with the repo's current HEAD
     (fresh/stale/unknown, HEAD resolved once per repo per call). None when
     no manifest row for ``page_id`` (``repo`` narrows the match when
-    several repos plan the same page id) has a readable concept.
+    several repos plan the same page id) has a readable concept. The
+    returned ``repo`` names the owning repo — the caller needs it for the
+    repo-qualified URL ``/wiki/{repo}/{page_id}``.
     """
     from cairn.wiki.manifest import load_manifest
 
@@ -741,6 +747,7 @@ def get_wiki_page(
         if key_repo not in heads:
             heads[key_repo] = get_repo_head(key_repo)
         return {
+            "repo": key_repo,
             "page_id": page_id,
             "title": row.get("title") or concept.title or page_id,
             "state": row.get("state", ""),

--- a/src/cairn/dashboard/markdown.py
+++ b/src/cairn/dashboard/markdown.py
@@ -4,11 +4,25 @@ Pure stdlib (``html`` + ``re``): importing this module must never load the
 server stack — the same guard the dashboard package is held to. Every line
 is HTML-escaped before any construct is rendered, so inline HTML never
 passes through; the whitelisted block constructs are headings, paragraphs,
-unordered lists, fenced code, and GFM pipe tables, and backtick spans wrap
-in ``<code>`` after escaping. Mermaid fences emit ``<pre class="mermaid">``
-so the wiki detail view's client-side mermaid.js can render them live; with
-JavaScript or the CDN unavailable the fence degrades to a visible code
-block.
+unordered lists, fenced code, and GFM pipe tables. Mermaid fences emit
+``<pre class="mermaid">`` so the wiki detail view's client-side mermaid.js
+can render them live; with JavaScript or the CDN unavailable the fence
+degrades to a visible code block.
+
+Inline constructs (one left-to-right pass over already-escaped text, code
+spans consumed atomically so link syntax inside backticks stays literal):
+
+- backtick spans wrap in ``<code>``; a span whose exact text appears in the
+  caller's ``link_map`` (wiki refs the page itself vouches for) wraps in an
+  anchor to the mapped href instead;
+- ``[label](target)`` renders as an anchor only for allowlisted targets
+  (``http(s)://``, ``/``, ``#``) — the href is emitted exclusively from the
+  allowlist match, so ``javascript:``/``data:``/relative mischief stays
+  literal text, never an attribute.
+
+Headings carry deterministic slug ids (repeats suffixed ``-1``, ``-2``, ...);
+:func:`render_markdown_with_toc` returns the h2/h3 outline with anchors
+that provably match the rendered ids (same slugger over the same text).
 """
 from __future__ import annotations
 
@@ -20,6 +34,13 @@ _HEADING_RE = re.compile(r"^(#{1,6})\s+(.*)$")
 _FENCE_RE = re.compile(r"^```(\S*)\s*$")
 _LIST_ITEM_RE = re.compile(r"^-\s+(.*)$")
 _CODE_SPAN_RE = re.compile(r"`([^`]+)`")
+# One combined pass: the code-span alternative first, so `` `[x](/y)` ``
+# consumes the link syntax inside the span atomically.
+_INLINE_TOKEN_RE = re.compile(
+    "`([^`]+)`" "|" r"\[([^\]]+)\]\(([^)\s]+)\)"
+)
+# Schemes/roots an inline link may target — anything else renders literal.
+_ALLOWED_LINK_RE = re.compile(r"^(?:https?://|/|#)")
 _DELIM_ROW_RE = re.compile(r"^\|?\s*:?-{3,}:?\s*(\|\s*:?-{3,}:?\s*)*\|?$")
 _UNESCAPED_PIPE_RE = re.compile(r"(?<!\\)\|")
 
@@ -32,9 +53,39 @@ def _emit_fence(out: List[str], lang: str, lines: List[str]) -> None:
         out.append(f"<pre><code>{body}</code></pre>")
 
 
-def _inline_code(escaped_text: str) -> str:
-    """Wrap backtick spans in <code>; the text stays escaped, never re-escaped."""
-    return _CODE_SPAN_RE.sub(lambda m: f"<code>{m.group(1)}</code>", escaped_text)
+def _inline(escaped_text: str, link_map: Optional[dict] = None) -> str:
+    """Inline pass over escaped text: code spans (optionally link-mapped)
+    and allowlisted inline links; everything else stays as-is."""
+
+    def replace(match: "re.Match[str]") -> str:
+        code = match.group(1)
+        if code is not None:
+            href = (link_map or {}).get(code)
+            if href is not None:
+                safe = html.escape(href, quote=True)
+                return f'<a class="code-ref" href="{safe}"><code>{code}</code></a>'
+            return f"<code>{code}</code>"
+        label, target = match.group(2), match.group(3)
+        if _ALLOWED_LINK_RE.match(target):
+            return f'<a href="{target}">{label}</a>'
+        return match.group(0)  # refused target: the literal text, escaped
+
+    return _INLINE_TOKEN_RE.sub(replace, escaped_text)
+
+
+def _slugify(text: str) -> str:
+    """Deterministic heading slug: lowercase, non-alphanumerics collapse to
+    ``-``; an empty result (all-symbol heading) reads ``section``."""
+    slug = re.sub(r"[^a-z0-9]+", "-", text.lower()).strip("-")
+    return slug or "section"
+
+
+def _next_slug(counts: dict, text: str) -> str:
+    """``text``'s slug, suffixed ``-1``/``-2``/... on repeat within a page."""
+    base = _slugify(text)
+    seen = counts.get(base, 0)
+    counts[base] = seen + 1
+    return base if not seen else f"{base}-{seen}"
 
 
 def _split_row(escaped_row: str) -> List[str]:
@@ -61,18 +112,34 @@ def _column_alignment(escaped_delim: str) -> List[Optional[str]]:
     return aligns
 
 
-def _emit_table_row(escaped_row: str, tag: str, align: List[Optional[str]]) -> str:
+def _emit_table_row(
+    escaped_row: str,
+    tag: str,
+    align: List[Optional[str]],
+    link_map: Optional[dict],
+) -> str:
     cells = []
     for i, cell in enumerate(_split_row(escaped_row)):
-        text = _inline_code(cell.replace("\\|", "|"))
+        text = _inline(cell.replace("\\|", "|"), link_map)
         style = f' style="{align[i]}"' if i < len(align) and align[i] else ""
         cells.append(f"<{tag}{style}>{text}</{tag}>")
     return "<tr>" + "".join(cells) + "</tr>"
 
 
-def render_markdown(text: str) -> str:
+def render_markdown(text: str, link_map: Optional[dict] = None) -> str:
     """Render a markdown body to HTML: escape first, whitelist blocks."""
+    return render_markdown_with_toc(text, link_map=link_map)[0]
+
+
+def render_markdown_with_toc(
+    text: str, link_map: Optional[dict] = None
+) -> tuple:
+    """``(html, toc)``: the rendered body plus its h2/h3 outline as
+    ``[{level, text, anchor}]`` — each ``anchor`` is the id the matching
+    heading emitted (one slugger over one body, so they cannot drift)."""
     out: List[str] = []
+    toc: List[dict] = []
+    slug_counts: dict = {}
     paragraph: List[str] = []
     items: List[str] = []
     fence_lang: Optional[str] = None
@@ -84,14 +151,16 @@ def render_markdown(text: str) -> str:
 
     def flush_paragraph() -> None:
         if paragraph:
-            out.append("<p>" + _inline_code(" ".join(paragraph)) + "</p>")
+            out.append(
+                "<p>" + _inline(" ".join(paragraph), link_map) + "</p>"
+            )
             paragraph.clear()
 
     def flush_list() -> None:
         if items:
             out.append(
                 "<ul>"
-                + "".join(f"<li>{_inline_code(item)}</li>" for item in items)
+                + "".join(f"<li>{_inline(item, link_map)}</li>" for item in items)
                 + "</ul>"
             )
             items.clear()
@@ -104,9 +173,9 @@ def render_markdown(text: str) -> str:
         body = table_rows[2:]
         if all(len(_split_row(row)) == table_cols for row in body):
             out.append("<table>")
-            out.append(_emit_table_row(header, "th", table_align))
+            out.append(_emit_table_row(header, "th", table_align, link_map))
             for row in body:
-                out.append(_emit_table_row(row, "td", table_align))
+                out.append(_emit_table_row(row, "td", table_align, link_map))
             out.append("</table>")
         else:
             paragraph.extend(table_rows)
@@ -141,7 +210,24 @@ def render_markdown(text: str) -> str:
             flush_paragraph()
             flush_list()
             level = len(heading.group(1))
-            out.append(f"<h{level}>{_inline_code(heading.group(2))}</h{level}>")
+            # The slug/TOC text read the RAW line (pre-escape): the anchor
+            # is stable regardless of escaping, and the TOC carries plain
+            # text the template escapes itself.
+            raw_heading = _HEADING_RE.match(raw)
+            raw_title = raw_heading.group(2) if raw_heading else heading.group(2)
+            anchor = _next_slug(slug_counts, raw_title)
+            out.append(
+                f'<h{level} id="{anchor}">'
+                f"{_inline(heading.group(2), link_map)}</h{level}>"
+            )
+            if level in (2, 3):
+                toc.append(
+                    {
+                        "level": level,
+                        "text": _CODE_SPAN_RE.sub(r"\1", raw_title),
+                        "anchor": anchor,
+                    }
+                )
             continue
         if paragraph and _DELIM_ROW_RE.match(line):
             header_cells = _split_row(paragraph[-1])
@@ -159,7 +245,7 @@ def render_markdown(text: str) -> str:
         item = _LIST_ITEM_RE.match(line)
         if item:
             flush_paragraph()
-            items.append(_inline_code(item.group(1)))
+            items.append(_inline(item.group(1), link_map))
             continue
         if not line.strip():
             flush_paragraph()
@@ -173,4 +259,4 @@ def render_markdown(text: str) -> str:
     flush_table()
     flush_paragraph()
     flush_list()
-    return "\n".join(out)
+    return "\n".join(out), toc

--- a/src/cairn/dashboard/markdown.py
+++ b/src/cairn/dashboard/markdown.py
@@ -67,7 +67,12 @@ def _inline(escaped_text: str, link_map: Optional[dict] = None) -> str:
             return f"<code>{code}</code>"
         label, target = match.group(2), match.group(3)
         if _ALLOWED_LINK_RE.match(target):
-            return f'<a href="{target}">{label}</a>'
+            # The working text was escaped with quote=False (backtick/code
+            # spans must stay readable), so a ``"`` inside the target would
+            # terminate the href attribute — neutralize it here. Re-escaping
+            # wholesale would double-encode ``&amp;`` in legitimate URLs.
+            safe = target.replace('"', "&quot;")
+            return f'<a href="{safe}">{label}</a>'
         return match.group(0)  # refused target: the literal text, escaped
 
     return _INLINE_TOKEN_RE.sub(replace, escaped_text)

--- a/src/cairn/dashboard/shell.py
+++ b/src/cairn/dashboard/shell.py
@@ -3,20 +3,57 @@
 Everything every page shares lives here as pure functions over plain
 rows — no starlette imports, so importing this module never loads the
 server stack (the same guard the dashboard package is held to, pinned by
-test). :func:`selector_context` turns :func:`enumerate_stores
-<cairn.dashboard.workspaces.enumerate_stores>` rows (stat-only, never
-probed) into the topbar workspace selector's options; the label policy —
-basename of the registered workspace path, key fallback for orphan
-stores — is one function with one table-driven test.
+test). Two owners:
+
+- :func:`shell_context` is the single source of truth for NAVIGATION:
+  the sidebar renders from ``nav.sections`` and the command palette's
+  view list from ``palette.views`` — both derive from NAV_SECTIONS, so
+  the two can never drift apart, and hrefs are composed here with the
+  store param riding exactly like the sidebar's old hand-written anchors.
+- :func:`selector_context` turns :func:`enumerate_stores
+  <cairn.dashboard.workspaces.enumerate_stores>` rows (stat-only, never
+  probed) into the topbar workspace selector's options; the label policy
+  — basename of the registered workspace path, key fallback for orphan
+  stores — is one function with one table-driven test.
 """
 from __future__ import annotations
 
 from typing import List, Optional
+from urllib.parse import quote
 
 # The label shown for the no-selection option: the launch store the CLI
 # resolved (the dashboard process's own db), which the selector can always
 # return to.
 LAUNCH_LABEL = "Launch workspace"
+
+# Sidebar + palette view grouping. Order within a section is the display
+# order; the section list is the sidebar's top-to-bottom order. A None
+# label renders a standalone item group with no header — Workspaces leads
+# the nav ungrouped (FR-001's overview-first contract) above the scoped
+# groups. The Overview landing stays out — it is the brand link, not a
+# nav item.
+NAV_SECTIONS: tuple = (
+    (None, ("workspaces",)),
+    ("Explore", ("projects", "graph")),
+    ("Knowledge", ("wiki", "memory", "tasks")),
+    ("Activity", ("history", "tokens", "chains")),
+    ("System", ("health", "embeddings", "settings")),
+)
+
+NAV_LABELS: dict = {
+    "workspaces": "Workspaces",
+    "projects": "Projects",
+    "graph": "Graph",
+    "history": "History",
+    "tokens": "Tokens",
+    "chains": "Chains",
+    "health": "Health",
+    "memory": "Memory",
+    "wiki": "Wiki",
+    "tasks": "Tasks",
+    "embeddings": "Embeddings",
+    "settings": "Settings",
+}
 
 
 def workspace_label(path: Optional[str], key: str) -> str:
@@ -37,7 +74,12 @@ def selector_context(
     switch targets the same validated set resolve_selection serves), each
     as ``{key, label, path}`` with the registry path kept for the option's
     title tooltip; ``selected`` is the active key ("" = launch store)."""
-    options = [
+    options = _populated_options(stores)
+    return {"options": options, "selected": store_key, "launch_label": launch_label}
+
+
+def _populated_options(stores: List[dict]) -> List[dict]:
+    return [
         {
             "key": row["key"],
             "label": workspace_label(row.get("path"), row["key"]),
@@ -46,4 +88,44 @@ def selector_context(
         for row in stores
         if row.get("state") == "populated"
     ]
-    return {"options": options, "selected": store_key, "launch_label": launch_label}
+
+
+def shell_context(
+    stores: List[dict], store_key: str, path: str
+) -> dict:
+    """Everything base.html's chrome renders from, for one request.
+
+    ``nav.sections`` carries the grouped sidebar (each item's ``href``
+    already rides the selected store, matching the pre-shell anchors:
+    bare hrefs when nothing is selected); ``active`` flags derive from
+    the request path exactly as the old hand-written startswith checks
+    did. ``palette`` seeds the command palette: the same view list plus
+    the populated workspaces (the palette switches stores through the
+    same URL-rewrite behavior as the topbar selector).
+    """
+    nav_query = "?store=" + quote(store_key, safe="") if store_key else ""
+    sections: List[dict] = []
+    palette_views: List[dict] = []
+    for section_label, view_ids in NAV_SECTIONS:
+        items: List[dict] = []
+        for view_id in view_ids:
+            label = NAV_LABELS[view_id]
+            href = "/" + view_id + nav_query
+            items.append(
+                {
+                    "id": view_id,
+                    "label": label,
+                    "href": href,
+                    "active": path.startswith("/" + view_id),
+                }
+            )
+            palette_views.append({"label": label, "href": href})
+        sections.append({"label": section_label, "items": items})
+    return {
+        "selector": selector_context(stores, store_key),
+        "nav": {"sections": sections},
+        "palette": {
+            "views": palette_views,
+            "workspaces": _populated_options(stores),
+        },
+    }

--- a/src/cairn/dashboard/shell.py
+++ b/src/cairn/dashboard/shell.py
@@ -1,0 +1,49 @@
+"""Server-rendered context for the dashboard shell chrome (topbar, nav).
+
+Everything every page shares lives here as pure functions over plain
+rows — no starlette imports, so importing this module never loads the
+server stack (the same guard the dashboard package is held to, pinned by
+test). :func:`selector_context` turns :func:`enumerate_stores
+<cairn.dashboard.workspaces.enumerate_stores>` rows (stat-only, never
+probed) into the topbar workspace selector's options; the label policy —
+basename of the registered workspace path, key fallback for orphan
+stores — is one function with one table-driven test.
+"""
+from __future__ import annotations
+
+from typing import List, Optional
+
+# The label shown for the no-selection option: the launch store the CLI
+# resolved (the dashboard process's own db), which the selector can always
+# return to.
+LAUNCH_LABEL = "Launch workspace"
+
+
+def workspace_label(path: Optional[str], key: str) -> str:
+    """Human-readable selector label for one store row: the basename of
+    the registered workspace path, falling back to the 16-hex key for an
+    orphan store no registry entry points at."""
+    if path:
+        name = str(path).rstrip("/").rsplit("/", 1)[-1]
+        if name:
+            return name
+    return key
+
+
+def selector_context(
+    stores: List[dict], store_key: str, launch_label: str = LAUNCH_LABEL
+) -> dict:
+    """The topbar selector's render context: populated stores only (the
+    switch targets the same validated set resolve_selection serves), each
+    as ``{key, label, path}`` with the registry path kept for the option's
+    title tooltip; ``selected`` is the active key ("" = launch store)."""
+    options = [
+        {
+            "key": row["key"],
+            "label": workspace_label(row.get("path"), row["key"]),
+            "path": row.get("path") or "",
+        }
+        for row in stores
+        if row.get("state") == "populated"
+    ]
+    return {"options": options, "selected": store_key, "launch_label": launch_label}

--- a/src/cairn/dashboard/shell.py
+++ b/src/cairn/dashboard/shell.py
@@ -68,14 +68,17 @@ def workspace_label(path: Optional[str], key: str) -> str:
 
 
 def selector_context(
-    stores: List[dict], store_key: str, launch_label: str = LAUNCH_LABEL
+    stores: List[dict], store_key: str
 ) -> dict:
     """The topbar selector's render context: populated stores only (the
     switch targets the same validated set resolve_selection serves), each
     as ``{key, label, path}`` with the registry path kept for the option's
     title tooltip; ``selected`` is the active key ("" = launch store)."""
-    options = _populated_options(stores)
-    return {"options": options, "selected": store_key, "launch_label": launch_label}
+    return {
+        "options": _populated_options(stores),
+        "selected": store_key,
+        "launch_label": LAUNCH_LABEL,
+    }
 
 
 def _populated_options(stores: List[dict]) -> List[dict]:
@@ -104,6 +107,7 @@ def shell_context(
     same URL-rewrite behavior as the topbar selector).
     """
     nav_query = "?store=" + quote(store_key, safe="") if store_key else ""
+    options = _populated_options(stores)
     sections: List[dict] = []
     palette_views: List[dict] = []
     for section_label, view_ids in NAV_SECTIONS:
@@ -122,10 +126,11 @@ def shell_context(
             palette_views.append({"label": label, "href": href})
         sections.append({"label": section_label, "items": items})
     return {
-        "selector": selector_context(stores, store_key),
-        "nav": {"sections": sections},
-        "palette": {
-            "views": palette_views,
-            "workspaces": _populated_options(stores),
+        "selector": {
+            "options": options,
+            "selected": store_key,
+            "launch_label": LAUNCH_LABEL,
         },
+        "nav": {"sections": sections},
+        "palette": {"views": palette_views, "workspaces": options},
     }

--- a/src/cairn/dashboard/static/app.css
+++ b/src/cairn/dashboard/static/app.css
@@ -1,4 +1,6 @@
-/* Cairn dashboard — GitNexus-inspired design system.
+/* Cairn dashboard — "Terrain" design system: warm sandstone light mode,
+   deep ink-brown dark mode, one burnt-amber primary (a cairn is a trail
+   marker — the palette reads geological, not tech-corporate).
    Theme contract (pinned by tests/test_dashboard_theme.py — note that
    test locates blocks by first substring match, so keep selector
    spellings OUT of comments):
@@ -10,55 +12,57 @@
      system-color-scheme media query may appear in this file. */
 
 :root {
-  --bg: #eef1f6;
-  --surface: #ffffff;
-  --surface-2: #f4f6fa;
-  --sidebar: #f7f9fc;
-  --canvas: #fbfcfe;
-  --text: #182230;
-  --muted: #5f6d81;
-  --border: #dbe2ec;
-  --accent: #0d9488;
-  --accent-2: #7c5cf6;
-  --accent-contrast: #ffffff;
-  --accent-soft: rgba(13, 148, 136, 0.12);
-  --ok: #15803d;
-  --warn: #b45309;
+  --bg: #f5f2ec;
+  --surface: #fffdf9;
+  --surface-2: #f0ebe1;
+  --sidebar: #ece5d8;
+  --canvas: #faf8f3;
+  --text: #23201b;
+  --muted: #6f675a;
+  --border: #dcd2c0;
+  --accent: #b45309;
+  --accent-2: #4f46e5;
+  --accent-contrast: #fffdf9;
+  --accent-soft: rgba(180, 83, 9, 0.12);
+  --ok: #166534;
+  --warn: #a16207;
   --err: #b91c1c;
-  --shadow: rgba(23, 31, 46, 0.1);
+  --shadow: rgba(35, 32, 27, 0.12);
+  --backdrop: rgba(35, 32, 27, 0.32);
 }
 
 [data-theme="dark"] {
-  --bg: #0b0f16;
-  --surface: #131a26;
-  --surface-2: #18202e;
-  --sidebar: #0e131d;
-  --canvas: #0a0d13;
-  --text: #e6edf5;
-  --muted: #8d9aae;
-  --border: #232d3f;
-  --accent: #2dd4bf;
-  --accent-2: #a78bfa;
-  --accent-contrast: #04211d;
-  --accent-soft: rgba(45, 212, 191, 0.14);
-  --ok: #34d399;
-  --warn: #fbbf24;
+  --bg: #14110d;
+  --surface: #1c1813;
+  --surface-2: #241f18;
+  --sidebar: #171310;
+  --canvas: #100e0b;
+  --text: #ece7dd;
+  --muted: #a29885;
+  --border: #342c21;
+  --accent: #f59e0b;
+  --accent-2: #818cf8;
+  --accent-contrast: #1c1503;
+  --accent-soft: rgba(245, 158, 11, 0.14);
+  --ok: #4ade80;
+  --warn: #fde047;
   --err: #f87171;
-  --shadow: rgba(0, 0, 0, 0.45);
+  --shadow: rgba(0, 0, 0, 0.5);
+  --backdrop: rgba(0, 0, 0, 0.6);
   color-scheme: dark;
 }
 
 /* Theme-invariant design constants (NOT scanned by the theme test —
    keep them out of the first :root block above). */
 :root {
-  --radius-s: 6px;
-  --radius: 10px;
-  --radius-l: 14px;
+  --radius-s: 8px;
+  --radius: 12px;
+  --radius-l: 16px;
   --shadow-1: 0 1px 2px var(--shadow);
   --shadow-2: 0 12px 32px -16px var(--shadow);
   --shadow-3: 0 24px 64px -24px var(--shadow);
-  --sidebar-w: 220px;
-  --sidebar-w-collapsed: 58px;
+  --sidebar-w: 232px;
+  --sidebar-w-collapsed: 60px;
   --topbar-h: 56px;
   --font-mono: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
   --font-sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
@@ -67,6 +71,10 @@
 
 * {
   box-sizing: border-box;
+}
+
+html {
+  scroll-behavior: smooth;
 }
 
 body {
@@ -184,6 +192,7 @@ body.app-shell {
   color: var(--accent);
   background: var(--accent-soft);
   font-weight: 600;
+  box-shadow: inset 2px 0 0 var(--accent);
 }
 
 .side-nav a.active svg {
@@ -347,7 +356,7 @@ body.app-shell {
 .palette-backdrop {
   position: absolute;
   inset: 0;
-  background: rgba(0, 0, 0, 0.45);
+  background: var(--backdrop);
 }
 
 .palette-card {
@@ -454,14 +463,15 @@ body.app-shell {
   border: 1px solid var(--border);
   border-radius: var(--radius-l);
   box-shadow: var(--shadow-1);
-  padding: 1.4rem 1.6rem;
+  padding: 1.5rem 1.7rem;
   overflow-x: auto;
 }
 
 .panel h1 {
   margin: 0 0 0.6rem;
-  font-size: 1.4rem;
-  letter-spacing: -0.01em;
+  font-size: 1.5rem;
+  font-weight: 700;
+  letter-spacing: -0.02em;
 }
 
 .muted {
@@ -879,10 +889,12 @@ body.app-shell {
   font-size: 0.92rem;
 }
 
+/* Transparent header row with a strong rule under it — the header reads
+   as typography, not a filled strip. */
 .data-table th {
-  padding: 0.55rem 0.75rem;
-  border-bottom: 1px solid var(--border);
-  background: var(--surface-2);
+  padding: 0.5rem 0.75rem;
+  border-bottom: 2px solid color-mix(in srgb, var(--text) 16%, transparent);
+  background: none;
   text-align: left;
   font-size: 0.72rem;
   font-weight: 600;
@@ -894,7 +906,7 @@ body.app-shell {
 
 .data-table td {
   padding: 0.55rem 0.75rem;
-  border-bottom: 1px solid var(--border);
+  border-bottom: 1px solid color-mix(in srgb, var(--border) 55%, transparent);
   vertical-align: top;
 }
 
@@ -914,6 +926,7 @@ code {
   border: 1px solid var(--border);
   border-radius: var(--radius-s);
   background: var(--canvas);
+  font-family: var(--font-mono);
   font-size: 0.84em;
   word-break: break-all;
 }
@@ -1203,6 +1216,178 @@ code {
   }
 }
 
+/* ---- Wiki: catalog, article prose, and page navigation ---- */
+
+.wiki-controls {
+  margin-bottom: 0.4rem;
+}
+
+.wiki-state-filter {
+  margin: 0.45rem 0 0.2rem;
+}
+
+.wiki-repo-heading {
+  margin: 1.7rem 0 0.55rem;
+  padding-bottom: 0.35rem;
+  border-bottom: 1px solid var(--border);
+  font-size: 1.02rem;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+}
+
+.wiki-repo-heading .muted {
+  font-weight: 400;
+  font-size: 0.82rem;
+}
+
+.wiki-breadcrumb {
+  margin-bottom: 0.5rem;
+  font-size: 0.82rem;
+  color: var(--muted);
+}
+
+.wiki-breadcrumb a {
+  color: var(--muted);
+  text-decoration: none;
+}
+
+.wiki-breadcrumb a:hover,
+.wiki-breadcrumb a:focus {
+  color: var(--accent);
+}
+
+/* Article + TOC rail; the rail docks beside the article on wide screens
+   and stacks below it (hidden from the flow, simply full-width) below
+   1100px. */
+.wiki-layout {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  gap: 1.6rem;
+  align-items: start;
+}
+
+@media (min-width: 1100px) {
+  .wiki-layout {
+    grid-template-columns: minmax(0, 1fr) 210px;
+  }
+
+  .wiki-toc {
+    position: sticky;
+    top: calc(var(--topbar-h) + 1.25rem);
+  }
+}
+
+.wiki-body {
+  max-width: 46rem;
+  line-height: 1.68;
+}
+
+.wiki-body h2 {
+  margin-top: 1.9rem;
+  padding-top: 0.9rem;
+  border-top: 1px solid var(--border);
+}
+
+.wiki-body h2:first-child {
+  margin-top: 0;
+  padding-top: 0;
+  border-top: 0;
+}
+
+.wiki-body pre {
+  overflow-x: auto;
+}
+
+.wiki-body pre.mermaid {
+  display: flex;
+  justify-content: center;
+  padding: 0.9rem;
+  background: var(--canvas);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+}
+
+.wiki-body table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.9rem;
+}
+
+.wiki-body th,
+.wiki-body td {
+  padding: 0.4rem 0.6rem;
+  border-bottom: 1px solid color-mix(in srgb, var(--border) 55%, transparent);
+  text-align: left;
+}
+
+.wiki-body th {
+  font-size: 0.72rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  color: var(--muted);
+}
+
+/* Backtick refs that link into the graph: the code chip is the anchor —
+   intent (hover/focus) tints it, no underline to fight the chip border. */
+a.code-ref {
+  text-decoration: none;
+}
+
+a.code-ref:hover code,
+a.code-ref:focus code {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+.wiki-toc {
+  padding: 0.85rem 0.95rem;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--surface-2);
+  font-size: 0.82rem;
+}
+
+.wiki-toc-label {
+  margin-bottom: 0.45rem;
+  font-size: 0.68rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--muted);
+}
+
+.wiki-toc ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.wiki-toc li {
+  margin: 0.2rem 0;
+}
+
+.wiki-toc-l3 {
+  padding-left: 0.75rem;
+}
+
+.wiki-toc a {
+  color: var(--muted);
+  text-decoration: none;
+}
+
+.wiki-toc a:hover,
+.wiki-toc a:focus {
+  color: var(--accent);
+}
+
+.wiki-pager {
+  margin-top: 1.9rem;
+  padding-top: 0.85rem;
+  border-top: 1px solid var(--border);
+  font-size: 0.9rem;
+}
+
 /* ---- Symbol-search typeahead dropdown ---- */
 .suggest-wrap {
   position: relative;
@@ -1221,7 +1406,7 @@ code {
   background: var(--surface);
   border: 1px solid var(--border);
   border-radius: 10px;
-  box-shadow: 0 12px 32px rgba(15, 23, 42, 0.18);
+  box-shadow: var(--shadow-2);
   padding: 4px 0;
 }
 

--- a/src/cairn/dashboard/static/app.css
+++ b/src/cairn/dashboard/static/app.css
@@ -206,6 +206,44 @@ body.app-shell {
   color: var(--muted);
 }
 
+/* ---- Topbar actions: workspace selector + live chrome ---- */
+
+.topbar-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.9rem;
+  margin-left: auto;
+}
+
+.store-picker select {
+  max-width: 260px;
+  padding: 0.34rem 0.6rem;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-s);
+  background: var(--surface);
+  color: var(--text);
+  font: inherit;
+  font-size: 0.85rem;
+  cursor: pointer;
+}
+
+.store-picker select:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 1px;
+}
+
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 .site-main {
   width: 100%;
   max-width: 1280px;
@@ -277,7 +315,6 @@ body.app-shell {
 #live-controls {
   align-items: center;
   gap: 0.6rem;
-  margin-left: auto;
   font-size: 0.85rem;
 }
 

--- a/src/cairn/dashboard/static/app.css
+++ b/src/cairn/dashboard/static/app.css
@@ -56,8 +56,11 @@
   --radius-l: 14px;
   --shadow-1: 0 1px 2px var(--shadow);
   --shadow-2: 0 12px 32px -16px var(--shadow);
+  --shadow-3: 0 24px 64px -24px var(--shadow);
   --sidebar-w: 220px;
+  --sidebar-w-collapsed: 58px;
   --topbar-h: 56px;
+  --font-mono: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
   --font-sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
     "Helvetica Neue", Arial, sans-serif;
 }
@@ -137,6 +140,23 @@ body.app-shell {
   gap: 0.15rem;
 }
 
+.nav-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+  margin-top: 0.85rem;
+}
+
+.nav-group-label {
+  padding: 0 0.65rem 0.1rem;
+  font-size: 0.66rem;
+  font-weight: 600;
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+  color: var(--muted);
+  opacity: 0.75;
+}
+
 .side-nav a {
   display: flex;
   align-items: center;
@@ -174,6 +194,59 @@ body.app-shell {
   margin-top: auto;
   padding-top: 0.75rem;
   border-top: 1px solid var(--border);
+  display: flex;
+  gap: 0.4rem;
+}
+
+.sidebar-collapse {
+  flex: none;
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+  padding: 0.42rem 0.65rem;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-s);
+  background: transparent;
+  color: var(--muted);
+  font: inherit;
+  font-size: 0.9rem;
+  cursor: pointer;
+  transition: background 120ms ease, color 120ms ease;
+}
+
+.sidebar-collapse:hover,
+.sidebar-collapse:focus {
+  color: var(--text);
+  background: var(--accent-soft);
+}
+
+/* Collapsed rail (desktop only — the ≤920px sidebar is a horizontal
+   bar where collapse does not apply): icon rail, labels and group
+   headers hidden, chevron flips. */
+@media (min-width: 921px) {
+  html[data-sidebar="collapsed"] body.app-shell {
+    grid-template-columns: var(--sidebar-w-collapsed) minmax(0, 1fr);
+  }
+
+  html[data-sidebar="collapsed"] .brand span,
+  html[data-sidebar="collapsed"] .nav-group-label,
+  html[data-sidebar="collapsed"] .side-nav a span,
+  html[data-sidebar="collapsed"] .sidebar-collapse span,
+  html[data-sidebar="collapsed"] .theme-toggle {
+    display: none;
+  }
+
+  html[data-sidebar="collapsed"] .side-nav a,
+  html[data-sidebar="collapsed"] .brand,
+  html[data-sidebar="collapsed"] .sidebar-collapse {
+    justify-content: center;
+    padding-left: 0;
+    padding-right: 0;
+  }
+
+  html[data-sidebar="collapsed"] .sidebar-collapse svg {
+    transform: rotate(180deg);
+  }
 }
 
 .app-body {
@@ -232,6 +305,129 @@ body.app-shell {
   outline-offset: 1px;
 }
 
+/* ---- Command palette ---- */
+
+.palette-open {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.36rem 0.65rem;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-s);
+  background: var(--surface);
+  color: var(--muted);
+  font: inherit;
+  font-size: 0.85rem;
+  cursor: pointer;
+  transition: background 120ms ease, color 120ms ease;
+}
+
+.palette-open:hover,
+.palette-open:focus {
+  color: var(--text);
+  background: var(--accent-soft);
+}
+
+.palette-open kbd {
+  padding: 0.05rem 0.35rem;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  background: var(--surface-2);
+  font-family: var(--font-mono);
+  font-size: 0.68rem;
+  color: var(--muted);
+}
+
+.palette {
+  position: fixed;
+  inset: 0;
+  z-index: 100;
+}
+
+.palette-backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.45);
+}
+
+.palette-card {
+  position: relative;
+  max-width: 560px;
+  margin: 12vh auto 0;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-l);
+  box-shadow: var(--shadow-3);
+  overflow: hidden;
+}
+
+.palette-card input {
+  width: 100%;
+  padding: 0.85rem 1rem;
+  border: none;
+  border-bottom: 1px solid var(--border);
+  background: transparent;
+  color: var(--text);
+  font: inherit;
+  font-size: 0.95rem;
+}
+
+.palette-card input:focus {
+  outline: none;
+}
+
+.palette-card ul {
+  max-height: 46vh;
+  margin: 0;
+  padding: 0.35rem;
+  list-style: none;
+  overflow-y: auto;
+}
+
+.palette-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 0.5rem 0.7rem;
+  border-radius: var(--radius-s);
+  cursor: pointer;
+}
+
+.palette-row.active {
+  background: var(--accent-soft);
+  box-shadow: inset 2px 0 0 var(--accent);
+}
+
+.palette-row-label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.palette-row-hint {
+  flex: none;
+  max-width: 45%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--muted);
+  font-size: 0.78rem;
+}
+
+.palette-row-empty {
+  justify-content: center;
+  cursor: default;
+  color: var(--muted);
+}
+
+.palette-hint {
+  margin: 0;
+  padding: 0.5rem 1rem;
+  border-top: 1px solid var(--border);
+  font-size: 0.75rem;
+}
+
 .visually-hidden {
   position: absolute;
   width: 1px;
@@ -284,7 +480,7 @@ body.app-shell {
 /* ---- Theme toggle ---- */
 
 .theme-toggle {
-  width: 100%;
+  flex: 1;
   padding: 0.42rem 0.65rem;
   border: 1px solid var(--border);
   border-radius: var(--radius-s);

--- a/src/cairn/dashboard/static/shell.js
+++ b/src/cairn/dashboard/static/shell.js
@@ -1,0 +1,29 @@
+/* Cairn dashboard shell chrome: the behaviors every page shares — the
+   topbar workspace selector today, sidebar collapse and the command
+   palette alongside. app.js (the per-view graph/live-refresh logic) is a
+   separate file with separate element ids; the two never touch. */
+(function () {
+  "use strict";
+  var select = document.getElementById("store-select");
+  if (!select) {
+    return;
+  }
+  select.addEventListener("change", function () {
+    var key = select.value;
+    var url = new URL(window.location.href);
+    if (key) {
+      url.searchParams.set("store", key);
+    } else {
+      /* Back to the launch store: a bare URL the stickiness script would
+         redirect right back to the remembered store — clear the memory
+         so the launch store is what loads. */
+      url.searchParams.delete("store");
+      try {
+        window.localStorage.removeItem("cairn-store");
+      } catch (err) {
+        /* storage unavailable: the selection stays URL-only */
+      }
+    }
+    window.location.assign(url.pathname + url.search + url.hash);
+  });
+})();

--- a/src/cairn/dashboard/static/shell.js
+++ b/src/cairn/dashboard/static/shell.js
@@ -1,113 +1,17 @@
 /* Cairn dashboard shell chrome: the behaviors every page shares — the
    topbar workspace selector, the sidebar collapse, and the command
    palette. app.js (the per-view graph/live-refresh logic) is a separate
-   file with separate element ids; the two never touch. */
-
-/* Workspace selector: switching rewrites the ?store= param on the
-   current URL and reloads, so the tab stays and every view re-renders on
-   the selected workspace. */
+   file with separate element ids; the two never touch.
+   One outer IIFE keeps every helper file-local. */
 (function () {
   "use strict";
-  var select = document.getElementById("store-select");
-  if (!select) {
-    return;
-  }
-  select.addEventListener("change", function () {
-    var key = select.value;
-    var url = new URL(window.location.href);
-    if (key) {
-      url.searchParams.set("store", key);
-    } else {
-      /* Back to the launch store: a bare URL the stickiness script would
-         redirect right back to the remembered store — clear the memory
-         so the launch store is what loads. */
-      url.searchParams.delete("store");
-      try {
-        window.localStorage.removeItem("cairn-store");
-      } catch (err) {
-        /* storage unavailable: the selection stays URL-only */
-      }
-    }
-    window.location.assign(url.pathname + url.search + url.hash);
-  });
-})();
 
-/* Sidebar collapse: the state persists (localStorage "cairn-sidebar")
-   and base.html's head script re-applies it pre-paint on the next load. */
-(function () {
-  "use strict";
-  var button = document.getElementById("sidebar-collapse");
-  if (!button) {
-    return;
-  }
-  button.addEventListener("click", function () {
-    var root = document.documentElement;
-    var collapsing = root.getAttribute("data-sidebar") !== "collapsed";
-    if (collapsing) {
-      root.setAttribute("data-sidebar", "collapsed");
-    } else {
-      root.removeAttribute("data-sidebar");
-    }
-    try {
-      window.localStorage.setItem(
-        "cairn-sidebar",
-        collapsing ? "collapsed" : "expanded"
-      );
-    } catch (err) {
-      /* storage unavailable: the choice lasts only for this page */
-    }
-    button.setAttribute(
-      "aria-label",
-      collapsing ? "Expand sidebar" : "Collapse sidebar"
-    );
-  });
-})();
-
-/* Command palette (Ctrl/Cmd+K): views and workspaces from the
-   server-rendered seed (store-carrying hrefs), symbols live from
-   /graph/suggest on the current store — the same endpoint and guarded
-   store param the graph typeahead uses. */
-(function () {
-  "use strict";
-  var overlay = document.getElementById("palette");
-  var input = document.getElementById("palette-input");
-  var list = document.getElementById("palette-list");
-  var openButton = document.getElementById("palette-open");
-  var dataEl = document.getElementById("palette-data");
-  if (!overlay || !input || !list || !dataEl) {
-    return;
-  }
-
-  var views = [];
-  var workspaces = [];
-  try {
-    var seed = JSON.parse(dataEl.textContent || "{}");
-    views = seed.views || [];
-    workspaces = seed.workspaces || [];
-  } catch (err) {
-    /* unparsable seed: views/workspaces stay empty; symbols still work */
-  }
-
-  var rows = []; // {label, hint, action}
-  var active = -1;
-  var seq = 0; // symbol-fetch sequence: stale responses never render
-  var timer = null;
-  var lastFocus = null;
-
-  // Platform-correct kbd hint (cosmetic; both modifiers always work).
-  var kbd = document.getElementById("palette-kbd");
-  if (kbd && /Mac/i.test(navigator.platform || "")) {
-    kbd.textContent = "\u2318K";
-  }
-
-  function isOpen() {
-    return !overlay.hidden;
-  }
-
-  function currentStore() {
-    return new URL(window.location.href).searchParams.get("store") || "";
-  }
-
+  /* Switch the global workspace: rewrite the ?store= param on the
+     current URL and reload — the tab stays and every view re-renders on
+     the selected workspace (FR-003's seam stays the URL param). Back to
+     the launch store (empty key) navigates bare, and clearing the
+     remembered key matters: the head stickiness script would otherwise
+     redirect the bare URL right back to the old store. */
   function switchStore(key) {
     var url = new URL(window.location.href);
     if (key) {
@@ -123,200 +27,291 @@
     window.location.assign(url.pathname + url.search + url.hash);
   }
 
-  function symbolHref(name) {
-    var store = currentStore();
-    return (
-      "/graph?scope=symbol&focus=" + encodeURIComponent(name) +
-      (store ? "&store=" + encodeURIComponent(store) : "")
-    );
-  }
-
-  function renderRows() {
-    list.textContent = "";
-    if (!rows.length) {
-      var empty = document.createElement("li");
-      empty.className = "palette-row palette-row-empty";
-      empty.textContent = "no matches";
-      list.appendChild(empty);
-      list.removeAttribute("aria-activedescendant");
+  /* ---- Workspace selector (topbar) ---- */
+  (function () {
+    var select = document.getElementById("store-select");
+    if (!select) {
       return;
     }
-    rows.forEach(function (row, i) {
-      var li = document.createElement("li");
-      li.id = "palette-row-" + i;
-      li.className = "palette-row" + (i === active ? " active" : "");
-      li.setAttribute("role", "option");
-      li.setAttribute("aria-selected", i === active ? "true" : "false");
-      var label = document.createElement("span");
-      label.className = "palette-row-label";
-      label.textContent = row.label;
-      li.appendChild(label);
-      if (row.hint) {
-        var hint = document.createElement("span");
-        hint.className = "palette-row-hint";
-        hint.textContent = row.hint;
-        li.appendChild(hint);
-      }
-      li.addEventListener("click", function () {
-        row.action();
-      });
-      list.appendChild(li);
+    select.addEventListener("change", function () {
+      switchStore(select.value);
     });
-    list.setAttribute(
-      "aria-activedescendant",
-      active >= 0 ? "palette-row-" + active : ""
-    );
-    var current = document.getElementById("palette-row-" + active);
-    if (current && current.scrollIntoView) {
-      current.scrollIntoView({ block: "nearest" });
-    }
-  }
+  })();
 
-  function fetchSymbols(query) {
-    var mySeq = seq;
-    if (timer) {
-      clearTimeout(timer);
+  /* ---- Sidebar collapse ----
+     The state persists (localStorage "cairn-sidebar") and base.html's
+     head script re-applies it pre-paint on the next load. */
+  (function () {
+    var button = document.getElementById("sidebar-collapse");
+    if (!button) {
+      return;
     }
-    timer = setTimeout(function () {
-      var url = "/graph/suggest?name=" + encodeURIComponent(query);
-      var store = currentStore();
-      if (store) {
-        url += "&store=" + encodeURIComponent(store);
-      }
-      fetch(url)
-        .then(function (resp) {
-          return resp.json();
-        })
-        .then(function (data) {
-          if (mySeq !== seq) {
-            return; // a newer keystroke owns the list now
-          }
-          var matches = (data && data.matches) || [];
-          matches.slice(0, 8).forEach(function (m) {
-            rows.push({
-              label: m.name,
-              hint: m.kind + (m.file ? " — " + m.file : ""),
-              action: function () {
-                window.location.assign(symbolHref(m.name));
-              },
-            });
-          });
-          if (data && data.truncated) {
-            rows.push({
-              label: "more matches…",
-              hint: "keep typing to narrow",
-              action: function () {},
-            });
-          }
-          if (active < 0 && rows.length) {
-            active = 0;
-          }
-          renderRows();
-        })
-        .catch(function () {
-          /* fetch failed: views/workspaces still listed */
-        });
-    }, 160);
-  }
-
-  function refresh(query) {
-    seq += 1; // any in-flight symbol response is stale now
-    rows = [];
-    var q = (query || "").toLowerCase();
-    views.forEach(function (v) {
-      if (!q || v.label.toLowerCase().indexOf(q) !== -1) {
-        rows.push({
-          label: v.label,
-          hint: "view",
-          action: function () {
-            window.location.assign(v.href);
-          },
-        });
-      }
-    });
-    workspaces.forEach(function (w) {
-      if (!q || (w.label || "").toLowerCase().indexOf(q) !== -1) {
-        rows.push({
-          label: w.label,
-          hint: "workspace",
-          action: function () {
-            switchStore(w.key);
-          },
-        });
-      }
-    });
-    active = rows.length ? 0 : -1;
-    renderRows();
-    if (q.length >= 2) {
-      fetchSymbols(query);
-    }
-  }
-
-  function open() {
-    lastFocus = document.activeElement;
-    overlay.hidden = false;
-    input.value = "";
-    refresh("");
-    input.focus();
-  }
-
-  function close() {
-    overlay.hidden = true;
-    seq += 1;
-    if (timer) {
-      clearTimeout(timer);
-      timer = null;
-    }
-    if (lastFocus && lastFocus.focus) {
-      lastFocus.focus();
-    }
-  }
-
-  if (openButton) {
-    openButton.addEventListener("click", open);
-  }
-  overlay.addEventListener("click", function (event) {
-    var target = event.target;
-    if (target && target.getAttribute && target.getAttribute("data-palette-close") !== null) {
-      close();
-    }
-  });
-  input.addEventListener("input", function () {
-    refresh(input.value);
-  });
-  input.addEventListener("keydown", function (event) {
-    var key = event.key || "";
-    if (key === "ArrowDown") {
-      event.preventDefault();
-      if (rows.length) {
-        active = (active + 1) % rows.length;
-        renderRows();
-      }
-    } else if (key === "ArrowUp") {
-      event.preventDefault();
-      if (rows.length) {
-        active = (active - 1 + rows.length) % rows.length;
-      }
-      renderRows();
-    } else if (key === "Enter") {
-      event.preventDefault();
-      if (active >= 0 && rows[active]) {
-        rows[active].action();
-      }
-    }
-  });
-  document.addEventListener("keydown", function (event) {
-    var key = event.key || "";
-    if ((event.metaKey || event.ctrlKey) && (key === "k" || key === "K")) {
-      event.preventDefault();
-      if (isOpen()) {
-        close();
+    button.addEventListener("click", function () {
+      var root = document.documentElement;
+      var collapsing = root.getAttribute("data-sidebar") !== "collapsed";
+      if (collapsing) {
+        root.setAttribute("data-sidebar", "collapsed");
       } else {
-        open();
+        root.removeAttribute("data-sidebar");
       }
-    } else if (key === "Escape" && isOpen()) {
-      event.preventDefault();
-      close();
+      try {
+        window.localStorage.setItem(
+          "cairn-sidebar",
+          collapsing ? "collapsed" : "expanded"
+        );
+      } catch (err) {
+        /* storage unavailable: the choice lasts only for this page */
+      }
+      button.setAttribute(
+        "aria-label",
+        collapsing ? "Expand sidebar" : "Collapse sidebar"
+      );
+    });
+  })();
+
+  /* ---- Command palette (Ctrl/Cmd+K) ----
+     Views and workspaces come from the server-rendered seed
+     (store-carrying hrefs); symbols arrive live from /graph/suggest on
+     the current store — the same endpoint and guarded store param the
+     graph typeahead uses. */
+  (function () {
+    var overlay = document.getElementById("palette");
+    var input = document.getElementById("palette-input");
+    var list = document.getElementById("palette-list");
+    var openButton = document.getElementById("palette-open");
+    var dataEl = document.getElementById("palette-data");
+    if (!overlay || !input || !list || !dataEl) {
+      return;
     }
-  });
+
+    var views = [];
+    var workspaces = [];
+    try {
+      var seed = JSON.parse(dataEl.textContent || "{}");
+      views = seed.views || [];
+      workspaces = seed.workspaces || [];
+    } catch (err) {
+      /* unparsable seed: views/workspaces stay empty; symbols still work */
+    }
+
+    var rows = []; // {label, hint, action}
+    var active = -1;
+    var seq = 0; // symbol-fetch sequence: stale responses never render
+    var timer = null;
+    var lastFocus = null;
+
+    // Platform-correct kbd hint (cosmetic; both modifiers always work).
+    var kbd = document.getElementById("palette-kbd");
+    if (kbd && /Mac/i.test(navigator.platform || "")) {
+      kbd.textContent = "\u2318K";
+    }
+
+    function isOpen() {
+      return !overlay.hidden;
+    }
+
+    function currentStore() {
+      return new URL(window.location.href).searchParams.get("store") || "";
+    }
+
+    function symbolHref(name) {
+      var store = currentStore();
+      return (
+        "/graph?scope=symbol&focus=" + encodeURIComponent(name) +
+        (store ? "&store=" + encodeURIComponent(store) : "")
+      );
+    }
+
+    function renderRows() {
+      list.textContent = "";
+      if (!rows.length) {
+        var empty = document.createElement("li");
+        empty.className = "palette-row palette-row-empty";
+        empty.textContent = "no matches";
+        list.appendChild(empty);
+        list.removeAttribute("aria-activedescendant");
+        return;
+      }
+      rows.forEach(function (row, i) {
+        var li = document.createElement("li");
+        li.id = "palette-row-" + i;
+        li.className = "palette-row" + (i === active ? " active" : "");
+        li.setAttribute("role", "option");
+        li.setAttribute("aria-selected", i === active ? "true" : "false");
+        var label = document.createElement("span");
+        label.className = "palette-row-label";
+        label.textContent = row.label;
+        li.appendChild(label);
+        if (row.hint) {
+          var hint = document.createElement("span");
+          hint.className = "palette-row-hint";
+          hint.textContent = row.hint;
+          li.appendChild(hint);
+        }
+        li.addEventListener("click", function () {
+          row.action();
+        });
+        list.appendChild(li);
+      });
+      list.setAttribute(
+        "aria-activedescendant",
+        active >= 0 ? "palette-row-" + active : ""
+      );
+      var current = document.getElementById("palette-row-" + active);
+      if (current && current.scrollIntoView) {
+        current.scrollIntoView({ block: "nearest" });
+      }
+    }
+
+    function fetchSymbols(query) {
+      var mySeq = seq;
+      if (timer) {
+        clearTimeout(timer);
+      }
+      timer = setTimeout(function () {
+        var url = "/graph/suggest?name=" + encodeURIComponent(query);
+        var store = currentStore();
+        if (store) {
+          url += "&store=" + encodeURIComponent(store);
+        }
+        fetch(url)
+          .then(function (resp) {
+            if (!resp.ok) {
+              throw new Error("suggest fetch failed");
+            }
+            return resp.json();
+          })
+          .then(function (data) {
+            if (mySeq !== seq) {
+              return; // a newer keystroke owns the list now
+            }
+            var matches = (data && data.matches) || [];
+            matches.slice(0, 8).forEach(function (m) {
+              rows.push({
+                label: m.name,
+                hint: m.kind + (m.file ? " — " + m.file : ""),
+                action: function () {
+                  window.location.assign(symbolHref(m.name));
+                },
+              });
+            });
+            if (data && data.truncated) {
+              rows.push({
+                label: "more matches…",
+                hint: "keep typing to narrow",
+                action: function () {},
+              });
+            }
+            if (active < 0 && rows.length) {
+              active = 0;
+            }
+            renderRows();
+          })
+          .catch(function () {
+            /* fetch failed: views/workspaces still listed */
+          });
+      }, 160);
+    }
+
+    function refresh(query) {
+      seq += 1; // any in-flight symbol response is stale now
+      rows = [];
+      var q = (query || "").toLowerCase();
+      views.forEach(function (v) {
+        if (!q || v.label.toLowerCase().indexOf(q) !== -1) {
+          rows.push({
+            label: v.label,
+            hint: "view",
+            action: function () {
+              window.location.assign(v.href);
+            },
+          });
+        }
+      });
+      workspaces.forEach(function (w) {
+        if (!q || (w.label || "").toLowerCase().indexOf(q) !== -1) {
+          rows.push({
+            label: w.label,
+            hint: "workspace",
+            action: function () {
+              switchStore(w.key);
+            },
+          });
+        }
+      });
+      active = rows.length ? 0 : -1;
+      renderRows();
+      if (q.length >= 2) {
+        fetchSymbols(query);
+      }
+    }
+
+    function open() {
+      lastFocus = document.activeElement;
+      overlay.hidden = false;
+      input.value = "";
+      refresh("");
+      input.focus();
+    }
+
+    function close() {
+      overlay.hidden = true;
+      seq += 1;
+      if (timer) {
+        clearTimeout(timer);
+        timer = null;
+      }
+      if (lastFocus && lastFocus.focus) {
+        lastFocus.focus();
+      }
+    }
+
+    if (openButton) {
+      openButton.addEventListener("click", open);
+    }
+    overlay.addEventListener("click", function (event) {
+      var target = event.target;
+      if (target && target.getAttribute && target.getAttribute("data-palette-close") !== null) {
+        close();
+      }
+    });
+    input.addEventListener("input", function () {
+      refresh(input.value);
+    });
+    input.addEventListener("keydown", function (event) {
+      var key = event.key || "";
+      if (key === "ArrowDown") {
+        event.preventDefault();
+        if (rows.length) {
+          active = (active + 1) % rows.length;
+          renderRows();
+        }
+      } else if (key === "ArrowUp") {
+        event.preventDefault();
+        if (rows.length) {
+          active = (active - 1 + rows.length) % rows.length;
+        }
+        renderRows();
+      } else if (key === "Enter") {
+        event.preventDefault();
+        if (active >= 0 && rows[active]) {
+          rows[active].action();
+        }
+      }
+    });
+    document.addEventListener("keydown", function (event) {
+      var key = event.key || "";
+      if ((event.metaKey || event.ctrlKey) && (key === "k" || key === "K")) {
+        event.preventDefault();
+        if (isOpen()) {
+          close();
+        } else {
+          open();
+        }
+      } else if (key === "Escape" && isOpen()) {
+        event.preventDefault();
+        close();
+      }
+    });
+  })();
 })();

--- a/src/cairn/dashboard/static/shell.js
+++ b/src/cairn/dashboard/static/shell.js
@@ -1,7 +1,11 @@
 /* Cairn dashboard shell chrome: the behaviors every page shares — the
-   topbar workspace selector today, sidebar collapse and the command
-   palette alongside. app.js (the per-view graph/live-refresh logic) is a
-   separate file with separate element ids; the two never touch. */
+   topbar workspace selector, the sidebar collapse, and the command
+   palette. app.js (the per-view graph/live-refresh logic) is a separate
+   file with separate element ids; the two never touch. */
+
+/* Workspace selector: switching rewrites the ?store= param on the
+   current URL and reloads, so the tab stays and every view re-renders on
+   the selected workspace. */
 (function () {
   "use strict";
   var select = document.getElementById("store-select");
@@ -25,5 +29,294 @@
       }
     }
     window.location.assign(url.pathname + url.search + url.hash);
+  });
+})();
+
+/* Sidebar collapse: the state persists (localStorage "cairn-sidebar")
+   and base.html's head script re-applies it pre-paint on the next load. */
+(function () {
+  "use strict";
+  var button = document.getElementById("sidebar-collapse");
+  if (!button) {
+    return;
+  }
+  button.addEventListener("click", function () {
+    var root = document.documentElement;
+    var collapsing = root.getAttribute("data-sidebar") !== "collapsed";
+    if (collapsing) {
+      root.setAttribute("data-sidebar", "collapsed");
+    } else {
+      root.removeAttribute("data-sidebar");
+    }
+    try {
+      window.localStorage.setItem(
+        "cairn-sidebar",
+        collapsing ? "collapsed" : "expanded"
+      );
+    } catch (err) {
+      /* storage unavailable: the choice lasts only for this page */
+    }
+    button.setAttribute(
+      "aria-label",
+      collapsing ? "Expand sidebar" : "Collapse sidebar"
+    );
+  });
+})();
+
+/* Command palette (Ctrl/Cmd+K): views and workspaces from the
+   server-rendered seed (store-carrying hrefs), symbols live from
+   /graph/suggest on the current store — the same endpoint and guarded
+   store param the graph typeahead uses. */
+(function () {
+  "use strict";
+  var overlay = document.getElementById("palette");
+  var input = document.getElementById("palette-input");
+  var list = document.getElementById("palette-list");
+  var openButton = document.getElementById("palette-open");
+  var dataEl = document.getElementById("palette-data");
+  if (!overlay || !input || !list || !dataEl) {
+    return;
+  }
+
+  var views = [];
+  var workspaces = [];
+  try {
+    var seed = JSON.parse(dataEl.textContent || "{}");
+    views = seed.views || [];
+    workspaces = seed.workspaces || [];
+  } catch (err) {
+    /* unparsable seed: views/workspaces stay empty; symbols still work */
+  }
+
+  var rows = []; // {label, hint, action}
+  var active = -1;
+  var seq = 0; // symbol-fetch sequence: stale responses never render
+  var timer = null;
+  var lastFocus = null;
+
+  // Platform-correct kbd hint (cosmetic; both modifiers always work).
+  var kbd = document.getElementById("palette-kbd");
+  if (kbd && /Mac/i.test(navigator.platform || "")) {
+    kbd.textContent = "\u2318K";
+  }
+
+  function isOpen() {
+    return !overlay.hidden;
+  }
+
+  function currentStore() {
+    return new URL(window.location.href).searchParams.get("store") || "";
+  }
+
+  function switchStore(key) {
+    var url = new URL(window.location.href);
+    if (key) {
+      url.searchParams.set("store", key);
+    } else {
+      url.searchParams.delete("store");
+      try {
+        window.localStorage.removeItem("cairn-store");
+      } catch (err) {
+        /* storage unavailable: the selection stays URL-only */
+      }
+    }
+    window.location.assign(url.pathname + url.search + url.hash);
+  }
+
+  function symbolHref(name) {
+    var store = currentStore();
+    return (
+      "/graph?scope=symbol&focus=" + encodeURIComponent(name) +
+      (store ? "&store=" + encodeURIComponent(store) : "")
+    );
+  }
+
+  function renderRows() {
+    list.textContent = "";
+    if (!rows.length) {
+      var empty = document.createElement("li");
+      empty.className = "palette-row palette-row-empty";
+      empty.textContent = "no matches";
+      list.appendChild(empty);
+      list.removeAttribute("aria-activedescendant");
+      return;
+    }
+    rows.forEach(function (row, i) {
+      var li = document.createElement("li");
+      li.id = "palette-row-" + i;
+      li.className = "palette-row" + (i === active ? " active" : "");
+      li.setAttribute("role", "option");
+      li.setAttribute("aria-selected", i === active ? "true" : "false");
+      var label = document.createElement("span");
+      label.className = "palette-row-label";
+      label.textContent = row.label;
+      li.appendChild(label);
+      if (row.hint) {
+        var hint = document.createElement("span");
+        hint.className = "palette-row-hint";
+        hint.textContent = row.hint;
+        li.appendChild(hint);
+      }
+      li.addEventListener("click", function () {
+        row.action();
+      });
+      list.appendChild(li);
+    });
+    list.setAttribute(
+      "aria-activedescendant",
+      active >= 0 ? "palette-row-" + active : ""
+    );
+    var current = document.getElementById("palette-row-" + active);
+    if (current && current.scrollIntoView) {
+      current.scrollIntoView({ block: "nearest" });
+    }
+  }
+
+  function fetchSymbols(query) {
+    var mySeq = seq;
+    if (timer) {
+      clearTimeout(timer);
+    }
+    timer = setTimeout(function () {
+      var url = "/graph/suggest?name=" + encodeURIComponent(query);
+      var store = currentStore();
+      if (store) {
+        url += "&store=" + encodeURIComponent(store);
+      }
+      fetch(url)
+        .then(function (resp) {
+          return resp.json();
+        })
+        .then(function (data) {
+          if (mySeq !== seq) {
+            return; // a newer keystroke owns the list now
+          }
+          var matches = (data && data.matches) || [];
+          matches.slice(0, 8).forEach(function (m) {
+            rows.push({
+              label: m.name,
+              hint: m.kind + (m.file ? " — " + m.file : ""),
+              action: function () {
+                window.location.assign(symbolHref(m.name));
+              },
+            });
+          });
+          if (data && data.truncated) {
+            rows.push({
+              label: "more matches…",
+              hint: "keep typing to narrow",
+              action: function () {},
+            });
+          }
+          if (active < 0 && rows.length) {
+            active = 0;
+          }
+          renderRows();
+        })
+        .catch(function () {
+          /* fetch failed: views/workspaces still listed */
+        });
+    }, 160);
+  }
+
+  function refresh(query) {
+    seq += 1; // any in-flight symbol response is stale now
+    rows = [];
+    var q = (query || "").toLowerCase();
+    views.forEach(function (v) {
+      if (!q || v.label.toLowerCase().indexOf(q) !== -1) {
+        rows.push({
+          label: v.label,
+          hint: "view",
+          action: function () {
+            window.location.assign(v.href);
+          },
+        });
+      }
+    });
+    workspaces.forEach(function (w) {
+      if (!q || (w.label || "").toLowerCase().indexOf(q) !== -1) {
+        rows.push({
+          label: w.label,
+          hint: "workspace",
+          action: function () {
+            switchStore(w.key);
+          },
+        });
+      }
+    });
+    active = rows.length ? 0 : -1;
+    renderRows();
+    if (q.length >= 2) {
+      fetchSymbols(query);
+    }
+  }
+
+  function open() {
+    lastFocus = document.activeElement;
+    overlay.hidden = false;
+    input.value = "";
+    refresh("");
+    input.focus();
+  }
+
+  function close() {
+    overlay.hidden = true;
+    seq += 1;
+    if (timer) {
+      clearTimeout(timer);
+      timer = null;
+    }
+    if (lastFocus && lastFocus.focus) {
+      lastFocus.focus();
+    }
+  }
+
+  if (openButton) {
+    openButton.addEventListener("click", open);
+  }
+  overlay.addEventListener("click", function (event) {
+    var target = event.target;
+    if (target && target.getAttribute && target.getAttribute("data-palette-close") !== null) {
+      close();
+    }
+  });
+  input.addEventListener("input", function () {
+    refresh(input.value);
+  });
+  input.addEventListener("keydown", function (event) {
+    var key = event.key || "";
+    if (key === "ArrowDown") {
+      event.preventDefault();
+      if (rows.length) {
+        active = (active + 1) % rows.length;
+        renderRows();
+      }
+    } else if (key === "ArrowUp") {
+      event.preventDefault();
+      if (rows.length) {
+        active = (active - 1 + rows.length) % rows.length;
+      }
+      renderRows();
+    } else if (key === "Enter") {
+      event.preventDefault();
+      if (active >= 0 && rows[active]) {
+        rows[active].action();
+      }
+    }
+  });
+  document.addEventListener("keydown", function (event) {
+    var key = event.key || "";
+    if ((event.metaKey || event.ctrlKey) && (key === "k" || key === "K")) {
+      event.preventDefault();
+      if (isOpen()) {
+        close();
+      } else {
+        open();
+      }
+    } else if (key === "Escape" && isOpen()) {
+      event.preventDefault();
+      close();
+    }
   });
 })();

--- a/src/cairn/dashboard/templates/_icons.html
+++ b/src/cairn/dashboard/templates/_icons.html
@@ -1,0 +1,32 @@
+{#-
+  Nav icons keyed by view id — the presentation half of shell.NAV_SECTIONS.
+  One macro so the sidebar loop and any future chrome render the same
+  glyph for the same view.
+-#}
+{% macro svg(name) -%}
+{%- if name == "workspaces" -%}
+<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 2 2 7l10 5 10-5-10-5z"/><path d="m2 17 10 5 10-5"/><path d="m2 12 10 5 10-5"/></svg>
+{%- elif name == "projects" -%}
+<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"/></svg>
+{%- elif name == "graph" -%}
+<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="18" cy="5" r="3"/><circle cx="6" cy="12" r="3"/><circle cx="18" cy="19" r="3"/><path d="M8.6 13.5l6.8 4M15.4 6.5l-6.8 4"/></svg>
+{%- elif name == "history" -%}
+<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><path d="M12 7v5l3 3"/></svg>
+{%- elif name == "tokens" -%}
+<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M13 2 3 14h7l-1 8 10-12h-7l1-8z"/></svg>
+{%- elif name == "chains" -%}
+<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M10 13a5 5 0 0 0 7.5.5l3-3a5 5 0 0 0-7-7l-1.7 1.7"/><path d="M14 11a5 5 0 0 0-7.5-.5l-3 3a5 5 0 0 0 7 7l1.7-1.7"/></svg>
+{%- elif name == "health" -%}
+<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M22 12h-4l-3 9L9 3l-3 9H2"/></svg>
+{%- elif name == "memory" -%}
+<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><ellipse cx="12" cy="5" rx="9" ry="3"/><path d="M21 12c0 1.7-4 3-9 3s-9-1.3-9-3"/><path d="M3 5v14c0 1.7 4 3 9 3s9-1.3 9-3V5"/></svg>
+{%- elif name == "wiki" -%}
+<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20V2H6.5A2.5 2.5 0 0 0 4 4.5z"/><path d="M4 19.5A2.5 2.5 0 0 0 6.5 22H20v-5"/></svg>
+{%- elif name == "tasks" -%}
+<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M9 11l3 3L22 4"/><path d="M21 12v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11"/></svg>
+{%- elif name == "embeddings" -%}
+<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m21 16-9 5-9-5V8l9-5 9 5z"/><path d="m3.3 7 8.7 5 8.7-5"/><path d="M12 22V12"/></svg>
+{%- elif name == "settings" -%}
+<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M4 21v-7"/><path d="M4 10V3"/><path d="M12 21v-9"/><path d="M12 8V3"/><path d="M20 21v-5"/><path d="M20 12V3"/><path d="M2 14h4"/><path d="M10 8h4"/><path d="M18 16h4"/></svg>
+{%- endif -%}
+{%- endmacro %}

--- a/src/cairn/dashboard/templates/_icons.html
+++ b/src/cairn/dashboard/templates/_icons.html
@@ -1,32 +1,33 @@
 {#-
-  Nav icons keyed by view id — the presentation half of shell.NAV_SECTIONS.
-  One macro so the sidebar loop and any future chrome render the same
-  glyph for the same view.
+  View icons keyed by view id — the presentation half of shell.NAV_SECTIONS.
+  One macro so the sidebar loop, the landing launcher, and any future
+  chrome render the same glyph for the same view (``size`` in px, 16 =
+  the sidebar default).
 -#}
-{% macro svg(name) -%}
+{% macro svg(name, size=16) -%}
 {%- if name == "workspaces" -%}
-<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 2 2 7l10 5 10-5-10-5z"/><path d="m2 17 10 5 10-5"/><path d="m2 12 10 5 10-5"/></svg>
+<svg width="{{ size }}" height="{{ size }}" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 2 2 7l10 5 10-5-10-5z"/><path d="m2 17 10 5 10-5"/><path d="m2 12 10 5 10-5"/></svg>
 {%- elif name == "projects" -%}
-<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"/></svg>
+<svg width="{{ size }}" height="{{ size }}" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"/></svg>
 {%- elif name == "graph" -%}
-<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="18" cy="5" r="3"/><circle cx="6" cy="12" r="3"/><circle cx="18" cy="19" r="3"/><path d="M8.6 13.5l6.8 4M15.4 6.5l-6.8 4"/></svg>
+<svg width="{{ size }}" height="{{ size }}" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="18" cy="5" r="3"/><circle cx="6" cy="12" r="3"/><circle cx="18" cy="19" r="3"/><path d="M8.6 13.5l6.8 4M15.4 6.5l-6.8 4"/></svg>
 {%- elif name == "history" -%}
-<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><path d="M12 7v5l3 3"/></svg>
+<svg width="{{ size }}" height="{{ size }}" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><path d="M12 7v5l3 3"/></svg>
 {%- elif name == "tokens" -%}
-<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M13 2 3 14h7l-1 8 10-12h-7l1-8z"/></svg>
+<svg width="{{ size }}" height="{{ size }}" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M13 2 3 14h7l-1 8 10-12h-7l1-8z"/></svg>
 {%- elif name == "chains" -%}
-<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M10 13a5 5 0 0 0 7.5.5l3-3a5 5 0 0 0-7-7l-1.7 1.7"/><path d="M14 11a5 5 0 0 0-7.5-.5l-3 3a5 5 0 0 0 7 7l1.7-1.7"/></svg>
+<svg width="{{ size }}" height="{{ size }}" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M10 13a5 5 0 0 0 7.5.5l3-3a5 5 0 0 0-7-7l-1.7 1.7"/><path d="M14 11a5 5 0 0 0-7.5-.5l-3 3a5 5 0 0 0 7 7l1.7-1.7"/></svg>
 {%- elif name == "health" -%}
-<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M22 12h-4l-3 9L9 3l-3 9H2"/></svg>
+<svg width="{{ size }}" height="{{ size }}" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M22 12h-4l-3 9L9 3l-3 9H2"/></svg>
 {%- elif name == "memory" -%}
-<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><ellipse cx="12" cy="5" rx="9" ry="3"/><path d="M21 12c0 1.7-4 3-9 3s-9-1.3-9-3"/><path d="M3 5v14c0 1.7 4 3 9 3s9-1.3 9-3V5"/></svg>
+<svg width="{{ size }}" height="{{ size }}" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><ellipse cx="12" cy="5" rx="9" ry="3"/><path d="M21 12c0 1.7-4 3-9 3s-9-1.3-9-3"/><path d="M3 5v14c0 1.7 4 3 9 3s9-1.3 9-3V5"/></svg>
 {%- elif name == "wiki" -%}
-<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20V2H6.5A2.5 2.5 0 0 0 4 4.5z"/><path d="M4 19.5A2.5 2.5 0 0 0 6.5 22H20v-5"/></svg>
+<svg width="{{ size }}" height="{{ size }}" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20V2H6.5A2.5 2.5 0 0 0 4 4.5z"/><path d="M4 19.5A2.5 2.5 0 0 0 6.5 22H20v-5"/></svg>
 {%- elif name == "tasks" -%}
-<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M9 11l3 3L22 4"/><path d="M21 12v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11"/></svg>
+<svg width="{{ size }}" height="{{ size }}" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M9 11l3 3L22 4"/><path d="M21 12v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11"/></svg>
 {%- elif name == "embeddings" -%}
-<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m21 16-9 5-9-5V8l9-5 9 5z"/><path d="m3.3 7 8.7 5 8.7-5"/><path d="M12 22V12"/></svg>
+<svg width="{{ size }}" height="{{ size }}" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m21 16-9 5-9-5V8l9-5 9 5z"/><path d="m3.3 7 8.7 5 8.7-5"/><path d="M12 22V12"/></svg>
 {%- elif name == "settings" -%}
-<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M4 21v-7"/><path d="M4 10V3"/><path d="M12 21v-9"/><path d="M12 8V3"/><path d="M20 21v-5"/><path d="M20 12V3"/><path d="M2 14h4"/><path d="M10 8h4"/><path d="M18 16h4"/></svg>
+<svg width="{{ size }}" height="{{ size }}" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M4 21v-7"/><path d="M4 10V3"/><path d="M12 21v-9"/><path d="M12 8V3"/><path d="M20 21v-5"/><path d="M20 12V3"/><path d="M2 14h4"/><path d="M10 8h4"/><path d="M18 16h4"/></svg>
 {%- endif -%}
 {%- endmacro %}

--- a/src/cairn/dashboard/templates/_links.html
+++ b/src/cairn/dashboard/templates/_links.html
@@ -20,6 +20,14 @@
 {{ base }}{% if parts %}?{{ parts | join("&") }}{% endif %}
 {%- endmacro %}
 
+{% macro store_field() -%}
+{#- Forms drop the action URL's query string on submit (GET forms) or never
+    carry one (POST actions), so the selected store rides the form body as a
+    hidden input. Empty selection renders nothing — bare pages stay
+    byte-identical. -#}
+{%- if store_key -%}<input type="hidden" name="store" value="{{ store_key }}">{%- endif -%}
+{%- endmacro %}
+
 {% macro view_link(view, param, value, window='') -%}
 {% set q = {param: value} %}
 {%- if window and window != 'all' %}{% set _ = q.update({'window': window}) %}{% endif -%}

--- a/src/cairn/dashboard/templates/base.html
+++ b/src/cairn/dashboard/templates/base.html
@@ -56,15 +56,19 @@
       });
     })();
   </script>
-  <script>
+  <script{% if shell is defined and shell.selector.options %} data-valid-stores='{{ shell.selector.options | map(attribute='key') | list | tojson }}'{% endif %}>
     /* Workspace stickiness: the store selection rides the URL
        (?store=<key>, the FR-003 seam), which a typed URL or new tab
        drops — so, like the theme, the last explicit selection is
        remembered (localStorage "cairn-store") and a bare visit
        redirects to it. Until the user picks a workspace, nothing is
        stored and bare URLs keep the launch store, byte-identical. A
-       remembered-but-since-deleted store lands on the friendly
-       missing-DB page, where Workspaces is one click away. */
+       remembered key that no longer names a populated store (the
+       workspace was deleted) is NOT redirected to — that would poison
+       every future visit with the missing-DB page — it is forgotten and
+       the launch store serves; the valid key set rides this tag's
+       data-valid-stores attribute, server-rendered from the same
+       enumerate_stores rows the selector lists. */
     (function () {
       "use strict";
       var STORAGE_KEY = "cairn-store";
@@ -75,11 +79,26 @@
           window.localStorage.setItem(STORAGE_KEY, selected);
         } else {
           var remembered = window.localStorage.getItem(STORAGE_KEY);
-          if (remembered) {
+          var valid = null;
+          var validRaw = document.currentScript
+            ? document.currentScript.getAttribute("data-valid-stores")
+            : null;
+          if (validRaw) {
+            try {
+              valid = JSON.parse(validRaw);
+            } catch (err) {
+              valid = null; /* unparsable set: redirect as before */
+            }
+          }
+          var known = valid === null ||
+            valid.indexOf(remembered) !== -1;
+          if (remembered && known) {
             url.searchParams.set("store", remembered);
             window.location.replace(
               url.pathname + url.search + url.hash
             );
+          } else if (remembered) {
+            window.localStorage.removeItem(STORAGE_KEY);
           }
         }
       } catch (err) {

--- a/src/cairn/dashboard/templates/base.html
+++ b/src/cairn/dashboard/templates/base.html
@@ -157,15 +157,37 @@
       {#- The topbar label derives from the path segment ("/" -> Overview);
           views may override via the view_title block. -#}
       <div class="topbar-title">{% block view_title %}{{ 'Overview' if path == '/' else (path.strip('/').split('/')[0] | capitalize) }}{% endblock %}</div>
-      <div id="live-controls" class="muted" data-state="running" hidden>
-        <span id="live-state"></span>
-        <button type="button" id="live-pause">Pause</button>
+      <div class="topbar-actions">
+        {#- Global workspace selector (FR-003 seam stays the URL param):
+            switching rewrites ?store= on the current URL and reloads, so
+            every tab shows the selected workspace. shell.js owns the
+            change behavior; the options are server-rendered. Production
+            renders always carry the shell context (render() injects it);
+            undefined here means a minimal-context unit render, where the
+            chrome degrades away like any other absent context var. -#}
+        {%- set selector = shell.selector if shell is defined else none %}
+        {% if selector %}
+        <label class="store-picker">
+          <span class="visually-hidden">Workspace</span>
+          <select id="store-select" aria-label="Workspace">
+            <option value="">{{ selector.launch_label }}</option>
+            {%- for o in selector.options %}
+            <option value="{{ o.key }}"{% if o.key == selector.selected %} selected{% endif %}{% if o.path %} title="{{ o.path }} — {{ o.key }}"{% endif %}>{{ o.label }}</option>
+            {%- endfor %}
+          </select>
+        </label>
+        {% endif %}
+        <div id="live-controls" class="muted" data-state="running" hidden>
+          <span id="live-state"></span>
+          <button type="button" id="live-pause">Pause</button>
+        </div>
       </div>
     </header>
     <main class="site-main">{% include "_embed_banner.html" %}
       {% block content %}{% endblock %}
     </main>
   </div>
+  <script src="{{ url_for('static', path='/shell.js') }}?v={{ asset_version }}"></script>
   {% block scripts %}{% endblock %}
 </body>
 </html>

--- a/src/cairn/dashboard/templates/base.html
+++ b/src/cairn/dashboard/templates/base.html
@@ -87,8 +87,28 @@
       }
     })();
   </script>
+  <script>
+    /* Sidebar collapse, applied pre-paint like the theme: the remembered
+       state (localStorage "cairn-sidebar", set by shell.js's toggle) sets
+       data-sidebar on the root before the shell renders, so a collapsed
+       session never flashes the expanded sidebar first. */
+    (function () {
+      "use strict";
+      try {
+        if (window.localStorage.getItem("cairn-sidebar") === "collapsed") {
+          document.documentElement.dataset.sidebar = "collapsed";
+        }
+      } catch (err) {
+        /* storage unavailable: the sidebar stays expanded */
+      }
+    })();
+  </script>
 </head>
 <body class="app-shell">
+  {%- set shell_ctx = shell if shell is defined else none %}
+  {%- set nav_sections = (shell_ctx.nav.sections if shell_ctx else none) or [] %}
+  {%- set selector = (shell_ctx.selector if shell_ctx else none) %}
+  {%- set palette = (shell_ctx.palette if shell_ctx else none) %}
   <aside class="sidebar">
     {#- FR-003: keep the selected store on every nav hop; empty when the
         launch store is served (byte-identical plain hrefs). -#}
@@ -98,57 +118,25 @@
       <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linejoin="round" aria-hidden="true"><path d="m12 3.5 4.5 5.5h-9L12 3.5z"/><path d="m12 12 4.5 5.5h-9L12 12z"/><path d="M12 21.5v-1"/></svg>
       <span>cairn</span>
     </a>
+    {% import "_icons.html" as icons %}
     <nav class="side-nav">
-      <a href="/workspaces{{ nav_query }}"{% if path.startswith('/workspaces') %} class="active" aria-current="page"{% endif %}>
-        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 2 2 7l10 5 10-5-10-5z"/><path d="m2 17 10 5 10-5"/><path d="m2 12 10 5 10-5"/></svg>
-        <span>Workspaces</span>
-      </a>
-      <a href="/projects{{ nav_query }}"{% if path.startswith('/projects') %} class="active" aria-current="page"{% endif %}>
-        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"/></svg>
-        <span>Projects</span>
-      </a>
-      <a href="/graph{{ nav_query }}"{% if path.startswith('/graph') %} class="active" aria-current="page"{% endif %}>
-        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="18" cy="5" r="3"/><circle cx="6" cy="12" r="3"/><circle cx="18" cy="19" r="3"/><path d="M8.6 13.5l6.8 4M15.4 6.5l-6.8 4"/></svg>
-        <span>Graph</span>
-      </a>
-      <a href="/history{{ nav_query }}"{% if path.startswith('/history') %} class="active" aria-current="page"{% endif %}>
-        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><path d="M12 7v5l3 3"/></svg>
-        <span>History</span>
-      </a>
-      <a href="/tokens{{ nav_query }}"{% if path.startswith('/tokens') %} class="active" aria-current="page"{% endif %}>
-        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M13 2 3 14h7l-1 8 10-12h-7l1-8z"/></svg>
-        <span>Tokens</span>
-      </a>
-      <a href="/chains{{ nav_query }}"{% if path.startswith('/chains') %} class="active" aria-current="page"{% endif %}>
-        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M10 13a5 5 0 0 0 7.5.5l3-3a5 5 0 0 0-7-7l-1.7 1.7"/><path d="M14 11a5 5 0 0 0-7.5-.5l-3 3a5 5 0 0 0 7 7l1.7-1.7"/></svg>
-        <span>Chains</span>
-      </a>
-      <a href="/health{{ nav_query }}"{% if path.startswith('/health') %} class="active" aria-current="page"{% endif %}>
-        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M22 12h-4l-3 9L9 3l-3 9H2"/></svg>
-        <span>Health</span>
-      </a>
-      <a href="/memory{{ nav_query }}"{% if path.startswith('/memory') %} class="active" aria-current="page"{% endif %}>
-        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><ellipse cx="12" cy="5" rx="9" ry="3"/><path d="M21 12c0 1.7-4 3-9 3s-9-1.3-9-3"/><path d="M3 5v14c0 1.7 4 3 9 3s9-1.3 9-3V5"/></svg>
-        <span>Memory</span>
-      </a>
-      <a href="/wiki{{ nav_query }}"{% if path.startswith('/wiki') %} class="active" aria-current="page"{% endif %}>
-        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20V2H6.5A2.5 2.5 0 0 0 4 4.5z"/><path d="M4 19.5A2.5 2.5 0 0 0 6.5 22H20v-5"/></svg>
-        <span>Wiki</span>
-      </a>
-      <a href="/tasks{{ nav_query }}"{% if path.startswith('/tasks') %} class="active" aria-current="page"{% endif %}>
-        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M9 11l3 3L22 4"/><path d="M21 12v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11"/></svg>
-        <span>Tasks</span>
-      </a>
-      <a href="/embeddings{{ nav_query }}"{% if path.startswith('/embeddings') %} class="active" aria-current="page"{% endif %}>
-        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m21 16-9 5-9-5V8l9-5 9 5z"/><path d="m3.3 7 8.7 5 8.7-5"/><path d="M12 22V12"/></svg>
-        <span>Embeddings</span>
-      </a>
-      <a href="/settings{{ nav_query }}"{% if path.startswith('/settings') %} class="active" aria-current="page"{% endif %}>
-        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M4 21v-7"/><path d="M4 10V3"/><path d="M12 21v-9"/><path d="M12 8V3"/><path d="M20 21v-5"/><path d="M20 12V3"/><path d="M2 14h4"/><path d="M10 8h4"/><path d="M18 16h4"/></svg>
-        <span>Settings</span>
-      </a>
+      {% for section in nav_sections %}
+      <div class="nav-group{% if not section["label"] %} nav-group-standalone{% endif %}">
+        {% if section["label"] %}<div class="nav-group-label">{{ section["label"] }}</div>{% endif %}
+        {% for item in section["items"] %}
+        <a href="{{ item.href }}"{% if item.active %} class="active" aria-current="page"{% endif %}>
+          {{ icons.svg(item.id) }}
+          <span>{{ item.label }}</span>
+        </a>
+        {% endfor %}
+      </div>
+      {% endfor %}
     </nav>
     <div class="sidebar-foot">
+      <button type="button" id="sidebar-collapse" class="sidebar-collapse" aria-label="Collapse sidebar" title="Collapse sidebar">
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m14 6-6 6 6 6"/></svg>
+        <span>Collapse</span>
+      </button>
       <button type="button" id="theme-toggle" class="theme-toggle">Theme</button>
     </div>
   </aside>
@@ -161,11 +149,7 @@
         {#- Global workspace selector (FR-003 seam stays the URL param):
             switching rewrites ?store= on the current URL and reloads, so
             every tab shows the selected workspace. shell.js owns the
-            change behavior; the options are server-rendered. Production
-            renders always carry the shell context (render() injects it);
-            undefined here means a minimal-context unit render, where the
-            chrome degrades away like any other absent context var. -#}
-        {%- set selector = shell.selector if shell is defined else none %}
+            change behavior; the options are server-rendered. -#}
         {% if selector %}
         <label class="store-picker">
           <span class="visually-hidden">Workspace</span>
@@ -177,6 +161,13 @@
           </select>
         </label>
         {% endif %}
+        {% if palette %}
+        <button type="button" id="palette-open" class="palette-open" aria-label="Open search (Ctrl+K or Cmd+K)">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" aria-hidden="true"><circle cx="11" cy="11" r="7"/><path d="m21 21-4.3-4.3"/></svg>
+          <span class="palette-open-label">Search</span>
+          <kbd id="palette-kbd">Ctrl K</kbd>
+        </button>
+        {% endif %}
         <div id="live-controls" class="muted" data-state="running" hidden>
           <span id="live-state"></span>
           <button type="button" id="live-pause">Pause</button>
@@ -187,6 +178,23 @@
       {% block content %}{% endblock %}
     </main>
   </div>
+  {% if palette %}
+  {#- Command palette overlay: body-level so live-refresh region swaps
+      (which replace only #refresh-region's children) never touch it.
+      The seed JSON carries the view list (store-carrying hrefs, composed
+      server-side from the same NAV_SECTIONS the sidebar renders) and the
+      workspace options; symbols arrive live from /graph/suggest. -#}
+  <div id="palette" class="palette" role="dialog" aria-modal="true" aria-label="Search" hidden>
+    <div class="palette-backdrop" data-palette-close></div>
+    <div class="palette-card">
+      <input id="palette-input" type="text" placeholder="Jump to a view, workspace, or symbol…"
+             autocomplete="off" role="combobox" aria-expanded="true" aria-controls="palette-list" aria-autocomplete="list">
+      <ul id="palette-list" role="listbox"></ul>
+      <p class="palette-hint muted">↑ ↓ navigate · ↵ open · esc close</p>
+    </div>
+  </div>
+  <script id="palette-data" type="application/json">{{ palette | tojson }}</script>
+  {% endif %}
   <script src="{{ url_for('static', path='/shell.js') }}?v={{ asset_version }}"></script>
   {% block scripts %}{% endblock %}
 </body>

--- a/src/cairn/dashboard/templates/graph.html
+++ b/src/cairn/dashboard/templates/graph.html
@@ -37,6 +37,7 @@
       <input type="checkbox" name="tests" value="1"{% if include_tests %} checked{% endif %}>
       Include tests
     </label>
+    {{ links.store_field() }}
     <button type="submit">Apply</button>
   </form>
   {#- Layout toggle (FR-004): links swap only the layout param, keeping

--- a/src/cairn/dashboard/templates/history.html
+++ b/src/cairn/dashboard/templates/history.html
@@ -30,6 +30,7 @@
       <input type="text" name="source" value="{{ source }}">
     </label>
     <input type="hidden" name="window" value="{{ window }}">
+    {{ links.store_field() }}
     <button type="submit">Apply</button>
   </form>
   {% include "window_control.html" %}

--- a/src/cairn/dashboard/templates/index.html
+++ b/src/cairn/dashboard/templates/index.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% import "_links.html" as links with context %}
+{% import "_icons.html" as icons %}
 {% block title %}Cairn Dashboard{% endblock %}
 {% block view_title %}Overview{% endblock %}
 {% block content %}
@@ -10,65 +11,66 @@
     <code>{{ db_path }}</code>
   </p>
   {#- FR-003: a selected store rides every landing-card link (links.url);
-      empty selection keeps the bare hrefs, byte-identical. -#}
+      empty selection keeps the bare hrefs, byte-identical. The glyphs
+      come from the same _icons macro the sidebar renders. -#}
   <div class="launcher-grid">
     <a class="launcher-card" href="{{ links.url('/workspaces') }}">
-      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 2 2 7l10 5 10-5-10-5z"/><path d="m2 17 10 5 10-5"/><path d="m2 12 10 5 10-5"/></svg>
+      {{ icons.svg('workspaces', 18) }}
       <span class="launcher-title">Workspaces</span>
       <span class="launcher-blurb">Local stores, one click away</span>
     </a>
     <a class="launcher-card" href="{{ links.url('/projects') }}">
-      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"/></svg>
+      {{ icons.svg('projects', 18) }}
       <span class="launcher-title">Projects &amp; index status</span>
       <span class="launcher-blurb">Indexed repos and embeddings</span>
     </a>
     <a class="launcher-card" href="{{ links.url('/graph') }}">
-      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="18" cy="5" r="3"/><circle cx="6" cy="12" r="3"/><circle cx="18" cy="19" r="3"/><path d="M8.6 13.5l6.8 4M15.4 6.5l-6.8 4"/></svg>
+      {{ icons.svg('graph', 18) }}
       <span class="launcher-title">Graph explorer</span>
       <span class="launcher-blurb">Interactive symbol graph</span>
     </a>
     <a class="launcher-card" href="{{ links.url('/history') }}">
-      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><path d="M12 7v5l3 3"/></svg>
+      {{ icons.svg('history', 18) }}
       <span class="launcher-title">Tool-call history</span>
       <span class="launcher-blurb">Every recorded invocation</span>
     </a>
     <a class="launcher-card" href="{{ links.url('/tokens') }}">
-      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M13 2 3 14h7l-1 8 10-12h-7l1-8z"/></svg>
+      {{ icons.svg('tokens', 18) }}
       <span class="launcher-title">Token usage</span>
       <span class="launcher-blurb">Context cost per tool</span>
     </a>
     <a class="launcher-card" href="{{ links.url('/chains') }}">
-      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M10 13a5 5 0 0 0 7.5.5l3-3a5 5 0 0 0-7-7l-1.7 1.7"/><path d="M14 11a5 5 0 0 0-7.5-.5l-3 3a5 5 0 0 0 7 7l1.7-1.7"/></svg>
+      {{ icons.svg('chains', 18) }}
       <span class="launcher-title">Session chains</span>
       <span class="launcher-blurb">Calls grouped per session</span>
     </a>
     <a class="launcher-card" href="{{ links.url('/health') }}">
-      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M22 12h-4l-3 9L9 3l-3 9H2"/></svg>
+      {{ icons.svg('health', 18) }}
       <span class="launcher-title">Health</span>
       <span class="launcher-blurb">Same checks as cairn doctor</span>
     </a>
     <a class="launcher-card" href="{{ links.url('/memory') }}">
-      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><ellipse cx="12" cy="5" rx="9" ry="3"/><path d="M21 12c0 1.7-4 3-9 3s-9-1.3-9-3"/><path d="M3 5v14c0 1.7 4 3 9 3s9-1.3 9-3V5"/></svg>
+      {{ icons.svg('memory', 18) }}
       <span class="launcher-title">Memory</span>
       <span class="launcher-blurb">Recent tribal knowledge</span>
     </a>
     <a class="launcher-card" href="{{ links.url('/wiki') }}">
-      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20V2H6.5A2.5 2.5 0 0 0 4 4.5z"/><path d="M4 19.5A2.5 2.5 0 0 0 6.5 22H20v-5"/></svg>
+      {{ icons.svg('wiki', 18) }}
       <span class="launcher-title">Wiki</span>
       <span class="launcher-blurb">Generated project pages</span>
     </a>
     <a class="launcher-card" href="{{ links.url('/tasks') }}">
-      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M9 11l3 3L22 4"/><path d="M21 12v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11"/></svg>
+      {{ icons.svg('tasks', 18) }}
       <span class="launcher-title">Task queue</span>
       <span class="launcher-blurb">LLM synthesis jobs</span>
     </a>
     <a class="launcher-card" href="{{ links.url('/embeddings') }}">
-      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m21 16-9 5-9-5V8l9-5 9 5z"/><path d="m3.3 7 8.7 5 8.7-5"/><path d="M12 22V12"/></svg>
+      {{ icons.svg('embeddings', 18) }}
       <span class="launcher-title">Embeddings</span>
       <span class="launcher-blurb">Backend, stamp, per-corpus state</span>
     </a>
     <a class="launcher-card" href="{{ links.url('/settings') }}">
-      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M4 21v-7"/><path d="M4 10V3"/><path d="M12 21v-9"/><path d="M12 8V3"/><path d="M20 21v-5"/><path d="M20 12V3"/><path d="M2 14h4"/><path d="M10 8h4"/><path d="M18 16h4"/></svg>
+      {{ icons.svg('settings', 18) }}
       <span class="launcher-title">Settings</span>
       <span class="launcher-blurb">Embedding config + parity check</span>
     </a>

--- a/src/cairn/dashboard/templates/settings.html
+++ b/src/cairn/dashboard/templates/settings.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% import "_links.html" as links with context %}
 {% block title %}Settings — Cairn Dashboard{% endblock %}
 {#- The env-pin marker (D-008): an env var shadowing the file value must be
     visible, or a save that "does nothing" is unexplainable. The API key's
@@ -24,6 +25,7 @@
   <p role="alert" style="margin: 0 0 1rem; padding: 0.6rem 0.9rem; border: 1px solid color-mix(in srgb, var(--warn) 32%, transparent); border-radius: var(--radius); background: color-mix(in srgb, var(--warn) 12%, transparent); color: var(--warn); font-weight: 600;">{{ error }}</p>
   {% endif %}
   <form class="graph-controls" method="post" action="/settings/save">
+    {{ links.store_field() }}
     <label>Backend
       <select name="CAIRN_EMBED_BACKEND">
         {% for b in backends %}
@@ -69,6 +71,7 @@
     compares against what is stored (gate 0.98).
   </p>
   <form class="graph-controls" method="post" action="/settings/parity-check">
+    {{ links.store_field() }}
     <button type="submit">Run parity check</button>
   </form>
   {% if parity %}

--- a/src/cairn/dashboard/templates/settings.html
+++ b/src/cairn/dashboard/templates/settings.html
@@ -24,7 +24,13 @@
   {% if error %}
   <p role="alert" style="margin: 0 0 1rem; padding: 0.6rem 0.9rem; border: 1px solid color-mix(in srgb, var(--warn) 32%, transparent); border-radius: var(--radius); background: color-mix(in srgb, var(--warn) 12%, transparent); color: var(--warn); font-weight: 600;">{{ error }}</p>
   {% endif %}
-  <form class="graph-controls" method="post" action="/settings/save">
+  {#- The POST actions carry the store in the action URL's query string
+      (POST forms keep it; GET forms drop it — hence store_field elsewhere):
+      the response then renders at a URL that already has ?store=, so the
+      head stickiness script never redirects the POST landing to a GET of
+      this POST-only route (405). The hidden input stays as the fallback
+      transport resolve_selection also accepts. -#}
+  <form class="graph-controls" method="post" action="{{ links.url('/settings/save') }}">
     {{ links.store_field() }}
     <label>Backend
       <select name="CAIRN_EMBED_BACKEND">
@@ -70,7 +76,7 @@
     Re-embeds a sample of stored chunks through the configured backend and
     compares against what is stored (gate 0.98).
   </p>
-  <form class="graph-controls" method="post" action="/settings/parity-check">
+  <form class="graph-controls" method="post" action="{{ links.url('/settings/parity-check') }}">
     {{ links.store_field() }}
     <button type="submit">Run parity check</button>
   </form>

--- a/src/cairn/dashboard/templates/tasks.html
+++ b/src/cairn/dashboard/templates/tasks.html
@@ -1,9 +1,11 @@
 {% extends "base.html" %}
+{% import "_links.html" as links with context %}
 {% block title %}Tasks — Cairn Dashboard{% endblock %}
 {% block content %}
 <section class="panel">
   <h1>Tasks</h1>
   <form class="graph-controls" method="get" action="/tasks">
+    {{ links.store_field() }}
     <label>Status
       <select name="status">
         <option value="all"{% if status == "all" %} selected{% endif %}>all</option>

--- a/src/cairn/dashboard/templates/wiki.html
+++ b/src/cairn/dashboard/templates/wiki.html
@@ -1,10 +1,33 @@
 {% extends "base.html" %}
+{% import "_links.html" as links with context %}
 {% block title %}Wiki — Cairn Dashboard{% endblock %}
 {% block content %}
 <section class="panel">
   <h1>Wiki</h1>
   <p class="muted">Generated wiki pages and their promotion state.</p>
+  <form class="graph-controls wiki-controls" method="get" action="/wiki">
+    <label>Search
+      <input type="text" name="q" value="{{ filters.q }}" placeholder="title, page id, or description">
+    </label>
+    {{ links.store_field() }}
+    <button type="submit">Search</button>
+  </form>
+  <p class="window-control wiki-state-filter">
+    State:
+    {%- set base_q = {} %}
+    {%- if filters.q %}{% set _ = base_q.update({'q': filters.q}) %}{% endif %}
+    {%- if filters.repo %}{% set _ = base_q.update({'repo': filters.repo}) %}{% endif %}
+    {% for s in ["all"] + (page_states | list) %}
+    {%- set q = dict(base_q, state=s) if s != "all" else dict(base_q) %}
+    {% if not loop.first %} · {% endif %}{% if s == (filters.state or "all") %}<strong>{{ s }}</strong>{% else %}<a href="{{ links.url('/wiki', q) }}">{{ s }}</a>{% endif %}
+    {%- endfor %}
+  </p>
   {% if pages %}
+  {% for repo, rows in pages | groupby("repo") %}
+  <h2 class="wiki-repo-heading">
+    <a href="{{ links.url('/wiki', dict(base_q, repo=repo)) }}">{{ repo }}</a>
+    <span class="muted">({{ rows | length }})</span>
+  </h2>
   <table class="data-table">
     <thead>
       <tr>
@@ -13,9 +36,12 @@
       </tr>
     </thead>
     <tbody>
-      {% for p in pages %}
+      {% for p in rows %}
       <tr>
-        <td><a href="/wiki/{{ p.page_id }}">{{ p.title }}</a></td>
+        <td>
+          <a href="{{ links.url('/wiki/' ~ p.repo ~ '/' ~ p.page_id) }}">{{ p.title }}</a>
+          {%- if p.description %} <span class="muted">— {{ p.description }}</span>{% endif %}
+        </td>
         <td>
           <span class="badge badge-{{ p.state }}">{{ p.state }}</span>
           <span class="badge badge-{{ p.staleness }}">{{ p.staleness }}</span>
@@ -24,8 +50,11 @@
       {% endfor %}
     </tbody>
   </table>
+  {% endfor %}
   {% else %}
-  <p class="empty-state">No wiki pages yet — generate some with <code>cairn wiki generate</code>.</p>
+  <p class="empty-state">
+    {%- if filters.q or filters.state or filters.repo %}No wiki pages match the current filters.{% else %}No wiki pages yet — generate some with <code>cairn wiki generate</code>.{% endif %}
+  </p>
   {% endif %}
 </section>
 {% endblock %}

--- a/src/cairn/dashboard/templates/wiki_page.html
+++ b/src/cairn/dashboard/templates/wiki_page.html
@@ -13,24 +13,48 @@
     <span class="badge badge-{{ page.state }}">{{ page.state }}</span>
     <span class="badge badge-{{ page.staleness }}">{{ page.staleness }}</span>
   </p>
-  <div class="wiki-body">
-    {{ page.html | safe }}
+  <div class="wiki-layout">
+    <div class="wiki-article">
+      <div class="wiki-body">
+        {{ page.html | safe }}
+      </div>
+      {% if page.sources %}
+      <h2>Sources</h2>
+      <ul>
+        {% for source in page.sources %}
+        <li>
+          {% if source.symbol %}
+            symbol:
+            {%- if source.symbol in page.ref_hrefs %} <a href="{{ page.ref_hrefs[source.symbol] }}"><code>{{ source.symbol }}</code></a>
+            {%- else %} <code>{{ source.symbol }}</code>{% endif %}
+          {% elif source.path %}
+            path: <code>{{ source.path }}</code>
+          {% else %}
+            {% for key, value in source.items() %}{{ key }}: <code>{{ value }}</code>{% if not loop.last %}, {% endif %}{% endfor %}
+          {% endif %}
+        </li>
+        {% endfor %}
+      </ul>
+      {% endif %}
+      {% if prev or next %}
+      <p class="wiki-pager">
+        {%- if prev %}<a href="{{ links.url('/wiki/' ~ page.repo ~ '/' ~ prev.page_id) }}">← {{ prev.title }}</a>{% else %}<span class="muted">←</span>{% endif %}
+        {%- if prev and next %} · {% endif %}
+        {%- if next %}<a href="{{ links.url('/wiki/' ~ page.repo ~ '/' ~ next.page_id) }}">{{ next.title }} →</a>{% else %}<span class="muted">→</span>{% endif %}
+      </p>
+      {% endif %}
+    </div>
+    {% if page.toc %}
+    <nav class="wiki-toc" aria-label="On this page">
+      <div class="wiki-toc-label">On this page</div>
+      <ul>
+        {% for item in page.toc %}
+        <li class="wiki-toc-l{{ item.level }}"><a href="#{{ item.anchor }}">{{ item.text }}</a></li>
+        {% endfor %}
+      </ul>
+    </nav>
+    {% endif %}
   </div>
-  {% if page.sources %}
-  <h2>Sources</h2>
-  <ul>
-    {% for source in page.sources %}
-    <li>{% for key, value in source.items() %}{{ key }}: <code>{{ value }}</code>{% if not loop.last %}, {% endif %}{% endfor %}</li>
-    {% endfor %}
-  </ul>
-  {% endif %}
-  {% if prev or next %}
-  <p class="wiki-pager">
-    {%- if prev %}<a href="{{ links.url('/wiki/' ~ page.repo ~ '/' ~ prev.page_id) }}">← {{ prev.title }}</a>{% else %}<span class="muted">←</span>{% endif %}
-    {%- if prev and next %} · {% endif %}
-    {%- if next %}<a href="{{ links.url('/wiki/' ~ page.repo ~ '/' ~ next.page_id) }}">{{ next.title }} →</a>{% else %}<span class="muted">→</span>{% endif %}
-  </p>
-  {% endif %}
 </section>
 {% endblock %}
 {% block scripts %}

--- a/src/cairn/dashboard/templates/wiki_page.html
+++ b/src/cairn/dashboard/templates/wiki_page.html
@@ -1,12 +1,17 @@
 {% extends "base.html" %}
+{% import "_links.html" as links with context %}
 {% block title %}{{ page.title }} — Cairn Dashboard{% endblock %}
 {% block content %}
 <section class="panel">
+  <nav class="wiki-breadcrumb" aria-label="Breadcrumb">
+    <a href="{{ links.url('/wiki') }}">Wiki</a> /
+    <a href="{{ links.url('/wiki', {'repo': page.repo}) }}">{{ page.repo }}</a> /
+    <span>{{ page.title }}</span>
+  </nav>
   <h1>{{ page.title }}</h1>
   <p>
     <span class="badge badge-{{ page.state }}">{{ page.state }}</span>
     <span class="badge badge-{{ page.staleness }}">{{ page.staleness }}</span>
-    <a href="/wiki">Back to wiki</a>
   </p>
   <div class="wiki-body">
     {{ page.html | safe }}
@@ -18,6 +23,13 @@
     <li>{% for key, value in source.items() %}{{ key }}: <code>{{ value }}</code>{% if not loop.last %}, {% endif %}{% endfor %}</li>
     {% endfor %}
   </ul>
+  {% endif %}
+  {% if prev or next %}
+  <p class="wiki-pager">
+    {%- if prev %}<a href="{{ links.url('/wiki/' ~ page.repo ~ '/' ~ prev.page_id) }}">← {{ prev.title }}</a>{% else %}<span class="muted">←</span>{% endif %}
+    {%- if prev and next %} · {% endif %}
+    {%- if next %}<a href="{{ links.url('/wiki/' ~ page.repo ~ '/' ~ next.page_id) }}">{{ next.title }} →</a>{% else %}<span class="muted">→</span>{% endif %}
+  </p>
   {% endif %}
 </section>
 {% endblock %}

--- a/tests/test_dashboard_app.py
+++ b/tests/test_dashboard_app.py
@@ -4107,3 +4107,93 @@ def test_render_markdown_pipe_tables_render_as_tables():
 
     assert "<table>" not in degraded
     assert "a | b | c" in degraded
+
+
+def test_render_markdown_inline_links_render_only_allowlisted_targets():
+    """[label](target) becomes an anchor only for http(s)://, /, and #
+    targets; every other scheme (javascript:, data:) or bare relative
+    renders as the literal escaped text — the href attribute is emitted
+    exclusively from an allowlist match, never from the source text."""
+    from cairn.dashboard.markdown import render_markdown
+
+    html = render_markdown(
+        "See [docs](https://example.com/a?b=1), [local](/graph), "
+        "[anchor](#top), [bad](javascript:alert(1)), "
+        "[data](data:text/plain,x), and [relative](some-page).\n"
+    )
+
+    assert '<a href="https://example.com/a?b=1">docs</a>' in html
+    assert '<a href="/graph">local</a>' in html
+    assert '<a href="#top">anchor</a>' in html
+    assert "[bad](javascript:alert(1))" in html  # literal, still escaped text
+    assert "[data](data:text/plain,x)" in html
+    assert "[relative](some-page)" in html
+    assert 'href="javascript' not in html
+    assert 'href="data:' not in html
+
+
+def test_render_markdown_code_spans_beat_link_syntax():
+    """A link written inside backticks is a code span, not a link — the
+    combined inline pass consumes the span atomically."""
+    from cairn.dashboard.markdown import render_markdown
+
+    html = render_markdown("Use the `[x](/y)` literal.\n")
+
+    assert "<code>[x](/y)</code>" in html
+    assert '<a href="/y">' not in html
+
+
+def test_render_markdown_link_map_wraps_vouched_code_refs():
+    """A code span whose exact text sits in the link map renders as an
+    anchor around the code element; unmapped spans stay plain <code>."""
+    from cairn.dashboard.markdown import render_markdown
+
+    html = render_markdown(
+        "Calls `demo_main` and `plain_word`.\n",
+        link_map={"demo_main": "/graph?scope=symbol&focus=demo_main&store=ab"},
+    )
+
+    assert (
+        '<a class="code-ref" href="/graph?scope=symbol&amp;focus=demo_main'
+        '&amp;store=ab"><code>demo_main</code></a>' in html
+    )
+    assert "<code>plain_word</code>" in html
+    assert 'code-ref" href="[^"]*plain_word' not in html
+
+
+def test_render_markdown_with_toc_anchors_match_heading_ids():
+    """The outline's anchors are exactly the ids the headings emitted,
+    including dedupe suffixes; h1/h4+ stay out of the outline."""
+    from cairn.dashboard.markdown import render_markdown_with_toc
+
+    html, toc = render_markdown_with_toc(
+        "# Title\n"
+        "\n"
+        "## Alpha\n"
+        "\n"
+        "text\n"
+        "\n"
+        "### Beta\n"
+        "\n"
+        "## Alpha again\n"
+        "\n"
+        "#### Deep\n"
+    )
+
+    assert [t["text"] for t in toc] == ["Alpha", "Beta", "Alpha again"]
+    assert toc[0]["anchor"] == "alpha"
+    assert toc[1]["anchor"] == "beta"
+    assert toc[2]["anchor"] == "alpha-again"
+    assert '<h2 id="alpha">' in html
+    assert '<h3 id="beta">' in html
+    assert '<h2 id="alpha-again">' in html
+    assert '<h1 id="title">' in html  # ids on every heading, toc h2/h3 only
+
+
+def test_render_markdown_with_toc_dedupes_repeated_headings():
+    from cairn.dashboard.markdown import render_markdown_with_toc
+
+    html, toc = render_markdown_with_toc("## Same\n\n## Same\n\n## Same\n")
+
+    assert [t["anchor"] for t in toc] == ["same", "same-1", "same-2"]
+    assert html.count("<h2 ") == 3

--- a/tests/test_dashboard_app.py
+++ b/tests/test_dashboard_app.py
@@ -3716,6 +3716,11 @@ def test_wiki_routes_registered_with_pinned_names(tmp_path):
 
     app = create_app(db_path=str(tmp_path / "ro.db"))
     assert app.url_path_for("wiki") == "/wiki"
+    assert (
+        app.url_path_for("wiki_page_repo", repo="demo", page_id="overview")
+        == "/wiki/demo/overview"
+    )
+    # The one-segment URL survives as the legacy redirect route.
     assert app.url_path_for("wiki_page", page_id="overview") == "/wiki/overview"
 
 
@@ -3739,17 +3744,120 @@ def test_wiki_is_linked_in_sidebar_and_launcher(tmp_path):
 
 def test_wiki_route_lists_pages_with_state_badges(tmp_path):
     """FR-009 / TC-025: /wiki lists every planned page with its state,
-    each entry linking to its detail view."""
+    each entry linking to its repo-qualified detail view, grouped by repo."""
     client = _wiki_client(tmp_path)
 
     resp = client.get("/wiki")
 
     assert resp.status_code == 200
     for page_id in ("overview", "viz-module", "tasks-module"):
-        assert f'href="/wiki/{page_id}"' in resp.text
+        assert f'href="/wiki/demo/{page_id}"' in resp.text
     assert "demo architecture overview" in resp.text
     for badge in ("promoted", "queued"):
         assert f">{badge}<" in resp.text
+    # The catalog groups by repo under a per-repo heading.
+    assert "wiki-repo-heading" in resp.text
+
+
+def test_wiki_catalog_filters_by_state_and_search(tmp_path):
+    """The catalog's GET filters: state narrows to one badge value, q
+    narrows by title/page-id/description substring, and they compose."""
+    client = _wiki_client(tmp_path)
+
+    promoted_only = client.get("/wiki", params={"state": "promoted"})
+    assert promoted_only.status_code == 200
+    assert "demo architecture overview" in promoted_only.text
+    assert "tasks module" not in promoted_only.text  # queued row filtered out
+
+    searched = client.get("/wiki", params={"q": "viz"})
+    assert searched.status_code == 200
+    assert 'href="/wiki/demo/viz-module"' in searched.text
+    assert 'href="/wiki/demo/overview"' not in searched.text
+
+    narrowed = client.get("/wiki", params={"q": "viz", "state": "promoted"})
+    assert 'href="/wiki/demo/viz-module"' in narrowed.text
+
+    nothing = client.get("/wiki", params={"q": "no-such-page"})
+    assert "No wiki pages match the current filters" in nothing.text
+
+
+def test_wiki_legacy_page_url_redirects_to_the_repo_qualified_url(tmp_path):
+    """Bookmarked one-segment URLs keep working: a 307 to the canonical
+    repo-qualified URL; an unknown page id stays the same 404 as before."""
+    client = _wiki_client(tmp_path)
+
+    resp = client.get("/wiki/overview", follow_redirects=False)
+    assert resp.status_code == 307
+    assert resp.headers["location"] == "/wiki/demo/overview"
+
+    followed = client.get("/wiki/overview", follow_redirects=True)
+    assert followed.status_code == 200
+    assert "<h2" in followed.text  # the redirect lands on a rendered page
+
+
+def test_wiki_legacy_redirect_carries_the_selected_store(tmp_path, monkeypatch):
+    """The store param rides the legacy redirect (the bookmark equivalent of
+    a selected-store deep link): /wiki/overview?store=A redirects to the
+    repo-qualified URL under A's knowledge root, store intact."""
+    client, home = _switch_client(tmp_path, monkeypatch)
+    _seed_wiki_pages(home / _SW_KEY_A / ".knowledge")
+
+    resp = client.get(
+        "/wiki/overview", params={"store": _SW_KEY_A}, follow_redirects=False
+    )
+
+    assert resp.status_code == 307
+    assert resp.headers["location"] == f"/wiki/demo/overview?store={_SW_KEY_A}"
+
+
+def test_wiki_repo_qualified_urls_reach_colliding_page_ids(tmp_path):
+    """The collision the repo segment fixes: two repos that both plan
+    ``overview`` are BOTH reachable at their own qualified URLs (the
+    legacy URL could only ever serve the first readable concept)."""
+    pytest.importorskip("httpx")
+    from starlette.testclient import TestClient
+
+    from cairn.dashboard.app import create_app
+
+    kdir = tmp_path / "knowledge"
+    _seed_wiki_pages(kdir)
+    for repo, marker in (("alpha", "alpha overview body"), ("beta", "beta overview body")):
+        wiki_dir = kdir / "_wiki"
+        manifest = json.loads((wiki_dir / "manifest.json").read_text())
+        manifest["pages"][f"{repo}/overview"] = {
+            **_wiki_plan_entry("overview", f"{repo} overview"),
+            "task_id": f"task-{repo}",
+            "state": "promoted",
+            "attempts": 0,
+        }
+        (wiki_dir / "manifest.json").write_text(json.dumps(manifest, indent=2))
+        from cairn.okf.bundle import OKFBundle
+        from cairn.okf.concept import OKFConcept
+
+        OKFBundle(str(kdir)).write_concept(
+            OKFConcept(
+                type="Wiki-Article",
+                title=f"Wiki: {repo} overview",
+                description=f"Wiki article for {repo}/overview",
+                resource="overview",
+                tags=[repo, "wiki"],
+                timestamp="2026-08-30T10:00:00Z",
+                concept_id=f"wiki/pages/{repo}/overview",
+                sources=_WIKI_SOURCES,
+                body=marker,
+                extensions={"page_id": "overview", "input_hash": f"hash-{repo}"},
+            )
+        )
+
+    client = TestClient(
+        create_app(
+            db_path=_graph_db_file(tmp_path, seed=False), knowledge_dir=str(kdir)
+        )
+    )
+    alpha = client.get("/wiki/alpha/overview")
+    beta = client.get("/wiki/beta/overview")
+    assert alpha.status_code == 200 and "alpha overview body" in alpha.text
+    assert beta.status_code == 200 and "beta overview body" in beta.text
 
 
 def test_wiki_route_empty_manifest_renders_empty_state(tmp_path):
@@ -3765,10 +3873,11 @@ def test_wiki_route_empty_manifest_renders_empty_state(tmp_path):
 
 def test_wiki_page_route_renders_markdown_body_and_sources(tmp_path):
     """FR-009 / TC-026: the detail view renders headings and lists as HTML
-    elements (never the raw markdown) with the sources listed."""
+    elements (never the raw markdown) with the sources listed, a breadcrumb
+    naming the repo, and prev/next links to the repo's other pages."""
     client = _wiki_client(tmp_path)
 
-    resp = client.get("/wiki/overview")
+    resp = client.get("/wiki/demo/overview")
 
     assert resp.status_code == 200
     assert re.search(r"<h2[^>]*>How it works</h2>", resp.text)
@@ -3781,12 +3890,17 @@ def test_wiki_page_route_renders_markdown_body_and_sources(tmp_path):
     assert "demo_main" in resp.text
     # Live mermaid: the detail view loads mermaid.js client-side.
     assert 'cdn.jsdelivr.net/npm/mermaid@11' in resp.text
+    # Breadcrumb + prev/next navigation (viz-module is the next promoted
+    # page in manifest order; overview is first, so no prev).
+    assert 'href="/wiki?repo=demo"' in resp.text
+    assert 'href="/wiki/demo/viz-module"' in resp.text
+    assert "wiki-pager" in resp.text
 
 
 def test_wiki_page_route_unknown_page_returns_404(tmp_path):
     client = _wiki_client(tmp_path)
-    resp = client.get("/wiki/no-such-page")
-    assert resp.status_code == 404
+    assert client.get("/wiki/no-such-page").status_code == 404
+    assert client.get("/wiki/demo/no-such-page").status_code == 404
 
 
 # --- wiki staleness badges (FR-007 / TC-019 / TC-020) -------------------------
@@ -3842,7 +3956,7 @@ def test_wiki_views_render_fresh_badge_beside_state_badge(tmp_path, monkeypatch)
     client = _staleness_client(tmp_path, monkeypatch, head=_SHA_A)
 
     listing = client.get("/wiki")
-    detail = client.get("/wiki/overview")
+    detail = client.get("/wiki/demo/overview")
 
     assert listing.status_code == 200
     assert ">fresh<" in listing.text
@@ -3858,7 +3972,7 @@ def test_wiki_views_render_stale_badge_after_head_moves(tmp_path, monkeypatch):
     client = _staleness_client(tmp_path, monkeypatch, head=_SHA_B)
 
     listing = client.get("/wiki")
-    detail = client.get("/wiki/overview")
+    detail = client.get("/wiki/demo/overview")
 
     assert listing.status_code == 200
     assert ">stale<" in listing.text
@@ -3876,7 +3990,7 @@ def test_wiki_views_render_unknown_badge_when_comparison_unavailable(
     client = _staleness_client(tmp_path, monkeypatch, head=None)
 
     listing = client.get("/wiki")
-    detail = client.get("/wiki/overview")
+    detail = client.get("/wiki/demo/overview")
 
     assert listing.status_code == 200
     assert ">unknown<" in listing.text

--- a/tests/test_dashboard_app.py
+++ b/tests/test_dashboard_app.py
@@ -2694,6 +2694,28 @@ def test_settings_save_keeps_the_selected_store(tmp_path, monkeypatch):
     assert f'href="/projects?store={_SW_KEY_A}"' in resp.text
 
 
+def test_settings_post_actions_carry_the_store_in_the_url(tmp_path, monkeypatch):
+    """Both settings POST actions compose through links.url when a store
+    is selected: the POST lands at /settings/save?store=<key>, so the
+    response URL already carries the selection and the head stickiness
+    script never redirects the landing to a GET of a POST-only route
+    (405). Bare selection keeps the bare action URLs."""
+    client, _ = _switch_client(tmp_path, monkeypatch)
+
+    selected = client.get("/settings", params={"store": _SW_KEY_A})
+    assert (
+        f'action="/settings/save?store={_SW_KEY_A}"' in selected.text
+    )
+    assert (
+        f'action="/settings/parity-check?store={_SW_KEY_A}"'
+        in selected.text
+    )
+
+    bare = client.get("/settings")
+    assert 'action="/settings/save"' in bare.text
+    assert 'action="/settings/parity-check"' in bare.text
+
+
 # ---------------------------------------------------------------------------
 # Global workspace selector (topbar): server-rendered on every view from
 # enumerate_stores (populated only, never probed), labels from the
@@ -4213,6 +4235,21 @@ def test_markdown_renderer_module_never_loads_server_stack():
     assert proc.stdout.strip() == "False"
 
 
+def test_shell_module_never_loads_server_stack():
+    """The shell context module is pure like the renderer — importing it
+    must not pull in the server stack (it is imported only inside
+    create_app, so the package-level pin alone would never load it)."""
+    code = (
+        "import sys; import cairn.dashboard.shell; "
+        "print(any(m in sys.modules "
+        "for m in ('starlette', 'uvicorn', 'jinja2')))"
+    )
+    proc = subprocess.run(
+        [sys.executable, "-c", code], capture_output=True, text=True, check=True
+    )
+    assert proc.stdout.strip() == "False"
+
+
 def test_render_markdown_whitelists_blocks_and_escapes_inline_html():
     from cairn.dashboard.markdown import render_markdown
 
@@ -4327,6 +4364,24 @@ def test_render_markdown_inline_links_render_only_allowlisted_targets():
     assert "[relative](some-page)" in html
     assert 'href="javascript' not in html
     assert 'href="data:' not in html
+
+
+def test_render_markdown_link_target_quotes_cannot_break_out_of_href():
+    """A double quote inside an allowlisted target must not terminate the
+    href attribute (the working text is escaped with quote=False, so the
+    renderer neutralizes quotes at emission) — the classic attribute-
+    injection payload renders as data inside the href, never as new
+    attributes."""
+    from cairn.dashboard.markdown import render_markdown
+
+    html = render_markdown(
+        '[hover](https://e.com/"onmouseover="location=\'//evil\'"x="y)\n'
+    )
+
+    assert 'onmouseover="' not in html
+    # Exactly one anchor, and the payload lives inside its href.
+    assert html.count("<a ") == 1
+    assert 'href="https://e.com/&quot;onmouseover=&quot;location=' in html
 
 
 def test_render_markdown_code_spans_beat_link_syntax():

--- a/tests/test_dashboard_app.py
+++ b/tests/test_dashboard_app.py
@@ -2784,6 +2784,114 @@ def test_shell_js_switch_contract_is_pinned_at_source_level():
 
 
 # ---------------------------------------------------------------------------
+# Grouped sidebar + command palette (shell chrome): the sidebar renders
+# from shell.NAV_SECTIONS (same href shape as the hand-written anchors it
+# replaced), collapse persists pre-paint like the theme, and the palette
+# seeds from server JSON — views with store-carrying hrefs, workspaces,
+# symbols live from /graph/suggest. JS contracts are source-pinned.
+# ---------------------------------------------------------------------------
+
+
+def test_sidebar_renders_grouped_nav_from_shell_sections(tmp_path, monkeypatch):
+    """The grouped sections replace the flat list, every view's anchor
+    survives with the exact href shape the pins expect, and the selected
+    store rides every anchor."""
+    client, _ = _switch_client(tmp_path, monkeypatch)
+
+    bare = client.get("/projects")
+    assert bare.status_code == 200
+    for section in ("Explore", "Knowledge", "Activity", "System"):
+        assert f'class="nav-group-label">{section}<' in bare.text, section
+    for view_id, label in (
+        ("projects", "Projects"),
+        ("graph", "Graph"),
+        ("wiki", "Wiki"),
+        ("memory", "Memory"),
+        ("tasks", "Tasks"),
+        ("history", "History"),
+        ("tokens", "Tokens"),
+        ("chains", "Chains"),
+        ("workspaces", "Workspaces"),
+        ("health", "Health"),
+        ("embeddings", "Embeddings"),
+        ("settings", "Settings"),
+    ):
+        assert f'href="/{view_id}"' in bare.text, view_id
+        assert f"<span>{label}</span>" in bare.text, label
+    # The current view flags active.
+    assert 'href="/projects" class="active" aria-current="page"' in bare.text
+
+    selected = client.get("/projects", params={"store": _SW_KEY_A})
+    assert f'href="/graph?store={_SW_KEY_A}"' in selected.text
+
+
+def test_sidebar_collapse_button_and_prepaint_script(tmp_path, monkeypatch):
+    """The collapse toggle ships in the sidebar foot, and base.html's head
+    carries the pre-paint script that re-applies the remembered state
+    (localStorage "cairn-sidebar") before the shell renders."""
+    client, _ = _switch_client(tmp_path, monkeypatch)
+
+    resp = client.get("/projects")
+    assert 'id="sidebar-collapse"' in resp.text
+    base = (_templates_dir() / "base.html").read_text(encoding="utf-8")
+    assert '"cairn-sidebar"' in base
+    # The theme script stays the FIRST head script (pinned separately).
+    assert base.index("cairn-theme") < base.index("cairn-sidebar")
+
+    import cairn.dashboard
+
+    shell_src = (
+        Path(cairn.dashboard.__file__).resolve().parent / "static" / "shell.js"
+    ).read_text(encoding="utf-8")
+    assert 'localStorage.setItem(\n        "cairn-sidebar"' in shell_src or (
+        '"cairn-sidebar"' in shell_src and "setAttribute" in shell_src
+    )
+
+
+def test_command_palette_seeds_views_and_workspaces(tmp_path, monkeypatch):
+    """The palette overlay and its JSON seed ride every page: the view
+    list carries store-qualified hrefs when a store is selected, the
+    workspace list mirrors the selector's populated options."""
+    client, home = _switch_client(tmp_path, monkeypatch)
+    (home / "workspaces.json").write_text(
+        json.dumps({"/workspaces/proj-alpha": _SW_KEY_A}), encoding="utf-8"
+    )
+
+    resp = client.get("/projects", params={"store": _SW_KEY_A})
+    assert resp.status_code == 200
+    assert 'id="palette-open"' in resp.text
+    assert 'id="palette"' in resp.text
+    assert 'id="palette-data"' in resp.text
+
+    seed = json.loads(
+        re.search(
+            r'<script id="palette-data" type="application/json">(.*?)</script>',
+            resp.text,
+            re.S,
+        ).group(1)
+    )
+    by_label = {v["label"]: v["href"] for v in seed["views"]}
+    assert len(by_label) == 12
+    assert by_label["Graph"] == f"/graph?store={_SW_KEY_A}"
+    assert [w["key"] for w in seed["workspaces"]] == [_SW_KEY_A, _SW_KEY_B]
+
+
+def test_command_palette_js_contract_is_pinned_at_source_level():
+    """The palette reuses /graph/suggest with the store param guarded from
+    the current URL, and switches workspaces through the same URL-rewrite
+    behavior as the selector."""
+    import cairn.dashboard
+
+    src = (
+        Path(cairn.dashboard.__file__).resolve().parent / "static" / "shell.js"
+    ).read_text(encoding="utf-8")
+    assert "/graph/suggest?name=" in src
+    assert 'searchParams.get("store")' in src
+    assert "metaKey" in src  # Cmd/Ctrl+K opens
+    assert "keyCode" not in src  # key names, not deprecated codes
+
+
+# ---------------------------------------------------------------------------
 # Mixed-source usage (cli-usage-recording FR-002, TC-003 / TC-004): CLI
 # invocations land in tool_metrics as source='cli' rows named 'cli:<command>'
 # beside source='mcp' tool rows (cli_metrics stamps 'cli'; MCP rows ride the

--- a/tests/test_dashboard_app.py
+++ b/tests/test_dashboard_app.py
@@ -2647,6 +2647,54 @@ def test_graph_page_carries_the_selection_to_app_js(tmp_path, monkeypatch):
 
 
 # ---------------------------------------------------------------------------
+# Forms keep the selected store (FR-003 follow-up): GET filter forms drop
+# the action URL's query string on submit, and the settings POST actions
+# carried no store at all -- so applying a filter or saving settings on a
+# selected store silently reverted to the launch store one hop later
+# (rescued by the stickiness redirect, and for POSTs landing back on a
+# POST-only route path, not rescued at all). The fix: every form carries a
+# hidden store input, and settings_save resolves the body store through
+# the same validation seam.
+# ---------------------------------------------------------------------------
+
+
+def test_filter_forms_carry_the_selected_store_as_a_hidden_input(
+    tmp_path, monkeypatch
+):
+    """The history/tasks/graph filter forms and both settings forms render
+    the hidden store input on a selected store, and never on the launch
+    store (bare pages stay byte-identical)."""
+    client, _ = _switch_client(tmp_path, monkeypatch)
+
+    for path in ("/history", "/tasks", "/graph", "/settings"):
+        selected = client.get(path, params={"store": _SW_KEY_A})
+        assert selected.status_code == 200, path
+        assert (
+            f'<input type="hidden" name="store" value="{_SW_KEY_A}">'
+            in selected.text
+        ), path
+        bare = client.get(path)
+        assert '<input type="hidden" name="store"' not in bare.text, path
+
+
+def test_settings_save_keeps_the_selected_store(tmp_path, monkeypatch):
+    """settings_save reads the store from the POST body (a form POST drops
+    the query string) through the same validation seam and re-renders with
+    the selection riding the nav links. An invalid knob forces the
+    refusal re-render, proving the store survived without writing config."""
+    client, _ = _switch_client(tmp_path, monkeypatch)
+
+    resp = client.post(
+        "/settings/save",
+        data={"store": _SW_KEY_A, "CAIRN_EMBED_TIMEOUT": "not-a-number"},
+    )
+
+    assert resp.status_code == 400
+    assert "Refused" in resp.text
+    assert f'href="/projects?store={_SW_KEY_A}"' in resp.text
+
+
+# ---------------------------------------------------------------------------
 # Mixed-source usage (cli-usage-recording FR-002, TC-003 / TC-004): CLI
 # invocations land in tool_metrics as source='cli' rows named 'cli:<command>'
 # beside source='mcp' tool rows (cli_metrics stamps 'cli'; MCP rows ride the

--- a/tests/test_dashboard_app.py
+++ b/tests/test_dashboard_app.py
@@ -2695,6 +2695,95 @@ def test_settings_save_keeps_the_selected_store(tmp_path, monkeypatch):
 
 
 # ---------------------------------------------------------------------------
+# Global workspace selector (topbar): server-rendered on every view from
+# enumerate_stores (populated only, never probed), labels from the
+# registry path. Switching is shell.js rewriting ?store= on the current
+# URL and reloading — the browser-side contract is pinned at the source
+# level, like the app.js fetch builders.
+# ---------------------------------------------------------------------------
+
+_DASH_VIEWS = (
+    "/",
+    "/workspaces",
+    "/projects",
+    "/graph",
+    "/history",
+    "/tokens",
+    "/chains",
+    "/health",
+    "/memory",
+    "/wiki",
+    "/tasks",
+    "/embeddings",
+    "/settings",
+)
+
+
+def test_workspace_selector_renders_on_every_view(tmp_path, monkeypatch):
+    """The selector and its script ride the shell: present on every view,
+    on the launch store and a selected store alike."""
+    client, _ = _switch_client(tmp_path, monkeypatch)
+
+    for path in _DASH_VIEWS:
+        resp = client.get(path)
+        assert resp.status_code == 200, path
+        assert 'id="store-select"' in resp.text, path
+        assert "/static/shell.js" in resp.text, path
+
+
+def test_workspace_selector_lists_populated_stores_only(tmp_path, monkeypatch):
+    """Options are the populated stores — never the empty-state dir or an
+    unknown key — labeled by the registered workspace path's basename,
+    with the raw key as the orphan-store fallback."""
+    client, home = _switch_client(tmp_path, monkeypatch)
+    (home / "workspaces.json").write_text(
+        json.dumps({"/workspaces/proj-alpha": _SW_KEY_A}), encoding="utf-8"
+    )
+
+    resp = client.get("/projects")
+
+    assert resp.status_code == 200
+    assert f'<option value="{_SW_KEY_A}"' in resp.text
+    assert ">proj-alpha</option>" in resp.text
+    # Orphan store B (on disk, no registry entry): the key is the label.
+    assert f'<option value="{_SW_KEY_B}">{_SW_KEY_B}</option>' in resp.text
+    # Empty-state and unknown keys never appear as switch targets.
+    assert f'<option value="{_SW_KEY_EMPTY}"' not in resp.text
+    assert f'<option value="{_SW_KEY_UNKNOWN}"' not in resp.text
+    # The registry path rides the option as its tooltip.
+    assert 'title="/workspaces/proj-alpha' in resp.text
+    # The launch store is always reachable as the empty-value option.
+    assert "<option value=\"\">Launch workspace</option>" in resp.text
+
+
+def test_workspace_selector_marks_the_selected_store(tmp_path, monkeypatch):
+    client, _ = _switch_client(tmp_path, monkeypatch)
+
+    resp = client.get("/projects", params={"store": _SW_KEY_A})
+
+    assert (
+        f'<option value="{_SW_KEY_A}" selected' in resp.text
+    )
+    assert f'<option value="{_SW_KEY_B}" selected' not in resp.text
+
+
+def test_shell_js_switch_contract_is_pinned_at_source_level():
+    """The switch behavior, source-pinned like the app.js fetch builders:
+    rewrite the store param on the current URL (stay on the tab), and
+    clear the remembered store when returning to the launch store — or
+    the stickiness script would bounce the bare URL right back."""
+    import cairn.dashboard
+
+    src = (
+        Path(cairn.dashboard.__file__).resolve().parent / "static" / "shell.js"
+    ).read_text(encoding="utf-8")
+    assert 'getElementById("store-select")' in src
+    assert 'searchParams.set("store"' in src
+    assert 'searchParams.delete("store"' in src
+    assert 'localStorage.removeItem("cairn-store")' in src
+
+
+# ---------------------------------------------------------------------------
 # Mixed-source usage (cli-usage-recording FR-002, TC-003 / TC-004): CLI
 # invocations land in tool_metrics as source='cli' rows named 'cli:<command>'
 # beside source='mcp' tool rows (cli_metrics stamps 'cli'; MCP rows ride the

--- a/tests/test_dashboard_data.py
+++ b/tests/test_dashboard_data.py
@@ -2771,6 +2771,63 @@ def test_get_wiki_page_missing_page_or_dir_returns_none(tmp_path):
     assert get_wiki_page(str(tmp_path / "nope"), "overview") is None
 
 
+def test_get_wiki_page_builds_ref_map_from_sources_and_seeds(tmp_path):
+    """ref_hrefs maps the page's vouched symbols (frontmatter sources +
+    plan seeds) to graph deep links, store riding last; the body's
+    backticked spans linkify through the map while unmapped spans stay
+    plain code. toc carries the h2/h3 outline with matching anchors."""
+    from cairn.dashboard.data import get_wiki_page
+    from cairn.okf.bundle import OKFBundle
+    from cairn.okf.concept import OKFConcept
+
+    kdir = tmp_path / "knowledge"
+    body = (
+        "## How it works\n"
+        "\n"
+        "Calls `demo_main` on startup; see also `plain_word`.\n"
+    )
+    bundle = OKFBundle(str(kdir))
+    bundle.write_concept(
+        OKFConcept(
+            type="Wiki-Article",
+            title="Wiki: overview",
+            description="Wiki article for demo/overview",
+            resource="overview",
+            tags=["demo", "wiki"],
+            timestamp="2026-08-30T10:00:00Z",
+            concept_id="wiki/pages/demo/overview",
+            sources=_WIKI_SOURCES,
+            body=body,
+            extensions={"page_id": "overview", "input_hash": "hash-overview"},
+        )
+    )
+    _write_manifest(
+        kdir,
+        {
+            "demo/overview": _manifest_row(
+                _plan_entry("overview", "demo architecture overview"),
+                task_id="task-overview",
+                state="promoted",
+            )
+        },
+    )
+
+    page = get_wiki_page(str(kdir), "overview", store_key="ab12")
+
+    assert page["ref_hrefs"] == {
+        "demo_main": "/graph?scope=symbol&focus=demo_main&store=ab12"
+    }
+    assert (
+        '<a class="code-ref" href="/graph?scope=symbol&amp;focus=demo_main'
+        '&amp;store=ab12"><code>demo_main</code></a>' in page["html"]
+    )
+    assert "<code>plain_word</code>" in page["html"]
+    assert page["toc"] == [
+        {"level": 2, "text": "How it works", "anchor": "how-it-works"}
+    ]
+    assert '<h2 id="how-it-works">' in page["html"]
+
+
 # ---------------------------------------------------------------------------
 # Wiki staleness (FR-007 / D-020): recorded sha (concept extensions, manifest
 # row fallback) vs the workspace HEAD, as fresh/stale/unknown.

--- a/tests/test_dashboard_data.py
+++ b/tests/test_dashboard_data.py
@@ -2828,6 +2828,48 @@ def test_get_wiki_page_builds_ref_map_from_sources_and_seeds(tmp_path):
     assert '<h2 id="how-it-works">' in page["html"]
 
 
+def test_get_wiki_page_ref_map_keys_match_escaped_span_text(tmp_path):
+    """The renderer looks spans up post-escape, so a vouched symbol
+    containing &amp;-escapable characters (&, <) must key the map by its
+    escaped form or its backticked mentions silently stay plain code."""
+    from cairn.dashboard.data import get_wiki_page
+    from cairn.okf.bundle import OKFBundle
+    from cairn.okf.concept import OKFConcept
+
+    kdir = tmp_path / "knowledge"
+    bundle = OKFBundle(str(kdir))
+    bundle.write_concept(
+        OKFConcept(
+            type="Wiki-Article",
+            title="Wiki: overview",
+            description="Wiki article for demo/overview",
+            resource="overview",
+            tags=["demo", "wiki"],
+            timestamp="2026-09-02T10:00:00Z",
+            concept_id="wiki/pages/demo/overview",
+            sources=[{"symbol": "operator&"}],
+            body="The `operator&` helper.\n",
+            extensions={"page_id": "overview", "input_hash": "hash-overview"},
+        )
+    )
+    _write_manifest(
+        kdir,
+        {
+            "demo/overview": _manifest_row(
+                _plan_entry("overview", "demo architecture overview"),
+                task_id="task-overview",
+                state="promoted",
+            )
+        },
+    )
+
+    page = get_wiki_page(str(kdir), "overview")
+
+    assert "operator&amp;" in page["ref_hrefs"]
+    assert '<a class="code-ref"' in page["html"]
+    assert "operator&amp;</code></a>" in page["html"]
+
+
 # ---------------------------------------------------------------------------
 # Wiki staleness (FR-007 / D-020): recorded sha (concept extensions, manifest
 # row fallback) vs the workspace HEAD, as fresh/stale/unknown.

--- a/tests/test_dashboard_shell.py
+++ b/tests/test_dashboard_shell.py
@@ -1,0 +1,104 @@
+"""Unit tests for the dashboard shell context (cairn.dashboard.shell).
+
+Pure-function tests, no HTTP: the nav-as-data contract (sidebar and
+palette render from one source, hrefs ride the store like the old
+hand-written anchors) and the workspace label policy.
+"""
+
+from cairn.dashboard.shell import (
+    NAV_LABELS,
+    NAV_SECTIONS,
+    shell_context,
+    workspace_label,
+)
+
+
+def _stores():
+    return [
+        {"key": "aaaaaaaaaaaaaaaa", "path": "/workspaces/alpha", "state": "populated"},
+        {"key": "bbbbbbbbbbbbbbbb", "path": None, "state": "populated"},
+        {"key": "cccccccccccccccc", "path": "/workspaces/empty-one", "state": "empty"},
+        {"key": "dddddddddddddddd", "path": "/workspaces/gone", "state": "missing"},
+    ]
+
+
+def test_workspace_label_prefers_registered_path_basename():
+    assert workspace_label("/workspaces/alpha", "aaaaaaaaaaaaaaaa") == "alpha"
+    # Trailing slash, deep paths, root-only paths.
+    assert workspace_label("/workspaces/alpha/", "k") == "alpha"
+    assert workspace_label("/a/b/c/proj", "k") == "proj"
+    assert workspace_label("", "bbbbbbbbbbbbbbbb") == "bbbbbbbbbbbbbbbb"
+    assert workspace_label(None, "bbbbbbbbbbbbbbbb") == "bbbbbbbbbbbbbbbb"
+    # A path that is only slashes has no basename: the key stands in.
+    assert workspace_label("/", "k") == "k"
+
+
+def test_nav_sections_cover_every_view_exactly_once():
+    ids = [v for _, views in NAV_SECTIONS for v in views]
+    assert sorted(ids) == sorted(NAV_LABELS)
+    assert len(ids) == len(set(ids)) == 12
+
+
+def test_shell_context_groups_nav_and_flags_active_by_path():
+    ctx = shell_context(_stores(), "", "/graph")
+
+    labels = [s["label"] for s in ctx["nav"]["sections"]]
+    # Workspaces leads ungrouped (FR-001's overview-first contract), then
+    # the scoped groups.
+    assert labels == [None, "Explore", "Knowledge", "Activity", "System"]
+
+    graph = ctx["nav"]["sections"][1]["items"][1]
+    assert graph == {
+        "id": "graph",
+        "label": "Graph",
+        "href": "/graph",
+        "active": True,
+    }
+    # Exactly one active item, and only for the matching path prefix.
+    active = [
+        item
+        for section in ctx["nav"]["sections"]
+        for item in section["items"]
+        if item["active"]
+    ]
+    assert [item["id"] for item in active] == ["graph"]
+
+    # A wiki detail path still flags the wiki item (startswith, the old
+    # hand-written rule).
+    ctx = shell_context(_stores(), "", "/wiki/demo/overview")
+    active = [
+        item
+        for section in ctx["nav"]["sections"]
+        for item in section["items"]
+        if item["active"]
+    ]
+    assert [item["id"] for item in active] == ["wiki"]
+
+
+def test_shell_context_hrefs_ride_the_selected_store():
+    ctx = shell_context(_stores(), "aaaaaaaaaaaaaaaa", "/projects")
+
+    graph = ctx["nav"]["sections"][1]["items"][1]
+    assert graph["href"] == "/graph?store=aaaaaaaaaaaaaaaa"
+    # The palette's view list carries the same store-carrying hrefs.
+    palette_graph = next(v for v in ctx["palette"]["views"] if v["label"] == "Graph")
+    assert palette_graph["href"] == "/graph?store=aaaaaaaaaaaaaaaa"
+
+
+def test_shell_context_palette_lists_populated_workspaces_only():
+    ctx = shell_context(_stores(), "", "/")
+
+    keys = [w["key"] for w in ctx["palette"]["workspaces"]]
+    assert keys == ["aaaaaaaaaaaaaaaa", "bbbbbbbbbbbbbbbb"]  # populated only
+    labels = [w["label"] for w in ctx["palette"]["workspaces"]]
+    assert labels == ["alpha", "bbbbbbbbbbbbbbbb"]  # basename, key fallback
+
+
+def test_shell_context_selector_lists_populated_stores_only():
+    ctx = shell_context(_stores(), "bbbbbbbbbbbbbbbb", "/")
+
+    assert ctx["selector"]["selected"] == "bbbbbbbbbbbbbbbb"
+    assert [o["key"] for o in ctx["selector"]["options"]] == [
+        "aaaaaaaaaaaaaaaa",
+        "bbbbbbbbbbbbbbbb",
+    ]

--- a/tests/test_dashboard_workspaces.py
+++ b/tests/test_dashboard_workspaces.py
@@ -44,6 +44,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import shutil
 import time
 from pathlib import Path
@@ -358,3 +359,50 @@ def test_base_template_carries_store_stickiness_script(tmp_path):
     assert "localStorage.setItem" in block  # ...is remembered
     assert "localStorage.getItem" in block  # a bare visit...
     assert "location.replace" in block  # ...restores it
+
+
+def test_stickiness_script_only_redirects_to_still_valid_stores(
+    tmp_path, monkeypatch
+):
+    """A remembered key that no longer names a populated store (the
+    workspace was deleted) must not poison every future visit with the
+    missing-DB page: the server renders the valid populated key set on
+    the stickiness script's own tag (data-valid-stores), the script
+    redirects only to members, and a stale key is forgotten so the
+    launch store serves."""
+    pytest.importorskip("httpx")
+    from starlette.testclient import TestClient
+
+    from cairn import paths
+    from cairn.dashboard.app import create_app
+    from tests.test_dashboard_app import _seed_switch_store
+    from tests.test_dashboard_app import _SW_KEY_A
+
+    home = tmp_path / "cairn-home"
+    home.mkdir()
+    _seed_switch_store(
+        home / _SW_KEY_A / ".kg", "storeA", "store_a_tool",
+        "2026-09-01T07:00:00Z", calls=1,
+    )
+    monkeypatch.setattr(paths, "CAIRN_HOME", home)
+    client = TestClient(
+        create_app(
+            db_path=str(tmp_path / "dash.db"),
+            knowledge_dir=str(tmp_path / "missing"),
+        )
+    )
+
+    resp = client.get("/")
+
+    assert resp.status_code == 200
+    # The valid set rides the stickiness script's tag: populated keys
+    # only, in a single-quoted attribute (tojson escapes ' but not ").
+    attr = re.search(r"data-valid-stores='([^']*)'", resp.text)
+    assert attr is not None
+    assert json.loads(attr.group(1)) == [_SW_KEY_A]
+    # The guard reads the attribute and drops stale keys.
+    script_start = resp.text.index("cairn-store")
+    block = resp.text[script_start : resp.text.index("</script>", script_start)]
+    assert "data-valid-stores" in block
+    assert "JSON.parse" in block
+    assert "localStorage.removeItem(STORAGE_KEY)" in block

--- a/uv.lock
+++ b/uv.lock
@@ -202,7 +202,7 @@ filecache = [
 
 [[package]]
 name = "cairn-intel"
-version = "0.16.3"
+version = "0.17.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

The dashboard gets a modern shell: a **global workspace selector** in the topbar (every view follows the selection), a **Ctrl/Cmd+K command palette** (views, workspaces, live symbol search), a **grouped collapsible sidebar**, the **"Terrain" visual redesign** (warm sandstone light / ink-brown dark / burnt-amber accent — same token names, so the pinned theme contract holds), and a **full wiki navigation package** (repo-qualified URLs fixing the multi-repo collision bug, grouped catalog with filters + search, breadcrumbs, in-page TOCs, prev/next, markdown links under a scheme allowlist, and graph cross-links for refs the page itself vouches for). Along the way: forms stop silently dropping the selected store (filter Applies and settings saves reverted one hop later; the POST landings could even 405), and a remembered-but-deleted workspace no longer dead-ends every visit.

## Change type

- [x] Feature / improvement
- [x] Bugfix
- [ ] Refactor (no behavior change)
- [x] Docs / chore / CI

## Audit checklist

Author — confirm before requesting review (procedure: `docs/review-checklist.md`):

- [x] **Blast radius checked** — all changed symbols (`get_wiki_pages`, `get_wiki_page`, `resolve_selection`, `render_markdown*`, new `shell.py`) have zero callers outside the dashboard package (grep-verified; signature changes are additive with defaults). `cairn update` ran; the incremental indexer reported 0 reindexed files for these commits, so blast radius was verified by grep + the full dashboard suite instead of `impact_analysis`.
- [x] **Layering respected** — new pure module `shell.py` beside `data.py` (no server-stack imports, pinned by a new subprocess test); `markdown.py` stays stdlib-only; `app.js` is untouched (its source pins pass unmodified).
- [x] **Graph updated** — `cairn update` ran (see caveat above).
- [x] **Memory recorded** — mistake (escape-first renderers must neutralize quotes at attribute emission) + decision (shell architecture / vouched-refs linking) recorded via `cairn memory record`.
- [x] **Fallback/perf paths** — no fallback/perf path altered; `enumerate_stores` per render is stat-only (never `probe_stores`); `test_dashboard_scale.py` green.
- [x] **Tests** — 258 dashboard tests green (all 9 `test_dashboard_*` files + new `test_dashboard_shell.py`); new tests hermetic (tmp-path stores, monkeypatched `paths.CAIRN_HOME`); JS pinned via source-string assertions per repo convention.
- [x] **CHANGELOG** — `[Unreleased]` entries added (Added ×2, Changed, Fixed).
- [x] **Gates green** — `pre-commit run --all-files` clean on every commit; conventional commits throughout.

## Blast-radius note

No external consumers: `get_wiki_page`/`get_wiki_pages`/`resolve_selection` are dashboard-internal (additive optional params only). Deliberate pinned-contract updates: `/wiki/{page_id}` pins moved to repo-qualified URLs (legacy URL kept as a 307 redirect, store carried); every other pin (theme contract, stickiness markers, app.js source pins, nav/launcher regexes, FR-001 workspaces-first nav) passes **unmodified**.

## Verification

- `uv run --extra dev pytest tests/test_dashboard_*.py` → **258 passed**.
- Live browser pass against a two-store demo home (screenshots in the PR conversation): landing, wiki catalog (grouped + filters), wiki article (breadcrumb, TOC rail, rendered links, live mermaid, prev/next, linkified sources), open command palette (views + workspaces rows), light theme, and the collapsed icon rail.
- Review: three parallel review agents (simplicity/DRY, correctness/security, conventions) — both P1s (markdown attribute injection via quote in link target; settings POST landings bouncing to 405) plus a P2 (stale remembered store dead-end) and all simplification findings fixed in a04ddad with regression tests.