### PR TITLE
feat(dashboard): icon-only sidebar collapse and theme buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   one ellipsized line with the full value on the `title` tooltip instead
   of being squeezed to a one-glyph sliver by the auto table layout.
 
+### Changed
+- Dashboard sidebar: the collapse control and theme toggle are icon-only
+  square buttons — a chevron that flips with the collapse state, and a
+  sun/moon glyph showing the theme the button switches to (sun while
+  dark, moon while light). The visible text is gone; the accessible
+  name and tooltip state the action ("Switch to light theme" /
+  "Collapse sidebar") and stay in sync in both states.
 
 ## [0.17.0] - 2026-09-02
 

--- a/src/cairn/dashboard/static/app.css
+++ b/src/cairn/dashboard/static/app.css
@@ -116,7 +116,7 @@ body.app-shell {
   display: flex;
   flex-direction: column;
   gap: 0.25rem;
-  padding: 1rem 0.75rem;
+  padding: 1rem 0 0;
   background: var(--sidebar);
   border-right: 1px solid var(--border);
   overflow-y: auto;
@@ -201,10 +201,18 @@ body.app-shell {
 }
 
 .sidebar-foot {
+  /* Pinned to the rail's visible bottom: the nav outgrew short viewports
+     (13 items), and with the rail scrollable the footer buttons used to
+     end up below the fold. Sticky keeps them reachable without scrolling;
+     the fill + border cover nav rows scrolling underneath. */
+  position: sticky;
+  bottom: 0;
   margin-top: auto;
-  padding-top: 0.75rem;
+  padding: 0.75rem;
+  background: var(--sidebar);
   border-top: 1px solid var(--border);
   display: flex;
+  align-items: center;
   gap: 0.4rem;
 }
 
@@ -212,14 +220,14 @@ body.app-shell {
   flex: none;
   display: flex;
   align-items: center;
-  gap: 0.45rem;
-  padding: 0.42rem 0.65rem;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  padding: 0;
   border: 1px solid var(--border);
   border-radius: var(--radius-s);
   background: transparent;
   color: var(--muted);
-  font: inherit;
-  font-size: 0.9rem;
   cursor: pointer;
   transition: background 120ms ease, color 120ms ease;
 }
@@ -241,7 +249,6 @@ body.app-shell {
   html[data-sidebar="collapsed"] .brand span,
   html[data-sidebar="collapsed"] .nav-group-label,
   html[data-sidebar="collapsed"] .side-nav a span,
-  html[data-sidebar="collapsed"] .sidebar-collapse span,
   html[data-sidebar="collapsed"] .theme-toggle {
     display: none;
   }
@@ -491,16 +498,33 @@ body.app-shell {
 /* ---- Theme toggle ---- */
 
 .theme-toggle {
-  flex: 1;
-  padding: 0.42rem 0.65rem;
+  flex: none;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  padding: 0;
   border: 1px solid var(--border);
   border-radius: var(--radius-s);
   background: transparent;
   color: var(--muted);
-  font: inherit;
-  font-size: 0.9rem;
   cursor: pointer;
   transition: background 120ms ease, color 120ms ease;
+}
+
+/* The glyph shows the theme the button switches to: sun while dark,
+   moon while light — the accessible label states the same action. */
+.theme-toggle .icon-sun {
+  display: none;
+}
+
+[data-theme="dark"] .theme-toggle .icon-sun {
+  display: block;
+}
+
+[data-theme="dark"] .theme-toggle .icon-moon {
+  display: none;
 }
 
 .theme-toggle:hover,
@@ -1266,17 +1290,12 @@ code {
   }
 
   .sidebar-foot {
+    position: static;
     margin-top: 0;
     margin-left: auto;
-    padding-top: 0;
-    padding-left: 0.75rem;
+    padding: 0 0.75rem;
     border-top: 0;
     border-left: 1px solid var(--border);
-  }
-
-  .theme-toggle {
-    width: auto;
-    white-space: nowrap;
   }
 
   .topbar {

--- a/src/cairn/dashboard/static/shell.js
+++ b/src/cairn/dashboard/static/shell.js
@@ -62,10 +62,9 @@
       } catch (err) {
         /* storage unavailable: the choice lasts only for this page */
       }
-      button.setAttribute(
-        "aria-label",
-        collapsing ? "Expand sidebar" : "Collapse sidebar"
-      );
+      var label = collapsing ? "Expand sidebar" : "Collapse sidebar";
+      button.setAttribute("aria-label", label);
+      button.title = label;
     });
   })();
 

