### PR TITLE
chore(release): bump version to 0.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 > releases will be appended here incrementally.
 
 
-## [Unreleased]
+## [0.18.0] - 2026-09-02
 
 ### Added
 - Dashboard database view (`/database`, System section): the store's

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "cairn-intel"
-version = "0.17.0"
+version = "0.18.0"
 description = "Local codebase intelligence system: structural graph + compass + wiki + agent memory"
 readme = "README.md"
 license = "MIT"
@@ -232,7 +232,7 @@ select = ["F"]
 # The custom template (.cz_templates/keepachangelog.j2) renders that draft in
 # the existing `## [X.Y.Z] - YYYY-MM-DD` format rather than commitizen's
 # default `## X.Y.Z (YYYY-MM-DD)`.
-version = "0.17.0"
+version = "0.18.0"
 version_scheme = "pep440"
 tag_format = "v$version"
 update_changelog_on_bump = false

--- a/src/cairn/__init__.py
+++ b/src/cairn/__init__.py
@@ -1,3 +1,3 @@
 """Cairn: local codebase intelligence system."""
-__version__ = "0.17.0"
+__version__ = "0.18.0"
 __package_name__ = "cairn-intel"


### PR DESCRIPTION
## Summary

Finalizes the 0.18.0 release prep after the four dashboard PRs (#95 alignment fixes, #96 Memory type pills, #97 database relationship graph view, #98 icon-only sidebar buttons): commitizen-style version bump 0.17.0 → 0.18.0 (pyproject + `__init__.__version__`) and the `[Unreleased]` changelog section finalized as `[0.18.0] - 2026-09-02` (Added ×2 / Fixed / Changed).

## Change type
- [ ] Feature / improvement
- [ ] Bugfix
- [ ] Refactor (no behavior change)
- [x] Docs / chore / CI

## Audit checklist
- [x] **Blast radius checked** — version strings + changelog only; no code paths.
- [x] **Layering respected** — n/a (release chore).
- [x] **Graph updated** — `cairn update` runs post-merge.
- [x] **Memory recorded** — n/a.
- [x] **Fallback/perf paths** — none.
- [x] **Tests** — dashboard subset green on the merged stack (150 passed at #98); `import cairn` reports 0.18.0.
- [x] **CHANGELOG** — finalized for 0.18.0.
- [x] **Gates green** — pre-commit all hooks passed; conventional title.

## Blast-radius note
None — release metadata only. Tag (`v0.18.0`) and `make release`/PyPI publish deliberately NOT included; tag push happens on the owner's go.

## Verification
- `pre-commit run --all-files` passed; `cairn.__version__ == 0.18.0`; CHANGELOG carries all four merged changes under the dated 0.18.0 heading.