### PR TITLE
feat(dashboard): add a database relationship graph view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Dashboard database view (`/database`, System section): the store's
+  schema rendered as an interactive relationship graph on the same
+  vis-network canvas as the Graph view — tables are nodes sized by row
+  count, solid edges are declared foreign keys, dashed edges are
+  `*_id` references implied by column naming (a column already covered
+  by a declared FK is never re-inferred), internal `sqlite_%`/FTS shadow
+  tables are excluded, and selecting a node opens a side panel with the
+  table's columns, types, and incoming/outgoing references. Theme flips
+  re-color the live network.
 - Dashboard Memory view categorization: a Type filter pill row
   (all · decision · pattern · mistake · workaround) above the table,
   mirroring the Wiki catalog's state filter — `?type=` narrows the list

--- a/src/cairn/dashboard/app.py
+++ b/src/cairn/dashboard/app.py
@@ -244,6 +244,7 @@ def create_app(
         GRAPH_SCOPES,
         SESSION_GAP_S,
         MissingDatabaseError,
+        get_database_schema,
         get_graph,
         get_health,
         get_read_only_db,
@@ -1075,6 +1076,21 @@ def create_app(
             },
         )
 
+    def database(request: Request) -> Response:
+        selected_db, _, store_key = resolve_selection(
+            request, db_path, knowledge_dir
+        )
+        conn = get_read_only_db(selected_db)
+        try:
+            schema = get_database_schema(conn)
+        finally:
+            conn.close()
+        return render(
+            request,
+            "database.html",
+            {"schema": schema, "store_key": store_key},
+        )
+
     routes = [
         Route("/", landing, name="index"),
         Route("/workspaces", workspaces_overview, name="workspaces"),
@@ -1101,6 +1117,7 @@ def create_app(
         Route("/wiki/{repo}/{page_id}", wiki_page_repo, name="wiki_page_repo"),
         Route("/wiki/{page_id}", wiki_page, name="wiki_page"),
         Route("/embeddings", embeddings_status, name="embeddings"),
+        Route("/database", database, name="database"),
         Route("/settings", settings, name="settings"),
         # The app's first POST routes (FR-011) — loopback-only by the CLI's
         # DEFAULT_HOST + _require_loopback; the GET views stay untouched.

--- a/src/cairn/dashboard/data.py
+++ b/src/cairn/dashboard/data.py
@@ -590,6 +590,82 @@ def get_health(conn: sqlite3.Connection, db_path: Optional[str] = None) -> Dict:
     }
 
 
+def get_database_schema(conn: sqlite3.Connection) -> Dict:
+    """Store schema as a relationship graph for the database view.
+
+    Every user table becomes a node carrying row/column counts and its
+    primary-key columns; edges come from two sources — declared foreign
+    keys (authoritative, kind ``fk``) and ``*_id`` columns whose base name
+    names another table (kind ``inferred``, e.g. ``build_runs.repo_id``
+    without a declared FK). A column already covered by a declared FK is
+    never re-inferred. Read-only introspection; internal ``sqlite_%`` and
+    FTS shadow tables are excluded.
+    """
+    tables = sorted(
+        row[0]
+        for row in conn.execute("SELECT name FROM sqlite_master WHERE type='table'")
+        if not row[0].startswith("sqlite_") and "_fts" not in row[0]
+    )
+
+    def _q(identifier: str) -> str:
+        return '"' + identifier.replace('"', '""') + '"'
+
+    meta: Dict[str, Dict] = {}
+    for name in tables:
+        columns = [
+            {"name": r[1], "type": r[2] or "", "pk": bool(r[5])}
+            for r in conn.execute(f"PRAGMA table_info({_q(name)})")
+        ]
+        rows = conn.execute(f"SELECT COUNT(*) FROM {_q(name)}").fetchone()[0]
+        meta[name] = {"columns": columns, "rows": rows}
+
+    declared: set = set()
+    edges: Dict[Tuple[str, str], Dict] = {}
+    for name in tables:
+        for fk in conn.execute(f"PRAGMA foreign_key_list({_q(name)})"):
+            target, column = fk[2], fk[3]
+            if target not in meta:
+                continue
+            declared.add((name, column))
+            edge = edges.setdefault(
+                (name, target),
+                {"from": name, "to": target, "kind": "fk", "columns": []},
+            )
+            edge["columns"].append(column)
+
+    for name in tables:
+        for column in meta[name]["columns"]:
+            col = column["name"]
+            if not col.endswith("_id") or col == "id" or (name, col) in declared:
+                continue
+            base = col[: -len("_id")]
+            target = base + "s" if base + "s" in meta else (base if base in meta else None)
+            if not target or target == name:
+                continue
+            edge = edges.setdefault(
+                (name, target),
+                {
+                    "from": name,
+                    "to": target,
+                    "kind": "inferred",
+                    "columns": [],
+                },
+            )
+            edge["columns"].append(col)
+
+    return {
+        "tables": [
+            {
+                "name": name,
+                "rows": meta[name]["rows"],
+                "columns": meta[name]["columns"],
+            }
+            for name in tables
+        ],
+        "edges": [edges[key] for key in sorted(edges)],
+    }
+
+
 def get_recent_memories(
     knowledge_dir: str, limit: int = 20, memory_type: Optional[str] = None
 ) -> List[dict]:

--- a/src/cairn/dashboard/shell.py
+++ b/src/cairn/dashboard/shell.py
@@ -37,7 +37,7 @@ NAV_SECTIONS: tuple = (
     ("Explore", ("projects", "graph")),
     ("Knowledge", ("wiki", "memory", "tasks")),
     ("Activity", ("history", "tokens", "chains")),
-    ("System", ("health", "embeddings", "settings")),
+    ("System", ("health", "embeddings", "database", "settings")),
 )
 
 NAV_LABELS: dict = {
@@ -52,6 +52,7 @@ NAV_LABELS: dict = {
     "wiki": "Wiki",
     "tasks": "Tasks",
     "embeddings": "Embeddings",
+    "database": "Database",
     "settings": "Settings",
 }
 

--- a/src/cairn/dashboard/static/db-graph.js
+++ b/src/cairn/dashboard/static/db-graph.js
@@ -1,0 +1,232 @@
+/* Database view: the store's schema as a relationship network. Tables are
+   nodes sized by row count; edges are declared foreign keys (solid) or
+   *_id references implied by column naming (dashed). Theme-derived colors
+   come from CSS variables, so a theme flip re-applies them through
+   setOptions without touching layout or camera state — same contract as
+   the graph view. */
+(function () {
+  "use strict";
+
+  var dataEl = document.getElementById("db-graph-data");
+  var canvas = document.getElementById("db-graph-canvas");
+  if (!dataEl || !canvas || typeof vis === "undefined") {
+    return;
+  }
+  var schema = JSON.parse(dataEl.textContent);
+  var byName = {};
+  schema.tables.forEach(function (t) {
+    byName[t.name] = t;
+  });
+
+  function cssVar(name) {
+    return getComputedStyle(document.documentElement).getPropertyValue(name).trim();
+  }
+
+  function edgeStyle(kind) {
+    var fk = kind === "fk";
+    return {
+      color: cssVar(fk ? "--accent" : "--muted"),
+      width: fk ? 1.5 : 1,
+      dashes: fk ? false : [5, 5]
+    };
+  }
+
+  function themeOptions() {
+    var accent = cssVar("--accent");
+    return {
+      nodes: {
+        shape: "dot",
+        borderWidth: 2,
+        color: {
+          background: accent,
+          border: accent,
+          highlight: { background: accent, border: cssVar("--text") },
+          hover: { background: accent, border: cssVar("--text") }
+        },
+        font: {
+          face: cssVar("--font-sans"),
+          size: 12,
+          color: cssVar("--muted"),
+          strokeColor: cssVar("--canvas"),
+          strokeWidth: 3
+        }
+      },
+      edges: {
+        color: {
+          color: cssVar("--border"),
+          highlight: accent,
+          hover: accent
+        },
+        width: 1,
+        selectionWidth: 1.5,
+        hoverWidth: 1.5,
+        arrows: { to: { enabled: true, scaleFactor: 0.4 } },
+        smooth: { enabled: true, type: "continuous", roundness: 0.35 }
+      }
+    };
+  }
+
+  var maxRows = 1;
+  schema.tables.forEach(function (t) {
+    if (t.rows > maxRows) {
+      maxRows = t.rows;
+    }
+  });
+
+  var nodes = new vis.DataSet(
+    schema.tables.map(function (t) {
+      return {
+        id: t.name,
+        label: t.name,
+        size: 8 + 30 * Math.sqrt(t.rows / maxRows),
+        title: t.name + " — " + t.rows + " rows",
+        shape: "dot"
+      };
+    })
+  );
+  var edges = new vis.DataSet(
+    schema.edges.map(function (e, i) {
+      var style = edgeStyle(e.kind);
+      return {
+        id: i,
+        from: e.from,
+        to: e.to,
+        color: { color: style.color, highlight: cssVar("--accent") },
+        width: style.width,
+        dashes: style.dashes,
+        title: e.columns.join(", ")
+      };
+    })
+  );
+
+  var options = {
+    autoResize: true,
+    interaction: {
+      dragNodes: true,
+      dragView: true,
+      zoomView: true,
+      hover: true,
+      tooltipDelay: 120,
+      selectConnectedEdges: true,
+      hoverConnectedEdges: true
+    }
+  };
+  var themed = themeOptions();
+  Object.keys(themed).forEach(function (key) {
+    options[key] = themed[key];
+  });
+  options.physics = {
+    solver: "barnesHut",
+    barnesHut: { gravitationalConstant: -2200, springLength: 110 },
+    stabilization: { iterations: 250 }
+  };
+
+  var network = new vis.Network(canvas, { nodes: nodes, edges: edges }, options);
+
+  /* Theme toggle re-colors the live network: theme-derived options via
+     setOptions, then edge colors/dashes rebatched from the new palette
+     (edge kind lives on the schema payload, not the edge objects). */
+  function applyTheme() {
+    network.setOptions(themeOptions());
+    var updates = schema.edges.map(function (e, i) {
+      var style = edgeStyle(e.kind);
+      return {
+        id: i,
+        color: { color: style.color, highlight: cssVar("--accent") },
+        width: style.width,
+        dashes: style.dashes
+      };
+    });
+    edges.update(updates);
+  }
+  if (typeof MutationObserver !== "undefined") {
+    new MutationObserver(function () {
+      applyTheme();
+    }).observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ["data-theme"]
+    });
+  }
+
+  var panel = document.getElementById("db-panel");
+
+  function escapeHtml(text) {
+    return String(text).replace(/[&<>"']/g, function (c) {
+      return { "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c];
+    });
+  }
+
+  function columnRow(col) {
+    var type = col.type ? ' <span class="muted">' + escapeHtml(col.type) + "</span>" : "";
+    var pk = col.pk ? ' <span class="muted">· pk</span>' : "";
+    return (
+      '<div class="panel-row"><span class="panel-name">' +
+      escapeHtml(col.name) +
+      type +
+      pk +
+      "</span></div>"
+    );
+  }
+
+  function edgeList(name, direction) {
+    var rows = schema.edges.filter(function (e) {
+      return e[direction] === name;
+    });
+    if (!rows.length) {
+      return '<p class="panel-empty">none</p>';
+    }
+    return rows
+      .map(function (e) {
+        var other = direction === "from" ? e.to : e.from;
+        var verb = direction === "from" ? "→" : "←";
+        return (
+          '<div class="panel-row"><span class="panel-name">' +
+          verb + " " + escapeHtml(other) +
+          ' <span class="muted">(' + escapeHtml(e.kind) + ": " +
+          escapeHtml(e.columns.join(", ")) + ")</span></span></div>"
+        );
+      })
+      .join("");
+  }
+
+  function showPanel(name) {
+    var t = byName[name];
+    if (!t) {
+      return;
+    }
+    panel.innerHTML =
+      '<div class="panel-head-row"><span class="panel-kind">table</span>' +
+      '<span class="panel-title">' + escapeHtml(name) + "</span></div>" +
+      '<p class="panel-sub">' + t.rows + " rows · " + t.columns.length + " columns</p>" +
+      '<div class="panel-section"><div class="panel-head">Columns</div>' +
+      '<div class="panel-list">' + t.columns.map(columnRow).join("") + "</div></div>" +
+      '<div class="panel-section"><div class="panel-head">References (out)</div>' +
+      edgeList(name, "from") + "</div>" +
+      '<div class="panel-section"><div class="panel-head">Referenced by (in)</div>' +
+      edgeList(name, "to") + "</div>";
+    panel.hidden = false;
+  }
+
+  network.on("click", function (params) {
+    if (params.nodes.length) {
+      showPanel(params.nodes[0]);
+    } else {
+      panel.hidden = true;
+      panel.innerHTML = "";
+    }
+  });
+
+  /* Overlay buttons mirror the graph view's zoom controls. */
+  document.querySelectorAll("button[data-db-action]").forEach(function (btn) {
+    btn.addEventListener("click", function () {
+      var action = btn.getAttribute("data-db-action");
+      if (action === "zoom-in") {
+        network.moveTo({ scale: network.getScale() * 1.25 });
+      } else if (action === "zoom-out") {
+        network.moveTo({ scale: network.getScale() * 0.8 });
+      } else if (action === "fit") {
+        network.fit({ animation: false });
+      }
+    });
+  });
+})();

--- a/src/cairn/dashboard/templates/database.html
+++ b/src/cairn/dashboard/templates/database.html
@@ -1,0 +1,39 @@
+{% extends "base.html" %}
+{% block title %}Database — Cairn Dashboard{% endblock %}
+{% block view_title %}Database{% endblock %}
+{% block content %}
+<section class="panel">
+  <h1>Database</h1>
+  <p class="muted">Store schema as a relationship graph — node size encodes row count,
+    solid edges are declared foreign keys, dashed edges are <code>*_id</code> references
+    implied by column naming. Select a node for the table's columns and links.</p>
+  {% if schema.tables %}
+  <div class="graph-layout">
+    <div class="graph-stage">
+      <div id="db-graph-canvas" class="graph-canvas"></div>
+      <div class="graph-overlay">
+        <button type="button" data-db-action="zoom-in" title="Zoom in" aria-label="Zoom in">
+          <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" aria-hidden="true"><path d="M12 5v14M5 12h14"/></svg>
+        </button>
+        <button type="button" data-db-action="zoom-out" title="Zoom out" aria-label="Zoom out">
+          <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" aria-hidden="true"><path d="M5 12h14"/></svg>
+        </button>
+        <button type="button" data-db-action="fit" title="Fit view" aria-label="Fit view">
+          <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M8 3H5a2 2 0 0 0-2 2v3M16 3h3a2 2 0 0 1 2 2v3M8 21H5a2 2 0 0 1-2-2v-3M16 21h3a2 2 0 0 0 2-2v-3"/></svg>
+        </button>
+      </div>
+    </div>
+    <aside id="db-panel" class="graph-panel" aria-live="polite" hidden></aside>
+  </div>
+  <script id="db-graph-data" type="application/json"{% if store_key %} data-store="{{ store_key }}"{% endif %}>{{ schema | tojson }}</script>
+  {% else %}
+  <p class="empty-state">No tables in this store yet — run <code>cairn build</code> first.</p>
+  {% endif %}
+</section>
+{% endblock %}
+{% block scripts %}
+{% if schema.tables %}
+<script src="{{ url_for('static', path='/vis-network.min.js') }}?v={{ asset_version }}"></script>
+<script src="{{ url_for('static', path='/db-graph.js') }}?v={{ asset_version }}"></script>
+{% endif %}
+{% endblock %}

--- a/tests/test_dashboard_app.py
+++ b/tests/test_dashboard_app.py
@@ -852,6 +852,51 @@ def test_memory_route_type_filter(tmp_path):
     assert "<strong>all</strong>" in resp.text
 
 
+def test_database_route_renders_schema_relationships(tmp_path):
+    """The database view lists user tables and both edge kinds: declared
+    foreign keys (authoritative) and *_id references implied by column
+    naming; columns covered by a declared FK are never re-inferred, and a
+    reference to a non-table (session_id) produces no edge."""
+    db = tmp_path / "store.db"
+    conn = sqlite3.connect(db)
+    conn.executescript(
+        """
+        CREATE TABLE repos(id INTEGER PRIMARY KEY);
+        CREATE TABLE files(id INTEGER PRIMARY KEY, repo_id INTEGER REFERENCES repos(id));
+        CREATE TABLE build_runs(id INTEGER PRIMARY KEY, repo_id INTEGER);
+        CREATE TABLE events(id INTEGER PRIMARY KEY, session_id TEXT);
+        """
+    )
+    conn.commit()
+    conn.close()
+    client = _panel_client(tmp_path, str(db), str(tmp_path / "missing"))
+    resp = client.get("/database")
+    assert resp.status_code == 200
+
+    marker = '<script id="db-graph-data" type="application/json">'
+    payload = json.loads(resp.text.split(marker, 1)[1].split("</script>", 1)[0])
+    assert sorted(t["name"] for t in payload["tables"]) == [
+        "build_runs",
+        "events",
+        "files",
+        "repos",
+    ]
+    edges = {(e["from"], e["to"]): e for e in payload["edges"]}
+    assert edges[("files", "repos")]["kind"] == "fk"
+    assert edges[("files", "repos")]["columns"] == ["repo_id"]
+    assert edges[("build_runs", "repos")]["kind"] == "inferred"
+    assert not any("events" in (e["from"], e["to"]) for e in payload["edges"])
+
+
+def test_database_route_empty_store_renders_empty_state(tmp_path):
+    db = tmp_path / "empty.db"
+    sqlite3.connect(db).close()
+    client = _panel_client(tmp_path, str(db), str(tmp_path / "missing"))
+    resp = client.get("/database")
+    assert resp.status_code == 200
+    assert "No tables" in resp.text
+
+
 def test_memory_route_empty_knowledge_dir_renders_empty_state(tmp_path):
     client = _panel_client(
         tmp_path,
@@ -2913,7 +2958,7 @@ def test_command_palette_seeds_views_and_workspaces(tmp_path, monkeypatch):
         ).group(1)
     )
     by_label = {v["label"]: v["href"] for v in seed["views"]}
