### PR TITLE
fix(dashboard): align form controls and stabilize table columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 > releases will be appended here incrementally.
 
 
+## [Unreleased]
+
+### Fixed
+- Dashboard alignment: every `.graph-controls` row (graph filter bar,
+  settings embedding config, history/tasks/wiki filters) now renders on
+  one baseline — selects, text/password/number inputs, and submit buttons
+  share a fixed control height (their differing intrinsic widget heights
+  previously sat raggedly under the rows' bottom alignment), checkbox
+  toggles render as one centered line instead of stacking the checkbox
+  above its caption, and inline status chips (env-pin markers, the API-key
+  state) meet the same bottom line as the controls they annotate. Data
+  tables no longer collapse under width pressure: timestamp cells hold
+  one line instead of wrapping mid-string at their hyphens, and long-ID
+  `code` chips (memory IDs, history sessions, task IDs/resources) cap to
+  one ellipsized line with the full value on the `title` tooltip instead
+  of being squeezed to a one-glyph sliver by the auto table layout.
+
+
 ## [0.17.0] - 2026-09-02
 
 ### Added

--- a/src/cairn/dashboard/static/app.css
+++ b/src/cairn/dashboard/static/app.css
@@ -58,6 +58,7 @@
   --radius-s: 8px;
   --radius: 12px;
   --radius-l: 16px;
+  --control-h: 38px;
   --shadow-1: 0 1px 2px var(--shadow);
   --shadow-2: 0 12px 32px -16px var(--shadow);
   --shadow-3: 0 24px 64px -24px var(--shadow);
@@ -609,10 +610,15 @@ body.app-shell {
   letter-spacing: 0.07em;
 }
 
+/* One fixed row height for every control: selects, text inputs, and
+   buttons carry different intrinsic widget heights, which bottom-aligned
+   rows turn into ragged label baselines. */
 .graph-controls input[type="text"],
 .graph-controls input[type="number"],
+.graph-controls input[type="password"],
 .graph-controls select {
   min-width: 0;
+  height: var(--control-h);
   padding: 0.42rem 0.65rem;
   border: 1px solid var(--border);
   border-radius: var(--radius-s);
@@ -624,6 +630,45 @@ body.app-shell {
   transition: border-color 120ms ease;
 }
 
+.graph-controls input[type="number"] {
+  width: 7.5rem;
+}
+
+.graph-controls input[type="checkbox"] {
+  width: 15px;
+  height: 15px;
+  margin: 0;
+  accent-color: var(--accent);
+}
+
+/* Checkbox toggles share the control height and row direction so the box
+   centers against the neighboring inputs/buttons instead of stacking the
+   checkbox above its caption (column direction inherited from the label
+   rule above). */
+.graph-controls .graph-tests-toggle,
+.graph-controls .confirm-base-url {
+  flex-direction: row;
+  align-items: center;
+  height: var(--control-h);
+  gap: 0.45rem;
+}
+
+/* Bare inline items interleaved in the row (env-pin markers, the API-key
+   status chip) must meet the same bottom line as the controls they
+   annotate. */
+.graph-controls .env-pin,
+.graph-controls > .muted {
+  display: inline-flex;
+  align-items: center;
+  height: var(--control-h);
+  gap: 0.35rem;
+}
+
+.graph-controls .env-pin {
+  font-size: 0.78rem;
+  color: var(--muted);
+}
+
 .graph-controls input:focus,
 .graph-controls select:focus {
   outline: none;
@@ -632,7 +677,8 @@ body.app-shell {
 }
 
 .graph-controls button[type="submit"] {
-  padding: 0.45rem 1rem;
+  height: var(--control-h);
+  padding: 0 1.1rem;
   border: 0;
   border-radius: var(--radius-s);
   background: var(--accent);
@@ -919,6 +965,26 @@ td.num {
   text-align: right;
   font-variant-numeric: tabular-nums;
   white-space: nowrap;
+}
+
+/* Timestamp cells: ISO stamps break at their hyphens, so under width
+   pressure they wrap mid-string — hold them to one line. */
+.data-table td.ts {
+  white-space: nowrap;
+  font-variant-numeric: tabular-nums;
+}
+
+/* Long identifier chips (memory IDs): word-break on code collapses the
+   column's min-content width, so the auto table layout squeezes it to a
+   one-glyph sliver. Cap the chip to one ellipsized line; the full id
+   rides the title attribute. */
+.data-table td.cell-id code {
+  display: inline-block;
+  max-width: 34ch;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  vertical-align: bottom;
 }
 
 code {

--- a/src/cairn/dashboard/templates/history.html
+++ b/src/cairn/dashboard/templates/history.html
@@ -64,10 +64,10 @@
       {% for h in calls %}
       <tr>
         <td>{{ h.tool_name }}</td>
-        <td>{{ h.invoked_at | epoch }}</td>
+        <td class="ts">{{ h.invoked_at | epoch }}</td>
         <td class="num">{{ h.duration_ms | duration }}</td>
         <td><span class="badge badge-{{ h.status }}">{{ h.status }}</span></td>
-        <td><code>{{ links.view_link('chains', 'session', h.session_id, window) }}</code></td>
+        <td class="cell-id"><code title="{{ h.session_id }}">{{ links.view_link('chains', 'session', h.session_id, window) }}</code></td>
         <td>{{ h.source }}</td>
         <td class="num">{{ h | tokens }}</td>
         <td>{{ h.args_summary or "—" }}</td>

--- a/src/cairn/dashboard/templates/memory.html
+++ b/src/cairn/dashboard/templates/memory.html
@@ -21,8 +21,8 @@
         <td><span class="badge badge-{{ m.type }}">{{ m.type }}</span></td>
         <td>{{ m.title }}</td>
         <td>{{ m.tier or "—" }}</td>
-        <td>{{ m.timestamp or "—" }}</td>
-        <td><code>{{ m.id }}</code></td>
+        <td class="ts">{{ m.timestamp or "—" }}</td>
+        <td class="cell-id"><code title="{{ m.id }}">{{ m.id }}</code></td>
       </tr>
       {% endfor %}
     </tbody>

--- a/src/cairn/dashboard/templates/tasks.html
+++ b/src/cairn/dashboard/templates/tasks.html
@@ -33,14 +33,14 @@
     <tbody>
       {% for t in tasks %}
       <tr>
-        <td><code>{{ t.id }}</code></td>
+        <td class="cell-id"><code title="{{ t.id }}">{{ t.id }}</code></td>
         <td>{{ t.kind }}</td>
         <td><span class="badge badge-{{ t.status }}">{{ t.status }}</span></td>
-        <td><code>{{ t.resource }}</code></td>
+        <td class="cell-id"><code title="{{ t.resource }}">{{ t.resource }}</code></td>
         <td>{{ t.assigned_to or "—" }}</td>
-        <td>{{ t.created_at or "—" }}</td>
-        <td>{{ t.claimed_at or "—" }}</td>
-        <td>{{ t.completed_at or "—" }}</td>
+        <td class="ts">{{ t.created_at or "—" }}</td>
+        <td class="ts">{{ t.claimed_at or "—" }}</td>
+        <td class="ts">{{ t.completed_at or "—" }}</td>
       </tr>
       {% endfor %}
     </tbody>


### PR DESCRIPTION
## Summary

The dashboard's shared `.graph-controls` rows (graph filter bar, settings embedding config, history/tasks/wiki filters) rendered misaligned: selects, inputs, and buttons carry different intrinsic widget heights, so the rows' `align-items: flex-end` produced ragged label baselines (SCOPE/BACKEND labels sat lower than their neighbors), checkbox toggles stacked the checkbox above its caption, and inline chips floated loose. Separately, the Memory table's ID column collapsed to a one-glyph sliver (`word-break` on `code` gutted the column's min-content width under the auto table layout) and ISO timestamps wrapped mid-string at their hyphens. Fixes are CSS-first with targeted cell classes; verified pixel-wise (Graph/Settings/Memory) and via DOM geometry on every view.

## Change type

- [ ] Feature / improvement
- [x] Bugfix
- [ ] Refactor (no behavior change)
- [ ] Docs / chore / CI

## Audit checklist

Author — confirm before requesting review (procedure: `docs/review-checklist.md`):

- [x] **Blast radius checked** — CSS + 3 Jinja templates only; no Python symbols touched, so symbol-level `impact_analysis` is N/A. Selector reach audited across all 8 `.graph-controls` forms (the only direct-child `.muted` is settings.html:50's API-key chip); `td code` styling scoped to `.cell-id` cells only (workspaces/projects path chips untouched).
- [x] **Layering respected** — change confined to the dashboard presentation layer (static/app.css + templates); no boundary crossings; theme-variable contract (`tests/test_dashboard_theme.py` first-`:root` first-match) explicitly verified unaffected.
- [x] **Graph updated** — `cairn update` ran post-task (templates/CSS are non-symbol assets; graph content unaffected).
- [x] **Memory recorded** — `record_memory` captured the lesson (auto table layout + break-all code = column collapse class; fix pattern).
- [x] **Fallback/perf paths** — none altered (pure presentation CSS/markup).
- [x] **Tests** — `pytest tests/test_dashboard_app.py tests/test_dashboard_theme.py tests/test_dashboard_shell.py` → 147 passed (run after every edit wave). No new tests: markup additions are covered by existing route-content assertions; alignment itself is verified visually (below).
- [x] **CHANGELOG** — `[Unreleased]` → Fixed entry added.
- [x] **Gates green** — pre-commit all hooks passed; conventional title (`fix(dashboard): ...`); no new mypy/bandit surface (no Python changes).

## Blast-radius note

None — no public API or Python symbols touched. CSS additions are scoped under existing component classes (`.graph-controls`, `.data-table`); two new td-level classes (`ts`, `cell-id`) exist only in the three edited templates.

## Verification

- `uv run --extra dev pre-commit run --all-files` — all hooks passed.
- Dashboard test subset: **147 passed** (`test_dashboard_app.py` + `test_dashboard_theme.py` + `test_dashboard_shell.py`), re-run after each edit wave.
- Visual pass (dev server + in-app browser, dark theme, 1680px): Graph filter bar, Settings config rows, and Memory table screenshots confirmed aligned — labels share one baseline, select/inputs/checkbox/Apply share one height and center line; Memory RECORDED is single-line and IDs render as single-line ellipsized chips (full value on hover).
- DOM-geometry pass on History/Tasks/Wiki: every control measures exactly 38px tall with a single unique bottom edge shared by labels; timestamp cells measure exactly 1 rendered line box; history session chips 1 line (was 3 wrapped lines at 52px).
