### PR TITLE
feat(dashboard): add type categorization to the Memory view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Dashboard Memory view categorization: a Type filter pill row
+  (all · decision · pattern · mistake · workaround) above the table,
+  mirroring the Wiki catalog's state filter — `?type=` narrows the list
+  server-side before the newest-first limit applies, an
+  out-of-vocabulary value silently falls back to the unfiltered page,
+  the active pill renders highlighted, and the empty state names the
+  category when a filtered type has no records.
+
 ### Fixed
 - Dashboard alignment: every `.graph-controls` row (graph filter bar,
   settings embedding config, history/tasks/wiki filters) now renders on

--- a/src/cairn/dashboard/app.py
+++ b/src/cairn/dashboard/app.py
@@ -41,6 +41,10 @@ DEFAULT_PORT = 8765
 # llm.tasks Task.status vocabulary — the /tasks filter's allowed values.
 TASK_STATUSES = ("pending", "in-progress", "done", "failed")
 
+# Agent-memory type vocabulary (cairn memory record) — the /memory
+# filter's allowed values.
+MEMORY_TYPES = ("decision", "pattern", "mistake", "workaround")
+
 # Traffic-view time-window presets (FR-002) — the ``window`` param's
 # allowed values; "all" is the unbounded default.
 WINDOW_PRESETS = ("24h", "7d", "30d", "all")
@@ -685,14 +689,28 @@ def create_app(
         )
 
     def memory(request: Request) -> Response:
+        # Type filter, read like every other view's param: absent or blank
+        # means no filter; ``type`` outside MEMORY_TYPES falls back to no
+        # filter (silent fallback, matching the tasks/wiki filters).
+        memory_type = request.query_params.get("type", "all").strip() or "all"
+        if memory_type not in MEMORY_TYPES:
+            memory_type = "all"
         _, selected_knowledge, store_key = resolve_selection(
             request, db_path, knowledge_dir
         )
-        entries = get_recent_memories(selected_knowledge)
+        entries = get_recent_memories(
+            selected_knowledge,
+            memory_type=None if memory_type == "all" else memory_type,
+        )
         return render(
             request,
             "memory.html",
-            {"memories": entries, "store_key": store_key},
+            {
+                "memories": entries,
+                "memory_types": MEMORY_TYPES,
+                "memory_type": memory_type,
+                "store_key": store_key,
+            },
         )
 
     def tasks(request: Request) -> Response:

--- a/src/cairn/dashboard/data.py
+++ b/src/cairn/dashboard/data.py
@@ -590,11 +590,15 @@ def get_health(conn: sqlite3.Connection, db_path: Optional[str] = None) -> Dict:
     }
 
 
-def get_recent_memories(knowledge_dir: str, limit: int = 20) -> List[dict]:
+def get_recent_memories(
+    knowledge_dir: str, limit: int = 20, memory_type: Optional[str] = None
+) -> List[dict]:
     """Recent memories, newest-first, each with type and title (FR-009).
 
     Reads the OKF bundle's ``memory/`` namespace directly; an unreadable
-    concept file is skipped, never fatal.
+    concept file is skipped, never fatal. ``memory_type`` narrows to one
+    category (decision / pattern / mistake / workaround) before the limit
+    applies, so a filtered page still shows the newest of that type.
     """
     bundle = OKFBundle(knowledge_dir)
     entries: List[dict] = []
@@ -603,10 +607,13 @@ def get_recent_memories(knowledge_dir: str, limit: int = 20) -> List[dict]:
             concept = bundle.read_concept(cid)
         except Exception:
             continue
