### PR TITLE
chore(deps): sync uv.lock to cairn-intel 0.18.0

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -202,7 +202,7 @@ filecache = [
 
 [[package]]
 name = "cairn-intel"
-version = "0.17.0"
+version = "0.18.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Follow-up to #99: `uv run` re-synced `uv.lock` after the version bump merged. Single version-pair change (cairn-intel 0.17.0 → 0.18.0), matching the 0.17.0 precedent (6984113). No code changes.