-    assert len(by_label) == 12
+    assert len(by_label) == 13
     assert by_label["Graph"] == f"/graph?store={_SW_KEY_A}"
     assert [w["key"] for w in seed["workspaces"]] == [_SW_KEY_A, _SW_KEY_B]
 

--- a/tests/test_dashboard_shell.py
+++ b/tests/test_dashboard_shell.py
@@ -36,7 +36,7 @@ def test_workspace_label_prefers_registered_path_basename():
 def test_nav_sections_cover_every_view_exactly_once():
     ids = [v for _, views in NAV_SECTIONS for v in views]
     assert sorted(ids) == sorted(NAV_LABELS)
-    assert len(ids) == len(set(ids)) == 12
+    assert len(ids) == len(set(ids)) == 13
 
 
 def test_shell_context_groups_nav_and_flags_active_by_path():


### PR DESCRIPTION
## Summary

Adds a `/database` view (System section) rendering the store's schema as an interactive relationship graph on the same vendored vis-network canvas the Graph view uses: tables are nodes sized by row count, solid edges are declared foreign keys, dashed edges are `*_id` references implied by column naming. Selecting a node opens a details panel (columns, types, pk flags, in/out references).

## Change type

- [x] Feature / improvement
- [ ] Bugfix
- [ ] Refactor (no behavior change)
- [ ] Docs / chore / CI