+        entry_type = concept.extensions.get("memory_type") or concept.type
+        if memory_type is not None and entry_type != memory_type:
+            continue
         entries.append(
             {
                 "id": cid,
-                "type": concept.extensions.get("memory_type") or concept.type,
+                "type": entry_type,
                 "title": concept.title or cid,
                 "tier": concept.extensions.get("memory_tier", ""),
                 "timestamp": concept.timestamp or "",

--- a/src/cairn/dashboard/static/app.css
+++ b/src/cairn/dashboard/static/app.css
@@ -1182,6 +1182,12 @@ code {
   background: var(--surface-2);
 }
 
+/* Memory view's type filter rides the window-control pills; same margin
+   as the wiki state filter so both sit identically above their tables. */
+.memory-type-filter {
+  margin: 0.45rem 0 0.2rem;
+}
+
 /* ---- Launcher (landing page) ---- */
 
 .launcher-grid {

--- a/src/cairn/dashboard/templates/memory.html
+++ b/src/cairn/dashboard/templates/memory.html
@@ -1,9 +1,19 @@
 {% extends "base.html" %}
+{% import "_links.html" as links with context %}
 {% block title %}Memory — Cairn Dashboard{% endblock %}
 {% block content %}
 <section class="panel">
   <h1>Memory</h1>
   <p class="muted">Recent memories from the knowledge bundle, newest first.</p>
+  {% if memories or memory_type != "all" %}
+  <p class="window-control memory-type-filter">
+    Type:
+    {%- for t in ["all"] + (memory_types | list) %}
+    {%- set q = {"type": t} if t != "all" else {} %}
+    {%- if not loop.first %} · {% endif %}{% if t == memory_type %}<strong>{{ t }}</strong>{% else %}<a href="{{ links.url('/memory', q) }}">{{ t }}</a>{% endif %}
+    {%- endfor %}
+  </p>
+  {% endif %}
   {% if memories %}
   <table class="data-table">
     <thead>
@@ -28,7 +38,7 @@
     </tbody>
   </table>
   {% else %}
-  <p class="empty-state">No memories recorded yet — capture one with <code>cairn memory record</code>.</p>
+  <p class="empty-state">{% if memory_type != "all" %}No {{ memory_type }} memories recorded.{% else %}No memories recorded yet — capture one with <code>cairn memory record</code>.{% endif %}</p>
   {% endif %}
 </section>
 {% endblock %}

--- a/tests/test_dashboard_app.py
+++ b/tests/test_dashboard_app.py
@@ -832,6 +832,26 @@ def test_memory_route_lists_memories_newest_first_with_type(tmp_path):
         assert f">{mtype}<" in resp.text
 
 
+def test_memory_route_type_filter(tmp_path):
+    """The type pills narrow to one memory category before the limit
+    applies; an out-of-vocabulary type falls back to the unfiltered page."""
+    kdir = tmp_path / "knowledge"
+    _seed_memories(kdir)
+    client = _panel_client(tmp_path, _graph_db_file(tmp_path, seed=False), str(kdir))
+
+    resp = client.get("/memory", params={"type": "mistake"})
+    assert resp.status_code == 200
+    assert "Skipped the fuzzy retry" in resp.text
+    assert "Use RRF fusion by default" not in resp.text
+    assert "Seeded-DB test convention" not in resp.text
+    assert "<strong>mistake</strong>" in resp.text  # active pill
+
+    resp = client.get("/memory", params={"type": "bogus"})
+    assert resp.status_code == 200
+    assert "Use RRF fusion by default" in resp.text  # fallback: all types
+    assert "<strong>all</strong>" in resp.text
+
+
 def test_memory_route_empty_knowledge_dir_renders_empty_state(tmp_path):
     client = _panel_client(
         tmp_path,


### PR DESCRIPTION
## Summary

Adds type categorization to the dashboard Memory view: a Type filter pill row (all · decision · pattern · mistake · workaround) above the table, mirroring the Wiki catalog's existing state-filter pattern. `?type=` narrows the list server-side before the newest-first limit applies.

## Change type

- [x] Feature / improvement
- [ ] Bugfix
- [ ] Refactor (no behavior change)
- [ ] Docs / chore / CI

## Audit checklist

Author — confirm before requesting review (procedure: `docs/review-checklist.md`):

- [x] **Blast radius checked** — one route handler (`memory`), one data function (`get_recent_memories`, new optional kwarg — default `None` keeps the existing behavior byte-identical for current callers), one template, one CSS rule, one new test. No public CLI/API surface touched.
- [x] **Layering respected** — follows the established route pattern (tasks `status`, wiki `state`): query param → validate against a module-level vocabulary (`MEMORY_TYPES`, placed beside `TASK_STATUSES`) → data-layer filter; template rides `links.url` so the selected store travels on pill hrefs.
- [x] **Graph updated** — `cairn update` ran post-task.
- [x] **Memory recorded** — no novel decision/pattern beyond reuse of the existing filter idiom (documented inline); nothing recorded.
- [x] **Fallback/perf paths** — none altered; the filter runs inside the existing single bundle pass (no second read).
- [x] **Tests** — new `test_memory_route_type_filter` covers filtered narrowing, the active-pill render, and the bogus-type fallback; full dashboard subset **148 passed** (`test_dashboard_app` + `_theme` + `_shell`).
- [x] **CHANGELOG** — `[Unreleased]` → Added entry added.
- [x] **Gates green** — pre-commit all hooks passed; conventional title (`feat(dashboard): ...`); no new mypy/bandit surface beyond the reviewed handler.

## Blast-radius note

`get_recent_memories` gained an optional trailing kwarg (`memory_type=None`) — existing positional callers (`app.py` memory route, tests) are unaffected. No other consumers (grep-verified).

## Verification

- `pytest tests/test_dashboard_app.py tests/test_dashboard_theme.py tests/test_dashboard_shell.py` → **148 passed**.
- Manual (dev server + browser, dark theme): clicking the **mistake** pill navigates to `/memory?type=mistake&store=…`, shows only mistake-type rows with the active pill highlighted; `?type=bogus` falls back to the unfiltered page with `all` active.
- Note for reviewers: this branch is based on `main` and is independent of #95; both edit the top of `CHANGELOG.md` (`[Unreleased]`), so whichever merges second needs a one-line rebase. The memory-table column fixes (td classes) live in #95 — that PR composes with this one, not conflicts.