--- a/src/cairn/dashboard/templates/base.html
+++ b/src/cairn/dashboard/templates/base.html
@@ -27,7 +27,12 @@
         document.documentElement.dataset.theme = dark ? "dark" : "light";
         var toggle = document.getElementById("theme-toggle");
         if (toggle) {
-          toggle.textContent = dark ? "Light" : "Dark";
+          /* The button shows the icon of the theme it switches TO (sun in
+             dark, moon in light — CSS picks the glyph); the label states
+             the action for assistive tech. */
+          var label = dark ? "Switch to light theme" : "Switch to dark theme";
+          toggle.setAttribute("aria-label", label);
+          toggle.title = label;
         }
       }
       window.__cairnApplyTheme = applyTheme;
@@ -154,9 +159,11 @@
     <div class="sidebar-foot">
       <button type="button" id="sidebar-collapse" class="sidebar-collapse" aria-label="Collapse sidebar" title="Collapse sidebar">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m14 6-6 6 6 6"/></svg>
-        <span>Collapse</span>
       </button>
-      <button type="button" id="theme-toggle" class="theme-toggle">Theme</button>
+      <button type="button" id="theme-toggle" class="theme-toggle" aria-label="Switch theme" title="Switch theme">
+        <svg class="icon-sun" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" aria-hidden="true"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M6.34 17.66l-1.41 1.41M19.07 4.93l-1.41-1.41"/></svg>
+        <svg class="icon-moon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
+      </button>
     </div>
   </aside>
   <div class="app-body">


### PR DESCRIPTION
## Summary

The sidebar's collapse control and theme toggle become icon-only square buttons: a flipping chevron, and a sun/moon glyph that shows the theme the button switches to. Accessible names and tooltips state the action and stay in sync in both states. Also pins the sidebar footer to the rail's visible bottom — the thirteenth nav item (the database view) made the expanded nav outgrow common viewport heights, leaving the footer below the fold of the scrollable rail.

## Change type

- [x] Feature / improvement
- [ ] Bugfix
- [ ] Refactor (no behavior change)
- [ ] Docs / chore / CI

## Audit checklist

Author — confirm before requesting review (procedure: `docs/review-checklist.md`):

- [x] **Blast radius checked** — three files, all presentation: `base.html` (footer markup + the pre-paint script's label assignment), `app.css` (two button rules + sun/moon visibility + sticky footer), `shell.js` (title kept in sync with aria-label). No Python, no routes, no data.
- [x] **Layering respected** — theme icon visibility is CSS-driven from `data-theme` (same source the pre-paint script sets); the theme contract test's markers (storage/matchMedia/dataset.theme) are untouched.
- [x] **Graph updated** — `cairn update` ran post-task.
- [x] **Memory recorded** — no novel decision beyond the documented glyph convention (icon shows the target theme); inline comment covers it.
- [x] **Fallback/perf paths** — none altered.
- [x] **Tests** — dashboard subset **147 passed** (`test_dashboard_theme` still asserts the toggle id/class and the head-script contract, all preserved; no test pinned the old button text).
- [x] **CHANGELOG** — `[Unreleased]` → Changed entry added.
- [x] **Gates green** — pre-commit all hooks passed; conventional title.

## Blast-radius note

None — no Python or route changes. The `.theme-toggle` width override in the ≤920px media block was removed (obsolete for a fixed-size icon button); the collapsed-rail hide list drops the now-nonexistent `.sidebar-collapse span` selector.

## Verification

- `pytest tests/test_dashboard_app.py tests/test_dashboard_shell.py tests/test_dashboard_theme.py` → **147 passed**.
- Manual (dev server + browser): dark expanded shows chevron + **sun** squares; one click flips to light with a **moon**; collapsed rail shows the flipped chevron only (theme toggle stays hidden there, as before); accessible names verified live ("Switch to light theme" ↔ "Switch to dark theme", "Collapse sidebar" ↔ "Expand sidebar").
- Footer pin: at a 1680×**800** viewport the expanded nav scrolls while the footer stays visible at the rail bottom (was below the fold before the fix); restored to 1680×1000 + dark afterwards.
- Note for reviewers: independent of #95/#96/#97; only overlap is the `CHANGELOG.md` `[Unreleased]` section — whichever PR merges second needs a one-line rebase.