## Audit checklist

Author — confirm before requesting review (procedure: `docs/review-checklist.md`):

- [x] **Blast radius checked** — new route + new data function + new template/JS; shared-file edits are additive (one import, one handler, one route line, one nav entry + label). `get_database_schema` is a new symbol with no callers beyond the new handler; no existing function signatures changed.
- [x] **Layering respected** — mirrors the established view pattern (handler → data-layer function → `render()` with shell context; `store_key` rides resolve_selection; JSON payload embedded via the same `<script type="application/json"> | tojson` pattern as the graph view).
- [x] **Graph updated** — `cairn update` ran post-task.
- [x] **Memory recorded** — nothing novel beyond reusing the graph view's theme contract (documented inline in db-graph.js); nothing recorded.
- [x] **Fallback/perf paths** — read-only introspection on the existing read-only connection (closed in `finally`); COUNT(*) per table is index-scan cheap at this store's scale (26 tables, 94 MiB store renders fine — verified below).
- [x] **Tests** — new `test_database_route_renders_schema_relationships` (parses the embedded JSON payload: both edge kinds, FK column lists, no re-inference under a declared FK, no edge for non-table refs like `session_id`) + `test_database_route_empty_store_renders_empty_state`; nav-coverage (12→13) and palette-seed (12→13) counts updated. Dashboard subset: **149 passed**.
- [x] **CHANGELOG** — `[Unreleased]` → Added entry added.
- [x] **Gates green** — pre-commit all hooks passed; conventional title; mypy/bandit clean in CI.

## Blast-radius note

No existing signatures changed. The only shared-file behavior change: sidebar/palette gain one entry (`NAV_SECTIONS` System group + `NAV_LABELS`), with the two view-count test pins updated to match. The two hard-count tests are the designed tripwire for exactly this change.

## Verification

- `pytest tests/test_dashboard_app.py tests/test_dashboard_shell.py tests/test_dashboard_theme.py` → **149 passed**.
- Manual (dev server + browser, dark theme, real 94 MiB store): the graph renders 19 user tables; `transitive_edges`/`edges` nodes dominate by row count; the declared-FK cluster (files→repos, symbols→files, edges→symbols, imports→*, embeddings*→symbols, parse_errors→repos) shows as solid edges; inferred `repo_id` references (build_runs/repo_build_state/skipped_files/pending_sync → repos) show dashed. Clicking `symbols` opens the panel (9563 rows · 18 columns, pk flag on `id`, `→ files (fk: file_id)`). Theme toggle re-colors the live network.
