### PR TITLE
fix: scope compass generation per repo and hide sqlite-vec internals from the database view

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -112,6 +112,19 @@ checklist; `docs/review-checklist.md` is the procedure behind each box.
 Layers 0-1 (pre-commit + CI: tests, pip-audit, bandit, mypy, PR-title, dependency-review) are automated;
 this is the human/agent layer that catches what they can't.
 
+## Comment and doc style (mandatory, all files)
+Applies to code comments, docstrings, markdown, and CHANGELOG entries.
+- State behavior and contract only — what the code/doc is or does.
+- No decision logs: no rationale narratives, review findings, or
+  "why this changed" prose. Decisions go to cairn memory
+  (`record_memory`), never into comments.
+- No history: no dates, PR numbers, version references, "previously",
+  "reported bug", incident stories.
+- Short and precise; prefer numbered/bulleted lists over prose.
+- Anti-stale: no enumerations or examples that rot (line numbers,
+  version-specific names, workspace-specific paths) — reference the
+  code or a query instead.
+
 ## Tool Quirks (empirically verified)
 
 | Tool | Behavior | Workaround |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   pages once (the input-hash recipe now covers `source` and document
   seeds); in-flight legacy tasks complete normally.
 
+### Fixed
+- Compass generation in multi-repo workspaces: the critic's file-ref
+  check rejected backtick-quoted *directory* paths (`app/adk`,
+  `tests/unit`) as hallucinated — directories are never graph rows, they
+  exist only as prefixes of `files.path`, so `refs.file_exists` now also
+  matches segment-boundary directory prefixes and bridges repo-qualified
+  refs (`polaris-app/app/adk`) by re-validating the remainder within the
+  named repo (every shared consumer — critic, memory scoring, wiki
+  sources, task gate — inherits this via the one function, and LIKE
+  wildcards in refs are escaped). A bare module name (`app`) no longer
+  mixes same-named directories across repos into one compass: module
+  matching is segment-anchored (an unanchored `%app%` also matched
+  unrelated paths like `trapper/…`), a bare name resolves via the repos
+  that actually contain it and raises a clear "pass --repo" error when
+  ambiguous, cross-module-dependency sources are repo-scoped (a
+  same-named directory in another repo counts as a cross-module target,
+  with its repo-qualified label now critic-valid), and repo-prefixed
+  module paths (`polaris-app/app`) normalize to repo-relative.
+- Dashboard database view: stores with embeddings carry sqlite-vec
+  `vec0` virtual tables whose module is not loaded on the dashboard's
+  plain read-only connection — introspecting them crashed the whole view
+  with "no such module: vec0". The ANN internals (`vec_*`, `vecmv_*`,
+  and shadow tables) are excluded like the FTS shadows, and per-table
+  introspection is never fatal: a table whose module is unavailable is
+  skipped, not an error.
+
 ## [0.18.0] - 2026-09-02
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,9 +43,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   exist only as prefixes of `files.path`, so `refs.file_exists` now also
   matches segment-boundary directory prefixes and bridges repo-qualified
   refs (`polaris-app/app/adk`) by re-validating the remainder within the
-  named repo (every shared consumer — critic, memory scoring, wiki
-  sources, task gate — inherits this via the one function, and LIKE
-  wildcards in refs are escaped). A bare module name (`app`) no longer
+  named repo (every consumer — critic, memory scoring, wiki
+  sources/refine, task gate, workflow validation — inherits this via the
+  one function, and LIKE wildcards in refs are escaped). A bare module name (`app`) no longer
   mixes same-named directories across repos into one compass: module
   matching is segment-anchored (an unanchored `%app%` also matched
   unrelated paths like `trapper/…`), a bare name resolves via the repos
@@ -59,8 +59,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   plain read-only connection — introspecting them crashed the whole view
   with "no such module: vec0". The ANN internals (`vec_*`, `vecmv_*`,
   and shadow tables) are excluded like the FTS shadows, and per-table
-  introspection is never fatal: a table whose module is unavailable is
-  skipped, not an error.
+  introspection is never fatal: a table that cannot be introspected
+  (module unavailable, transient lock, ...) is skipped, not an error —
+  and every skip is reported (a one-line banner in the view) so the
+  omission stays observable.
 
 ## [0.18.0] - 2026-09-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   seeds); in-flight legacy tasks complete normally.
 
 ### Fixed
+- Server boot (`cairn serve` / MCP stdio): non-actionable third-party
+  output suppressed — HF Hub unauthenticated-request warnings, MCP
+  pre-initialization request warnings, model-loading progress bars.
+  Errors still surface.
 - Compass critic file refs (`refs.file_exists`):
   - directory paths resolve (`app/adk`): a directory is valid iff an
     indexed file lives under it

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,32 +37,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   seeds); in-flight legacy tasks complete normally.
 
 ### Fixed
-- Compass generation in multi-repo workspaces: the critic's file-ref
-  check rejected backtick-quoted *directory* paths (`app/adk`,
-  `tests/unit`) as hallucinated — directories are never graph rows, they
-  exist only as prefixes of `files.path`, so `refs.file_exists` now also
-  matches segment-boundary directory prefixes and bridges repo-qualified
-  refs (`polaris-app/app/adk`) by re-validating the remainder within the
-  named repo (every consumer — critic, memory scoring, wiki
-  sources/refine, task gate, workflow validation — inherits this via the
-  one function, and LIKE wildcards in refs are escaped). A bare module name (`app`) no longer
-  mixes same-named directories across repos into one compass: module
-  matching is segment-anchored (an unanchored `%app%` also matched
-  unrelated paths like `trapper/…`), a bare name resolves via the repos
-  that actually contain it and raises a clear "pass --repo" error when
-  ambiguous, cross-module-dependency sources are repo-scoped (a
-  same-named directory in another repo counts as a cross-module target,
-  with its repo-qualified label now critic-valid), and repo-prefixed
-  module paths (`polaris-app/app`) normalize to repo-relative.
-- Dashboard database view: stores with embeddings carry sqlite-vec
-  `vec0` virtual tables whose module is not loaded on the dashboard's
-  plain read-only connection — introspecting them crashed the whole view
-  with "no such module: vec0". The ANN internals (`vec_*`, `vecmv_*`,
-  and shadow tables) are excluded like the FTS shadows, and per-table
-  introspection is never fatal: a table that cannot be introspected
-  (module unavailable, transient lock, ...) is skipped, not an error —
-  and every skip is reported (a one-line banner in the view) so the
-  omission stays observable.
+- Compass critic file refs (`refs.file_exists`):
+  - directory paths resolve (`app/adk`): a directory is valid iff an
+    indexed file lives under it
+  - repo-qualified refs (`repo/app/adk`) re-validate within that repo
+  - LIKE wildcards in refs are escaped
+  - inherited by every consumer (critic, memory scoring, wiki
+    sources/refine, task gate, workflow validation)
+- Compass module resolution (multi-repo workspaces):
+  - module matching is segment-anchored; no substring matches
+  - bare names resolve via the repos containing them; ambiguity raises a
+    `--repo` hint instead of mixing repos
+  - `repo/module` paths normalize to repo-relative; all generation paths
+    (deterministic, LLM, task queue) produce one concept identity
+  - cross-dep sources are repo-scoped; a same-named directory in another
+    repo is a cross-module target (repo-qualified label)
+- Dashboard `/database` view:
+  - sqlite-vec internals (`vec_*`, `vecmv_*`) are excluded
+  - unintrospectable tables are skipped and reported (banner), never
+    fatal
 
 ## [0.18.0] - 2026-09-02
 

--- a/src/cairn/cli/compass.py
+++ b/src/cairn/cli/compass.py
@@ -97,7 +97,10 @@ def compass_generate(module, repo, db, knowledge, use_llm, dry_run, show_rejecti
             from ..llm.tasks import create_task
 
             facts = _gather_facts(conn, module, repo)
-            t = create_task(bundle, "compass-synthesize", module, facts=facts)
+            # Task resource = the normalized module path, so completion-time
+            # concept derivation matches the deterministic generator's
+            # identity for the same module.
+            t = create_task(bundle, "compass-synthesize", facts["module"], facts=facts)
             click.echo(f"Queued compass task: {t.id}")
             click.echo("Any agent with the cairn skill can process it:")
             click.echo(f"  cairn task show {t.id}        # view the task + facts")

--- a/src/cairn/cli/compass.py
+++ b/src/cairn/cli/compass.py
@@ -24,6 +24,7 @@ def compass():
               help="With --use-llm, print every revise cycle's critic verdict.")
 def compass_generate(module, repo, db, knowledge, use_llm, dry_run, show_rejections):
     from ..okf.bundle import OKFBundle
+    from ..compass.generator import ModuleResolutionError
 
     conn = get_db(db)
     try:
@@ -145,6 +146,9 @@ def compass_generate(module, repo, db, knowledge, use_llm, dry_run, show_rejecti
             click.echo(f"  ERROR: {e}")
         click.echo("\n--- body ---\n")
         click.echo(concept.body)
+    except ModuleResolutionError as e:
+        click.echo(f"Cannot generate compass for '{module}': {e}")
+        sys.exit(1)
     finally:
         conn.close()
 

--- a/src/cairn/cli/compass.py
+++ b/src/cairn/cli/compass.py
@@ -97,9 +97,7 @@ def compass_generate(module, repo, db, knowledge, use_llm, dry_run, show_rejecti
             from ..llm.tasks import create_task
 
             facts = _gather_facts(conn, module, repo)
-            # Task resource = the normalized module path, so completion-time
-            # concept derivation matches the deterministic generator's
-            # identity for the same module.
+            # facts["module"] is the repo-relative module path.
             t = create_task(bundle, "compass-synthesize", facts["module"], facts=facts)
             click.echo(f"Queued compass task: {t.id}")
             click.echo("Any agent with the cairn skill can process it:")

--- a/src/cairn/compass/generator.py
+++ b/src/cairn/compass/generator.py
@@ -30,21 +30,12 @@ from ..okf.concept import OKFConcept
 # Cap revise cycles to bound the generator->critic->revise loop.
 from ..llm.tasks import MAX_REVISE_CYCLES
 
-# Escape char for LIKE pattern matching. We escape the user-supplied
-# module_path so its literal '%' and '_' characters are treated as literals,
-# not wildcards (otherwise module_path="%" dumps the whole repo into one
-# compass file). The parameterization ('?') already prevents SQL injection;
-# this closes the separate wildcard-injection gap.
+# LIKE escape char: literal '%'/'_' in module paths must not act as wildcards.
 LIKE_ESCAPE_CHAR = "\\"
 
 
 def _escape_like(value: str, escape: str = LIKE_ESCAPE_CHAR) -> str:
-    """Escape LIKE wildcard metacharacters in `value` for safe use inside a
-    `... LIKE ? ESCAPE '<escape>'` clause.
-
-    Escapes the escape char itself first, then '%' and '_'. Returns the input
-    unchanged when it is empty/None.
-    """
+    """Escape LIKE wildcard metacharacters for `LIKE ? ESCAPE '<escape>'`."""
     if not value:
         return ""
     return (
@@ -55,23 +46,17 @@ def _escape_like(value: str, escape: str = LIKE_ESCAPE_CHAR) -> str:
 
 
 class ModuleResolutionError(ValueError):
-    """The module argument could not be resolved to a single repo.
-
-    Raised when a bare module name (e.g. `app`) names directories in more
-    than one repo and no --repo was given: silently dropping the repo filter
-    would mix both repos' facts into one compass.
-    """
+    """Module argument is ambiguous across repos or empty."""
 
 
 def _module_match_sql(alias: str = "path") -> str:
-    """SQL fragment matching a files.path column to a module directory on
-    segment boundaries, taking 3 params via _module_match_params: the
-    module path itself (a module pointing at a file), a root-anchored
-    module prefix (`app/...` for module `app`), or a mid-path module
-    prefix (`src/app/...`).
+    """SQL fragment matching a files.path column to a module directory
+    (3 params, via _module_match_params):
+    1. the module path itself
+    2. root-anchored module prefix (`app/...`)
+    3. mid-path module prefix (`src/app/...`)
 
-    Anchored on purpose: an unanchored `%app%` substring matches unrelated
-    paths (`trapper/utils.py`) and same-named directories in every repo.
+    Segment-anchored only — never a bare substring match.
     """
     return (
         f"({alias} = ? OR {alias} LIKE ? ESCAPE '\\' "
@@ -85,12 +70,7 @@ def _module_match_params(module_path: str) -> tuple:
 
 
 def _normalize_module_path(module_path: str, repo: Optional[str]) -> str:
-    """Strip a `{repo}/` prefix from a module path.
-
-    `cairn compass generate polaris-app/app` names the `app` module of the
-    polaris-app repo; files.path is repo-relative, so queries must use the
-    stripped form.
-    """
+    """Strip a leading `{repo}/` prefix (queries use repo-relative paths)."""
     if repo and module_path.startswith(repo + "/"):
         return module_path[len(repo) + 1:]
     return module_path
@@ -99,11 +79,8 @@ def _normalize_module_path(module_path: str, repo: Optional[str]) -> str:
 def _resolve_module(
     conn: sqlite3.Connection, module_path: str, repo: Optional[str],
 ) -> tuple:
-    """Resolve the (repo, repo-relative module path) pair for generation.
-
-    Raises ModuleResolutionError when the module is ambiguous across repos
-    (or empty after slash-stripping).
-    """
+    """Resolve (repo, repo-relative module path). Raises
+    ModuleResolutionError on ambiguity or empty input."""
     module_path = module_path.strip("/")
     if not module_path:
         raise ModuleResolutionError("module path is empty")
@@ -121,8 +98,8 @@ def generate_compass(
     """Generate a compass OKF concept for a module path.
 
     Args:
-        module_path: repo-relative module path; a `{repo}/`-prefixed path
-            (``polaris-app/app``) is normalized to repo-relative.
+        module_path: repo-relative module path (`{repo}/`-prefixed forms
+            are normalized).
         conn: graph DB connection.
         bundle: OKF bundle to write into (used for concept_id derivation).
         repo: optional repo name; if None, inferred from the path.
@@ -169,16 +146,12 @@ def generate_compass(
 def _infer_repo(conn, module_path: str) -> Optional[str]:
     cur = conn.cursor()
     for r in cur.execute("SELECT id, path FROM repos"):
-        # Match on repo id (stable basename) as a path segment of module_path.
-        # repos.path is workspace-relative (e.g. "." or a repo name), so the id
-        # is the durable identity.
+        # Repo id (stable basename) as a path segment of module_path.
         rid = r["id"]
         if module_path.startswith(rid + "/") or ("/" + rid + "/") in module_path \
                 or module_path == rid:
             return rid
-    # Bare module name: which repos actually contain it? A directory named
-    # `app` can exist in several repos -- without a repo filter the fact
-    # queries would mix them into one compass, so make ambiguity loud.
+    # Bare module name: infer from the repos that contain it; ambiguous -> raise.
     rows = cur.execute(
         f"SELECT DISTINCT repo_id FROM files WHERE {_module_match_sql()}",
         _module_match_params(module_path),
@@ -191,9 +164,7 @@ def _infer_repo(conn, module_path: str) -> Optional[str]:
         )
     if len(rows) == 1:
         return rows[0]["repo_id"]
-    # Fallback: single-repo workspace — there's only one repo. This keeps a
-    # no-match module (typo, empty dir) reporting "(no symbols detected in
-    # this module)" instead of crossing repos.
+    # Fallback: single-repo workspace infers its only repo.
     repos = cur.execute("SELECT id FROM repos").fetchall()
     if len(repos) == 1:
         return repos[0]["id"]
@@ -237,19 +208,15 @@ def _rank_key_files(conn, symbols: List[dict], top: int = 5) -> List[dict]:
 def _cross_module_deps(conn, module_path: str, repo: Optional[str]) -> List[str]:
     """Outgoing edges from this module's symbols to symbols in other modules.
 
-    The source side is segment-anchored to `module_path` and scoped to `repo`
-    when known (a bare directory name can exist in many repos). "Outside the
-    module" is repo-aware too: a same-named directory in ANOTHER repo is a
-    distinct module, so its files count as cross-module targets. All target
-    labels are repo-qualified (`{repo}/{top-two-segments}`); for cross-repo
-    targets that qualification is exactly what the critic's repo bridge
-    validates.
+    - source: segment-anchored to `module_path`, repo-scoped when known
+    - "outside the module" is repo-aware: a same-named directory in
+      another repo is a different module
+    - labels: `{repo}/{top-two-segments}` (repo-qualified refs are
+      critic-valid via the refs repo bridge)
     """
     cur = conn.cursor()
     mods = set()
-    # files.path is repo-relative (portable), so target paths need no repo-root
-    # stripping. We fetch repos.path only to strip it should an absolute path
-    # appear (paths stored before the current contract).
+    # Legacy stores may carry absolute paths; strip the repo root if present.
     legacy_repo_root = ""
     if repo:
         row = cur.execute("SELECT path FROM repos WHERE id = ?", (repo,)).fetchone()
@@ -383,10 +350,7 @@ def generate_compass_with_llm(
         client: an LLMClient (synthesize/revise). If None or unavailable, the
                 function falls back to the deterministic generator.
     """
-    # 1. Resolve the module the same way the deterministic path does (repo
-    # inference + repo-prefix normalization), then gather facts. Resolving
-    # here keeps this path's concept identity (resource/concept_id/tags)
-    # identical to the deterministic path's for the same module.
+    # 1. Resolve module, then gather facts (single source of truth).
     repo, module_path = _resolve_module(conn, module_path, repo)
     facts = _gather_facts(conn, module_path, repo)
 

--- a/src/cairn/compass/generator.py
+++ b/src/cairn/compass/generator.py
@@ -65,9 +65,10 @@ class ModuleResolutionError(ValueError):
 
 def _module_match_sql(alias: str = "path") -> str:
     """SQL fragment matching a files.path column to a module directory on
-    segment boundaries: the module path itself (module pointing at a file),
-    files directly under it, or files under it deeper in the tree. Takes 3
-    params via _module_match_params.
+    segment boundaries, taking 3 params via _module_match_params: the
+    module path itself (a module pointing at a file), a root-anchored
+    module prefix (`app/...` for module `app`), or a mid-path module
+    prefix (`src/app/...`).
 
     Anchored on purpose: an unanchored `%app%` substring matches unrelated
     paths (`trapper/utils.py`) and same-named directories in every repo.
@@ -100,9 +101,12 @@ def _resolve_module(
 ) -> tuple:
     """Resolve the (repo, repo-relative module path) pair for generation.
 
-    Raises ModuleResolutionError when the module is ambiguous across repos.
+    Raises ModuleResolutionError when the module is ambiguous across repos
+    (or empty after slash-stripping).
     """
     module_path = module_path.strip("/")
+    if not module_path:
+        raise ModuleResolutionError("module path is empty")
     repo = repo or _infer_repo(conn, module_path)
     return repo, _normalize_module_path(module_path, repo)
 
@@ -117,7 +121,8 @@ def generate_compass(
     """Generate a compass OKF concept for a module path.
 
     Args:
-        module_path: repo-relative or absolute path to the module directory.
+        module_path: repo-relative module path; a `{repo}/`-prefixed path
+            (``polaris-app/app``) is normalized to repo-relative.
         conn: graph DB connection.
         bundle: OKF bundle to write into (used for concept_id derivation).
         repo: optional repo name; if None, inferred from the path.
@@ -133,7 +138,7 @@ def generate_compass(
     # 3. Cross-module dependencies.
     cross_deps = _cross_module_deps(conn, module_path, repo_filter)
 
-    # 4. Quick commands (build commands inferred from gradle if available).
+    # 4. Quick commands (a gradle build command when the repo is known).
     quick_commands = _quick_commands(module_path, repo_filter)
 
     # 5. Synthesize body.
@@ -187,8 +192,8 @@ def _infer_repo(conn, module_path: str) -> Optional[str]:
     if len(rows) == 1:
         return rows[0]["repo_id"]
     # Fallback: single-repo workspace — there's only one repo. This keeps a
-    # no-match module (typo, empty dir) reporting "(no symbols detected)"
-    # instead of crossing repos.
+    # no-match module (typo, empty dir) reporting "(no symbols detected in
+    # this module)" instead of crossing repos.
     repos = cur.execute("SELECT id FROM repos").fetchall()
     if len(repos) == 1:
         return repos[0]["id"]
@@ -235,8 +240,10 @@ def _cross_module_deps(conn, module_path: str, repo: Optional[str]) -> List[str]
     The source side is segment-anchored to `module_path` and scoped to `repo`
     when known (a bare directory name can exist in many repos). "Outside the
     module" is repo-aware too: a same-named directory in ANOTHER repo is a
-    distinct module, so its files count as cross-module targets. Such targets
-    keep a repo-qualified label, which the critic's repo bridge validates.
+    distinct module, so its files count as cross-module targets. All target
+    labels are repo-qualified (`{repo}/{top-two-segments}`); for cross-repo
+    targets that qualification is exactly what the critic's repo bridge
+    validates.
     """
     cur = conn.cursor()
     mods = set()
@@ -376,7 +383,11 @@ def generate_compass_with_llm(
         client: an LLMClient (synthesize/revise). If None or unavailable, the
                 function falls back to the deterministic generator.
     """
-    # 1. Gather facts from the graph (single source of truth).
+    # 1. Resolve the module the same way the deterministic path does (repo
+    # inference + repo-prefix normalization), then gather facts. Resolving
+    # here keeps this path's concept identity (resource/concept_id/tags)
+    # identical to the deterministic path's for the same module.
+    repo, module_path = _resolve_module(conn, module_path, repo)
     facts = _gather_facts(conn, module_path, repo)
 
     # 2. If no client, fall back to deterministic generation.

--- a/src/cairn/compass/generator.py
+++ b/src/cairn/compass/generator.py
@@ -54,6 +54,59 @@ def _escape_like(value: str, escape: str = LIKE_ESCAPE_CHAR) -> str:
     )
 
 
+class ModuleResolutionError(ValueError):
+    """The module argument could not be resolved to a single repo.
+
+    Raised when a bare module name (e.g. `app`) names directories in more
+    than one repo and no --repo was given: silently dropping the repo filter
+    would mix both repos' facts into one compass.
+    """
+
+
+def _module_match_sql(alias: str = "path") -> str:
+    """SQL fragment matching a files.path column to a module directory on
+    segment boundaries: the module path itself (module pointing at a file),
+    files directly under it, or files under it deeper in the tree. Takes 3
+    params via _module_match_params.
+
+    Anchored on purpose: an unanchored `%app%` substring matches unrelated
+    paths (`trapper/utils.py`) and same-named directories in every repo.
+    """
+    return (
+        f"({alias} = ? OR {alias} LIKE ? ESCAPE '\\' "
+        f"OR {alias} LIKE ? ESCAPE '\\')"
+    )
+
+
+def _module_match_params(module_path: str) -> tuple:
+    e = _escape_like(module_path)
+    return (module_path, f"{e}/%", f"%/{e}/%")
+
+
+def _normalize_module_path(module_path: str, repo: Optional[str]) -> str:
+    """Strip a `{repo}/` prefix from a module path.
+
+    `cairn compass generate polaris-app/app` names the `app` module of the
+    polaris-app repo; files.path is repo-relative, so queries must use the
+    stripped form.
+    """
+    if repo and module_path.startswith(repo + "/"):
+        return module_path[len(repo) + 1:]
+    return module_path
+
+
+def _resolve_module(
+    conn: sqlite3.Connection, module_path: str, repo: Optional[str],
+) -> tuple:
+    """Resolve the (repo, repo-relative module path) pair for generation.
+
+    Raises ModuleResolutionError when the module is ambiguous across repos.
+    """
+    module_path = module_path.strip("/")
+    repo = repo or _infer_repo(conn, module_path)
+    return repo, _normalize_module_path(module_path, repo)
+
+
 def generate_compass(
     module_path: str,
     conn: sqlite3.Connection,
@@ -70,8 +123,8 @@ def generate_compass(
         repo: optional repo name; if None, inferred from the path.
         llm_synthesize: optional callable(symbols, key_files, cross_deps) -> str body.
     """
-    # 1. Find all symbols in the module path (path substring match).
-    repo_filter = repo or _infer_repo(conn, module_path)
+    # 1. Find all symbols in the module path (segment-anchored, repo-scoped).
+    repo_filter, module_path = _resolve_module(conn, module_path, repo)
     symbols = _symbols_in_module(conn, module_path, repo_filter)
 
     # 2. Key files: rank by incoming edges (most-referenced = most important).
@@ -118,7 +171,24 @@ def _infer_repo(conn, module_path: str) -> Optional[str]:
         if module_path.startswith(rid + "/") or ("/" + rid + "/") in module_path \
                 or module_path == rid:
             return rid
-    # Fallback: single-repo workspace — there's only one repo.
+    # Bare module name: which repos actually contain it? A directory named
+    # `app` can exist in several repos -- without a repo filter the fact
+    # queries would mix them into one compass, so make ambiguity loud.
+    rows = cur.execute(
+        f"SELECT DISTINCT repo_id FROM files WHERE {_module_match_sql()}",
+        _module_match_params(module_path),
+    ).fetchall()
+    if len(rows) > 1:
+        candidates = ", ".join(sorted(r["repo_id"] for r in rows))
+        raise ModuleResolutionError(
+            f"module '{module_path}' exists in multiple repos ({candidates}); "
+            "pass --repo to pick one"
+        )
+    if len(rows) == 1:
+        return rows[0]["repo_id"]
+    # Fallback: single-repo workspace — there's only one repo. This keeps a
+    # no-match module (typo, empty dir) reporting "(no symbols detected)"
+    # instead of crossing repos.
     repos = cur.execute("SELECT id FROM repos").fetchall()
     if len(repos) == 1:
         return repos[0]["id"]
@@ -127,10 +197,10 @@ def _infer_repo(conn, module_path: str) -> Optional[str]:
 
 def _symbols_in_module(conn, module_path: str, repo: Optional[str]) -> List[dict]:
     cur = conn.cursor()
-    q = """SELECT s.name, s.kind, s.qualified_name, s.line_start, f.path, f.repo_id
+    q = f"""SELECT s.name, s.kind, s.qualified_name, s.line_start, f.path, f.repo_id
            FROM symbols s JOIN files f ON s.file_id = f.id
-           WHERE f.path LIKE ? ESCAPE '\\'"""
-    params: list = [f"%{_escape_like(module_path)}%"]
+           WHERE {_module_match_sql('f.path')}"""
+    params: list = list(_module_match_params(module_path))
     if repo:
         q += " AND f.repo_id = ?"
         params.append(repo)
@@ -160,7 +230,14 @@ def _rank_key_files(conn, symbols: List[dict], top: int = 5) -> List[dict]:
 
 
 def _cross_module_deps(conn, module_path: str, repo: Optional[str]) -> List[str]:
-    """Outgoing edges from this module's symbols to symbols in other modules."""
+    """Outgoing edges from this module's symbols to symbols in other modules.
+
+    The source side is segment-anchored to `module_path` and scoped to `repo`
+    when known (a bare directory name can exist in many repos). "Outside the
+    module" is repo-aware too: a same-named directory in ANOTHER repo is a
+    distinct module, so its files count as cross-module targets. Such targets
+    keep a repo-qualified label, which the critic's repo bridge validates.
+    """
     cur = conn.cursor()
     mods = set()
     # files.path is repo-relative (portable), so target paths need no repo-root
@@ -171,16 +248,24 @@ def _cross_module_deps(conn, module_path: str, repo: Optional[str]) -> List[str]
         row = cur.execute("SELECT path FROM repos WHERE id = ?", (repo,)).fetchone()
         if row:
             legacy_repo_root = row["path"]
-    rows = cur.execute(
-        """SELECT DISTINCT f2.path AS target_path, f2.repo_id AS target_repo
+    if repo:
+        f2_outside = f"NOT ({_module_match_sql('f2.path')} AND f2.repo_id = ?)"
+    else:
+        f2_outside = f"NOT {_module_match_sql('f2.path')}"
+    q = f"""SELECT DISTINCT f2.path AS target_path, f2.repo_id AS target_repo
            FROM edges e
            JOIN symbols s1 ON e.source_id = s1.id
            JOIN files f1 ON s1.file_id = f1.id
            JOIN symbols s2 ON e.target_id = s2.id
            JOIN files f2 ON s2.file_id = f2.id
-           WHERE f1.path LIKE ? ESCAPE '\\' AND f2.path NOT LIKE ? ESCAPE '\\'""",
-        (f"%{_escape_like(module_path)}%", f"%{_escape_like(module_path)}%"),
-    ).fetchall()
+           WHERE {_module_match_sql('f1.path')} AND {f2_outside}"""
+    params: list = list(_module_match_params(module_path))
+    params += list(_module_match_params(module_path))
+    if repo:
+        params.append(repo)
+        q += " AND f1.repo_id = ?"
+        params.append(repo)
+    rows = cur.execute(q, params).fetchall()
     for r in rows:
         rel = r["target_path"]
         # Strip an absolute repo root if present; repo-relative paths need none.
@@ -257,7 +342,7 @@ def _derive_title(module_path: str) -> str:
 
 def _gather_facts(conn: sqlite3.Connection, module_path: str, repo: Optional[str]) -> Dict[str, Any]:
     """Gather graph-grounded facts for a module. Single source of truth for synthesis."""
-    repo = repo or _infer_repo(conn, module_path)
+    repo, module_path = _resolve_module(conn, module_path, repo)
     symbols = _symbols_in_module(conn, module_path, repo)
     key_files = _rank_key_files(conn, symbols)
     cross_deps = _cross_module_deps(conn, module_path, repo)

--- a/src/cairn/dashboard/data.py
+++ b/src/cairn/dashboard/data.py
@@ -590,31 +590,20 @@ def get_health(conn: sqlite3.Connection, db_path: Optional[str] = None) -> Dict:
     }
 
 
-# ANN internals: sqlite-vec ``vec0`` virtual tables and everything their
-# prefixes produce (the ``vec_<model>`` virtual table, its shadow tables
-# ``vec_<model>_info``/``_chunks``/``_rowids``/``_vector_chunksNN``, and the
-# ``vecmv_*`` mv-index tables). Their module is not loaded on the
-# dashboard's connection.
+# sqlite-vec ANN internals (``vec0`` virtual tables, shadows, ``vecmv_*``):
+# their module is not loaded on the dashboard's connection.
 _ANN_TABLE_PREFIXES = ("vec_", "vecmv_")
 
 
 def get_database_schema(conn: sqlite3.Connection) -> Dict:
-    """Store schema as a relationship graph for the database view.
+    """Store schema as a relationship graph for the /database view.
 
-    Every user table becomes a node carrying row/column counts and its
-    primary-key columns; edges come from two sources — declared foreign
-    keys (authoritative, kind ``fk``) and ``*_id`` columns whose base name
-    names another table (kind ``inferred``, e.g. ``build_runs.repo_id``
-    without a declared FK). A column already covered by a declared FK is
-    never re-inferred. Read-only introspection; internal ``sqlite_%`` and
-    FTS shadow tables are excluded, and so are the sqlite-vec ANN internals
-    (``vec_*``/``vecmv_*``): stores with embeddings carry ``vec0`` virtual
-    tables whose module is not loaded on the dashboard's plain read-only
-    connection, and introspecting them would fail the whole view. Per-table
-    introspection is never fatal for the same reason — a table that cannot
-    be introspected (module unavailable, transient lock, ...) is skipped,
-    not an error, and every skip is reported in the returned ``skipped``
-    list so the omission stays observable.
+    - nodes: user tables (row/column counts, pk columns)
+    - edges: declared foreign keys (``fk``); ``*_id`` columns naming
+      another table (``inferred``; never re-inferred over a declared FK)
+    - excluded: ``sqlite_%``, FTS shadows, sqlite-vec internals
+    - a table that cannot be introspected is skipped and reported in
+      ``skipped`` as ``{name, reason}``
     """
     tables = sorted(
         row[0]

--- a/src/cairn/dashboard/data.py
+++ b/src/cairn/dashboard/data.py
@@ -590,6 +590,12 @@ def get_health(conn: sqlite3.Connection, db_path: Optional[str] = None) -> Dict:
     }
 
 
+# ANN internals: sqlite-vec ``vec0`` virtual tables and their shadow
+# tables (``vec_<model>``, ``vec_<model>_info``/``_chunks``/``_rowids``,
+# ``vecmv_*``). Their module is not loaded on the dashboard's connection.
+_ANN_TABLE_PREFIXES = ("vec_", "vecmv_")
+
+
 def get_database_schema(conn: sqlite3.Connection) -> Dict:
     """Store schema as a relationship graph for the database view.
 
@@ -599,12 +605,19 @@ def get_database_schema(conn: sqlite3.Connection) -> Dict:
     names another table (kind ``inferred``, e.g. ``build_runs.repo_id``
     without a declared FK). A column already covered by a declared FK is
     never re-inferred. Read-only introspection; internal ``sqlite_%`` and
-    FTS shadow tables are excluded.
+    FTS shadow tables are excluded, and so are the sqlite-vec ANN internals
+    (``vec_*``/``vecmv_*``): stores with embeddings carry ``vec0`` virtual
+    tables whose module is not loaded on the dashboard's plain read-only
+    connection, and introspecting them would fail the whole view. Per-table
+    introspection is never fatal for the same reason — a table whose
+    module is unavailable is skipped, not an error.
     """
     tables = sorted(
         row[0]
         for row in conn.execute("SELECT name FROM sqlite_master WHERE type='table'")
-        if not row[0].startswith("sqlite_") and "_fts" not in row[0]
+        if not row[0].startswith("sqlite_")
+        and "_fts" not in row[0]
+        and not row[0].startswith(_ANN_TABLE_PREFIXES)
     )
 
     def _q(identifier: str) -> str:
@@ -612,12 +625,16 @@ def get_database_schema(conn: sqlite3.Connection) -> Dict:
 
     meta: Dict[str, Dict] = {}
     for name in tables:
-        columns = [
-            {"name": r[1], "type": r[2] or "", "pk": bool(r[5])}
-            for r in conn.execute(f"PRAGMA table_info({_q(name)})")
-        ]
-        rows = conn.execute(f"SELECT COUNT(*) FROM {_q(name)}").fetchone()[0]
+        try:
+            columns = [
+                {"name": r[1], "type": r[2] or "", "pk": bool(r[5])}
+                for r in conn.execute(f"PRAGMA table_info({_q(name)})")
+            ]
+            rows = conn.execute(f"SELECT COUNT(*) FROM {_q(name)}").fetchone()[0]
+        except sqlite3.Error:
+            continue
         meta[name] = {"columns": columns, "rows": rows}
+    tables = [name for name in tables if name in meta]
 
     declared: set = set()
     edges: Dict[Tuple[str, str], Dict] = {}

--- a/src/cairn/dashboard/data.py
+++ b/src/cairn/dashboard/data.py
@@ -590,9 +590,11 @@ def get_health(conn: sqlite3.Connection, db_path: Optional[str] = None) -> Dict:
     }
 
 
-# ANN internals: sqlite-vec ``vec0`` virtual tables and their shadow
-# tables (``vec_<model>``, ``vec_<model>_info``/``_chunks``/``_rowids``,
-# ``vecmv_*``). Their module is not loaded on the dashboard's connection.
+# ANN internals: sqlite-vec ``vec0`` virtual tables and everything their
+# prefixes produce (the ``vec_<model>`` virtual table, its shadow tables
+# ``vec_<model>_info``/``_chunks``/``_rowids``/``_vector_chunksNN``, and the
+# ``vecmv_*`` mv-index tables). Their module is not loaded on the
+# dashboard's connection.
 _ANN_TABLE_PREFIXES = ("vec_", "vecmv_")
 
 
@@ -609,8 +611,10 @@ def get_database_schema(conn: sqlite3.Connection) -> Dict:
     (``vec_*``/``vecmv_*``): stores with embeddings carry ``vec0`` virtual
     tables whose module is not loaded on the dashboard's plain read-only
     connection, and introspecting them would fail the whole view. Per-table
-    introspection is never fatal for the same reason — a table whose
-    module is unavailable is skipped, not an error.
+    introspection is never fatal for the same reason — a table that cannot
+    be introspected (module unavailable, transient lock, ...) is skipped,
+    not an error, and every skip is reported in the returned ``skipped``
+    list so the omission stays observable.
     """
     tables = sorted(
         row[0]
@@ -624,6 +628,7 @@ def get_database_schema(conn: sqlite3.Connection) -> Dict:
         return '"' + identifier.replace('"', '""') + '"'
 
     meta: Dict[str, Dict] = {}
+    skipped: List[Dict[str, str]] = []
     for name in tables:
         try:
             columns = [
@@ -631,7 +636,8 @@ def get_database_schema(conn: sqlite3.Connection) -> Dict:
                 for r in conn.execute(f"PRAGMA table_info({_q(name)})")
             ]
             rows = conn.execute(f"SELECT COUNT(*) FROM {_q(name)}").fetchone()[0]
-        except sqlite3.Error:
+        except sqlite3.Error as e:
+            skipped.append({"name": name, "reason": f"{type(e).__name__}: {e}"})
             continue
         meta[name] = {"columns": columns, "rows": rows}
     tables = [name for name in tables if name in meta]
@@ -680,6 +686,7 @@ def get_database_schema(conn: sqlite3.Connection) -> Dict:
             for name in tables
         ],
         "edges": [edges[key] for key in sorted(edges)],
+        "skipped": skipped,
     }
 
 

--- a/src/cairn/dashboard/templates/database.html
+++ b/src/cairn/dashboard/templates/database.html
@@ -7,6 +7,11 @@
   <p class="muted">Store schema as a relationship graph — node size encodes row count,
     solid edges are declared foreign keys, dashed edges are <code>*_id</code> references
     implied by column naming. Select a node for the table's columns and links.</p>
+  {% if schema.skipped %}
+  <p class="empty-state">{{ schema.skipped | length }} table(s) not shown —
+    {% for s in schema.skipped %}<code>{{ s.name }}</code>{% if not loop.last %}, {% endif %}{% endfor %}
+    ({{ schema.skipped[-1].reason }})</p>
+  {% endif %}
   {% if schema.tables %}
   <div class="graph-layout">
     <div class="graph-stage">

--- a/src/cairn/mcp_server/server.py
+++ b/src/cairn/mcp_server/server.py
@@ -27,7 +27,7 @@ if str(_PROJECT_ROOT) not in sys.path:
 
 from cairn.graph.schema import get_db
 from cairn.paths import render_env_resolution_chain, resolve_store
-from cairn.utils.logging import configure_logging
+from cairn.utils.logging import configure_logging, quiet_server_noise
 
 # Wire the metric-buffering conn factory BEFORE importing any tools_*.py:
 # the first @instrument-wrapped tool call would otherwise hit a None factory.
@@ -197,6 +197,9 @@ def run(transport: str = "stdio", port: int | None = None):
     # (_server_core.py:75) to avoid reconfiguring root, which this complements
     # rather than fights (it configures the `cairn` namespace, not root).
     configure_logging()
+
+    # Long-running server boot: suppress non-actionable third-party noise.
+    quiet_server_noise()
 
     # Fail fast if tool registration drifted.
     verify_tool_count()

--- a/src/cairn/refs.py
+++ b/src/cairn/refs.py
@@ -18,9 +18,7 @@ from typing import List, Tuple
 
 BACKTICK_RE = re.compile(r"`([^`]+)`")
 
-# Escape char for LIKE pattern matching. Refs come from generated prose, so
-# literal '%'/'_' in a path (e.g. `app/services_extra`) must not act as
-# wildcards.
+# LIKE escape char: literal '%'/'_' in refs must not act as wildcards.
 LIKE_ESCAPE_CHAR = "\\"
 
 
@@ -88,9 +86,13 @@ def extract_symbol_refs(body: str) -> List[str]:
 # --- graph existence checks ----------------------------------------------
 
 def _path_match_sql(alias: str = "path") -> str:
-    """SQL fragment matching a column to a path ref on any of:
-    exact file, file-suffix, root-anchored directory prefix, or mid-path
-    directory prefix. Takes 4 params via _path_match_params."""
+    """SQL fragment matching a column to a path ref (4 params, via
+    _path_match_params):
+    1. exact file path
+    2. file-path suffix
+    3. root-anchored directory prefix
+    4. mid-path directory prefix
+    """
     return (
         f"({alias} = ? OR {alias} LIKE ? ESCAPE '\\' "
         f"OR {alias} LIKE ? ESCAPE '\\' OR {alias} LIKE ? ESCAPE '\\')"
@@ -103,20 +105,14 @@ def _path_match_params(ref: str) -> Tuple[str, str, str, str]:
 
 
 def file_exists(conn: sqlite3.Connection, ref: str) -> bool:
-    """True if `ref` names a real file OR directory in the graph.
+    """True if `ref` resolves to a real file or directory.
 
-    The graph stores files only, so a directory exists iff some indexed file
-    lives under it: `src/graph` resolves via a segment-boundary prefix
-    (`src/graph/queries.py`), never a bare substring. A file ref matches
-    exactly or as a path suffix -- `queries.py` can't be satisfied by an
-    unrelated path that merely contains it.
-
-    A repo-qualified ref (`polaris-app/app/adk`) -- the form multi-repo facts
-    naturally cite -- is bridged by re-validating the remainder within that
-    repo: files.path is repo-relative under the current scanner contract, so
-    the qualified form never matches literally (legacy absolute-path stores
-    may match it as a mid-path prefix -- harmless, the bridge is then
-    redundant).
+    Directories exist only as prefixes of stored file paths. Match arms
+    (segment-boundary only, never bare substring):
+    1. exact file path
+    2. file-path suffix (`src/graph/queries.py`)
+    3. directory prefix (`src/graph`)
+    4. repo-qualified (`repo/...`) re-validated within that repo
     """
     ref = ref.strip("/")
     if not ref:

--- a/src/cairn/refs.py
+++ b/src/cairn/refs.py
@@ -113,8 +113,10 @@ def file_exists(conn: sqlite3.Connection, ref: str) -> bool:
 
     A repo-qualified ref (`polaris-app/app/adk`) -- the form multi-repo facts
     naturally cite -- is bridged by re-validating the remainder within that
-    repo: files.path is repo-relative, so the qualified form never matches
-    literally.
+    repo: files.path is repo-relative under the current scanner contract, so
+    the qualified form never matches literally (legacy absolute-path stores
+    may match it as a mid-path prefix -- harmless, the bridge is then
+    redundant).
     """
     ref = ref.strip("/")
     if not ref:

--- a/src/cairn/refs.py
+++ b/src/cairn/refs.py
@@ -12,11 +12,27 @@ from __future__ import annotations
 
 import re
 import sqlite3
-from typing import List
+from typing import List, Tuple
 
 # --- shared patterns ------------------------------------------------------
 
 BACKTICK_RE = re.compile(r"`([^`]+)`")
+
+# Escape char for LIKE pattern matching. Refs come from generated prose, so
+# literal '%'/'_' in a path (e.g. `app/services_extra`) must not act as
+# wildcards.
+LIKE_ESCAPE_CHAR = "\\"
+
+
+def _escape_like(value: str, escape: str = LIKE_ESCAPE_CHAR) -> str:
+    """Escape LIKE wildcard metacharacters for use inside `LIKE ? ESCAPE '\\'`."""
+    if not value:
+        return ""
+    return (
+        value.replace(escape, escape * 2)
+        .replace("%", escape + "%")
+        .replace("_", escape + "_")
+    )
 
 # Extensions for all languages cairn parses (see pyproject.toml
 # tree-sitter deps).
@@ -71,18 +87,52 @@ def extract_symbol_refs(body: str) -> List[str]:
 
 # --- graph existence checks ----------------------------------------------
 
-def file_exists(conn: sqlite3.Connection, ref: str) -> bool:
-    """Path-suffix match, not "contains this basename anywhere".
+def _path_match_sql(alias: str = "path") -> str:
+    """SQL fragment matching a column to a path ref on any of:
+    exact file, file-suffix, root-anchored directory prefix, or mid-path
+    directory prefix. Takes 4 params via _path_match_params."""
+    return (
+        f"({alias} = ? OR {alias} LIKE ? ESCAPE '\\' "
+        f"OR {alias} LIKE ? ESCAPE '\\' OR {alias} LIKE ? ESCAPE '\\')"
+    )
 
-    A bare filename (no "/") still only has the basename to go on and stays
-    a basename match -- but a path fragment (`src/graph/queries.py`) must
-    match as a suffix of a real stored path, so it can't be satisfied by an
-    unrelated file that merely shares a basename.
+
+def _path_match_params(ref: str) -> Tuple[str, str, str, str]:
+    e = _escape_like(ref)
+    return (ref, f"%/{e}", f"{e}/%", f"%/{e}/%")
+
+
+def file_exists(conn: sqlite3.Connection, ref: str) -> bool:
+    """True if `ref` names a real file OR directory in the graph.
+
+    The graph stores files only, so a directory exists iff some indexed file
+    lives under it: `src/graph` resolves via a segment-boundary prefix
+    (`src/graph/queries.py`), never a bare substring. A file ref matches
+    exactly or as a path suffix -- `queries.py` can't be satisfied by an
+    unrelated path that merely contains it.
+
+    A repo-qualified ref (`polaris-app/app/adk`) -- the form multi-repo facts
+    naturally cite -- is bridged by re-validating the remainder within that
+    repo: files.path is repo-relative, so the qualified form never matches
+    literally.
     """
+    ref = ref.strip("/")
+    if not ref:
+        return False
     cur = conn.cursor()
     row = cur.execute(
-        "SELECT 1 FROM files WHERE path = ? OR path LIKE ? LIMIT 1",
-        (ref, f"%/{ref}"),
+        f"SELECT 1 FROM files WHERE {_path_match_sql()} LIMIT 1",
+        _path_match_params(ref),
+    ).fetchone()
+    if row is not None:
+        return True
+    # Repo-qualification bridge: `repo/...` -> validate `...` within repo.
+    rid, _, rest = ref.partition("/")
+    if not rest:
+        return False
+    row = cur.execute(
+        f"SELECT 1 FROM files WHERE repo_id = ? AND {_path_match_sql()} LIMIT 1",
+        (rid, *_path_match_params(rest)),
     ).fetchone()
     return row is not None
 

--- a/src/cairn/utils/logging.py
+++ b/src/cairn/utils/logging.py
@@ -29,7 +29,7 @@ import logging
 import os
 import sys
 
-__all__ = ["configure_logging"]
+__all__ = ["configure_logging", "quiet_server_noise"]
 
 # The cairn namespace logger — the single ancestor of every
 # `logging.getLogger("cairn.<...>")` created across the codebase.
@@ -113,3 +113,31 @@ def configure_logging(verbose: bool = False, level_override: str | None = None) 
         logger.addHandler(handler)
     logger.setLevel(level_name)
     return level_name
+
+
+# Third-party loggers that are WARNING-noisy in long-running servers.
+_NOISY_LOGGERS = ("huggingface_hub", "mcp")
+
+
+def quiet_server_noise() -> None:
+    """Suppress non-actionable third-party output for long-running servers.
+
+    1. `_NOISY_LOGGERS` loggers -> ERROR (Hub rate-limit hints,
+       MCP pre-initialization request chatter)
+    2. progress bars -> off (huggingface_hub ``disable_progress_bars``;
+       ``TQDM_DISABLE=1`` as fallback): bar escape sequences corrupt
+       log files
+
+    Existing ``TQDM_DISABLE`` values are respected. Idempotent.
+    """
+    os.environ.setdefault("TQDM_DISABLE", "1")
+    try:
+        from huggingface_hub.utils import disable_progress_bars
+
+        disable_progress_bars()
+    except ImportError:
+        pass  # optional dependency; TQDM_DISABLE covers its bars
+    # After the HF import: importing huggingface_hub re-runs its own
+    # logging setup and would reset the level set here.
+    for name in _NOISY_LOGGERS:
+        logging.getLogger(name).setLevel(logging.ERROR)

--- a/tests/test_compass_critic.py
+++ b/tests/test_compass_critic.py
@@ -115,6 +115,33 @@ class TestFileExists:
         conn = _conn_with_fixture(fresh_db)
         assert _file_exists(conn, "src/DoesNotExist.kt") is False
 
+    def test_directory_ref_resolves_via_prefix(self, fresh_db):
+        # The graph stores files only; a directory exists iff some indexed
+        # file lives under it. Reported bug: `app/adk`-style directory refs
+        # were rejected as "hallucinated file path" even off a fresh build.
+        conn = _conn_with_fixture(fresh_db)
+        assert _file_exists(conn, "src/graph") is True
+        assert _file_exists(conn, "other/unrelated") is True
+
+    def test_hallucinated_directory_rejected(self, fresh_db):
+        conn = _conn_with_fixture(fresh_db)
+        assert _file_exists(conn, "no/such/dir") is False
+
+    def test_directory_prefix_matches_on_segment_boundary(self, fresh_db):
+        conn = _conn_with_fixture(fresh_db)
+        # `src/grap` must not resolve via a substring of `src/graph/...`.
+        assert _file_exists(conn, "src/grap") is False
+
+    def test_repo_qualified_ref_bridges_to_repo(self, fresh_db):
+        # files.path is repo-relative, so a repo-qualified ref (the form
+        # multi-repo facts cite) never matches literally -- it must be
+        # re-validated within the named repo.
+        conn = _conn_with_fixture(fresh_db)
+        assert _file_exists(conn, "r1/src/graph/queries.py") is True
+        assert _file_exists(conn, "r2/other/unrelated/queries.py") is True
+        # The bridge scopes: r2 does not contain src/graph/queries.py.
+        assert _file_exists(conn, "r2/src/graph/queries.py") is False
+
 
 class TestSymbolExists:
     def test_bare_name_matches(self, fresh_db):
@@ -149,6 +176,16 @@ class TestCriticConceptIntegration:
         result = critic_concept(concept, conn)
         assert any("DoesNotExist.kt" in e for e in result.errors)
         assert result.passed is False
+
+    def test_directory_ref_not_flagged_as_hallucination(self, fresh_db):
+        conn = _conn_with_fixture(fresh_db)
+        concept = OKFConcept(
+            type="Compass",
+            title="test",
+            body="The queries live in `src/graph` (see `src/graph/queries.py`).",
+        )
+        result = critic_concept(concept, conn)
+        assert result.errors == []
 
     def test_repeated_dead_path_reported_once(self, fresh_db):
         conn = _conn_with_fixture(fresh_db)

--- a/tests/test_compass_critic.py
+++ b/tests/test_compass_critic.py
@@ -116,9 +116,7 @@ class TestFileExists:
         assert _file_exists(conn, "src/DoesNotExist.kt") is False
 
     def test_directory_ref_resolves_via_prefix(self, fresh_db):
-        # The graph stores files only; a directory exists iff some indexed
-        # file lives under it. Reported bug: `app/adk`-style directory refs
-        # were rejected as "hallucinated file path" even off a fresh build.
+        # Directories exist only as prefixes of stored file paths.
         conn = _conn_with_fixture(fresh_db)
         assert _file_exists(conn, "src/graph") is True
         assert _file_exists(conn, "other/unrelated") is True
@@ -133,12 +131,8 @@ class TestFileExists:
         assert _file_exists(conn, "src/grap") is False
 
     def test_repo_qualified_ref_bridges_to_repo(self, fresh_db):
-        # Under the current repo-relative storage contract a repo-qualified
-        # ref never matches literally (files.path carries no repo prefix),
-        # so only the bridge -- re-validating the remainder within the
-        # named repo -- can resolve it. The pkg/inner row below is seeded
-        # repo-relative; no suffix/prefix arm can reach it without the
-        # bridge.
+        # files.path is repo-relative here, so only the repo bridge can
+        # resolve `repo/path` refs (the pkg/inner row is repo-relative).
         conn = _conn_with_fixture(fresh_db)
         conn.execute(
             "INSERT INTO files (id, repo_id, path, language) VALUES "
@@ -151,9 +145,7 @@ class TestFileExists:
         assert _file_exists(conn, "r2/pkg/inner/util.py") is False
 
     def test_like_wildcards_in_ref_are_literal(self, fresh_db):
-        # A ref's '%'/'_' must not act as wildcards: unescaped,
-        # `app/services_extra` would match `app/services/extra/...` ('_'
-        # matches '/') and `app/%` would match everything.
+        # '%'/'_' in refs are literals, not wildcards.
         conn = _conn_with_fixture(fresh_db)
         conn.execute(
             "INSERT INTO files (id, repo_id, path, language) VALUES "

--- a/tests/test_compass_critic.py
+++ b/tests/test_compass_critic.py
@@ -133,14 +133,42 @@ class TestFileExists:
         assert _file_exists(conn, "src/grap") is False
 
     def test_repo_qualified_ref_bridges_to_repo(self, fresh_db):
-        # files.path is repo-relative, so a repo-qualified ref (the form
-        # multi-repo facts cite) never matches literally -- it must be
-        # re-validated within the named repo.
+        # Under the current repo-relative storage contract a repo-qualified
+        # ref never matches literally (files.path carries no repo prefix),
+        # so only the bridge -- re-validating the remainder within the
+        # named repo -- can resolve it. The pkg/inner row below is seeded
+        # repo-relative; no suffix/prefix arm can reach it without the
+        # bridge.
         conn = _conn_with_fixture(fresh_db)
-        assert _file_exists(conn, "r1/src/graph/queries.py") is True
-        assert _file_exists(conn, "r2/other/unrelated/queries.py") is True
-        # The bridge scopes: r2 does not contain src/graph/queries.py.
-        assert _file_exists(conn, "r2/src/graph/queries.py") is False
+        conn.execute(
+            "INSERT INTO files (id, repo_id, path, language) VALUES "
+            "(4, 'r1', 'pkg/inner/util.py', 'python')"
+        )
+        conn.commit()
+        assert _file_exists(conn, "r1/pkg/inner/util.py") is True
+        assert _file_exists(conn, "r1/pkg/inner") is True  # bridged directory
+        # The bridge scopes: r2 has no pkg/inner.
+        assert _file_exists(conn, "r2/pkg/inner/util.py") is False
+
+    def test_like_wildcards_in_ref_are_literal(self, fresh_db):
+        # A ref's '%'/'_' must not act as wildcards: unescaped,
+        # `app/services_extra` would match `app/services/extra/...` ('_'
+        # matches '/') and `app/%` would match everything.
+        conn = _conn_with_fixture(fresh_db)
+        conn.execute(
+            "INSERT INTO files (id, repo_id, path, language) VALUES "
+            "(4, 'r1', '/tmp/r1/app/services/extra/mod.py', 'python')"
+        )
+        conn.commit()
+        assert _file_exists(conn, "app/services_extra") is False
+        assert _file_exists(conn, "app/services/extra") is True
+        assert _file_exists(conn, "app/%") is False
+
+    def test_ref_slash_and_empty_normalization(self, fresh_db):
+        conn = _conn_with_fixture(fresh_db)
+        assert _file_exists(conn, "src/graph/") is True
+        assert _file_exists(conn, "") is False
+        assert _file_exists(conn, "/") is False
 
 
 class TestSymbolExists:

--- a/tests/test_compass_generator.py
+++ b/tests/test_compass_generator.py
@@ -1,6 +1,7 @@
 """Module resolution for `cairn compass generate` in multi-repo workspaces.
 
-Two reported bugs (2026-09-03, polaris workspace):
+Reported symptoms (2026-09-03, polaris workspace) — two root causes, three
+surfaces:
 1. A bare module name (`app`) matched same-named directories in EVERY repo
    via an unanchored `%app%` path LIKE, mixing both repos' facts into one
    compass (polaris-app + polaris-api both have `app/`).
@@ -29,8 +30,25 @@ from cairn.compass.generator import (
     _resolve_module,
     _symbols_in_module,
     generate_compass,
+    generate_compass_with_llm,
 )
 from cairn.okf.bundle import OKFBundle
+
+
+class _PassCriticClient:
+    """Minimal LLM client whose first draft passes the deterministic critic."""
+
+    def synthesize(self, kind, facts):
+        return (
+            "# What Does This Module Do?\n- `agent_run` drives the module.\n"
+            "# Common Modification Patterns\n- Edit `agent.py` carefully.\n"
+            "# Build-Failure Patterns\n- None known.\n"
+            "# Cross-Module Dependencies\n- Calls out via utils.\n"
+            "# Tribal Knowledge\n- None yet.\n"
+        )
+
+    def revise(self, kind, draft, errors, facts):
+        return self.synthesize(kind, facts)
 
 
 def _row(conn, table, **cols):
@@ -93,6 +111,19 @@ class TestModuleResolution:
         names = {s["name"] for s in syms}
         assert names == {"agent_run"}
 
+    def test_module_like_wildcards_are_literal(self, conn):
+        # A module's '%'/'_' must not act as wildcards: unescaped,
+        # `%/graph_core/%` would match `graph/core/...` ('_' matches '/').
+        _row(conn, "files", id="f9", repo_id="polaris-app", path="graph/core/mod.py", language="python")
+        _row(conn, "symbols", id="s9", file_id="f9", name="core_fn", qualified_name="core.core_fn", kind="function", line_start=1, line_end=5)
+        conn.commit()
+        assert _symbols_in_module(conn, "graph_core", "polaris-app") == []
+        assert {s["name"] for s in _symbols_in_module(conn, "graph/core", "polaris-app")} == {"core_fn"}
+
+    def test_empty_module_path_rejected(self, conn, tmp_path):
+        with pytest.raises(ModuleResolutionError):
+            generate_compass("/", conn, OKFBundle(str(tmp_path / "k")))
+
 
 class TestGenerateCompass:
     def test_repo_scoped_compass_not_polluted(self, conn, tmp_path):
@@ -111,6 +142,40 @@ class TestGenerateCompass:
         assert concept.tags[0] == "polaris-app"
         assert "agent_run" in concept.body
         assert "api_handler" not in concept.body
+
+    def test_llm_path_identity_matches_deterministic(self, conn, tmp_path):
+        # The LLM path must derive its concept identity (resource,
+        # concept_id, tags) from the resolved repo + repo-relative module,
+        # so one module gets ONE compass file whichever path generated it
+        # (a diverged identity also never satisfies detect_gaps coverage).
+        bundle = OKFBundle(str(tmp_path / "k"))
+        det = generate_compass("polaris-app/app", conn, bundle)
+        fallback = generate_compass_with_llm("polaris-app/app", conn, bundle, client=None)
+        assert fallback["mode"] == "deterministic"
+        assert fallback["concept"].concept_id == det.concept_id == "compass/app"
+        assert fallback["concept"].resource == det.resource == "app"
+        assert fallback["concept"].tags == det.tags
+
+        llm = generate_compass_with_llm(
+            "polaris-app/app", conn, bundle, client=_PassCriticClient()
+        )
+        assert llm["mode"] == "llm"
+        assert llm["concept"].concept_id == det.concept_id
+        assert llm["concept"].resource == det.resource
+        assert llm["concept"].tags == det.tags
+
+
+def test_no_match_module_reports_empty_not_cross_repo(fresh_db, tmp_path):
+    # Single-repo workspace, module matching nothing: the only repo is
+    # still inferred so the compass reports "(no symbols detected ...)"
+    # rather than silently querying across repos.
+    _row(fresh_db, "repos", id="solo", name="solo", path="/work/solo")
+    _row(fresh_db, "files", id="sf1", repo_id="solo", path="app/agent.py", language="python")
+    _row(fresh_db, "symbols", id="ss1", file_id="sf1", name="solo_fn", qualified_name="solo.solo_fn", kind="function", line_start=1, line_end=5)
+    fresh_db.commit()
+    concept = generate_compass("typo", fresh_db, OKFBundle(str(tmp_path / "k")))
+    assert "(no symbols detected in this module)" in concept.body
+    assert concept.tags[0] == "solo"
 
 
 class TestCrossModuleDeps:
@@ -153,6 +218,23 @@ class TestCompassGenerateCLI:
             assert "multiple repos" in result.output
             assert "--repo" in result.output
             # Nothing written.
+            assert not list(Path(know).rglob("compass/*.md"))
+
+    def test_use_llm_queue_path_ambiguity_fails_at_enqueue(self):
+        # Default file-queue backend: ambiguity must fail at ENQUEUE time
+        # (the except covers the _gather_facts call), not later during
+        # task completion.
+        runner = CliRunner()
+        with tempfile.TemporaryDirectory() as tmp:
+            db, know = self._setup(tmp)
+            from cairn.cli import main
+            result = runner.invoke(
+                main,
+                ["compass", "generate", "app", "--use-llm", "--db", db, "--knowledge", know],
+            )
+            assert result.exit_code == 1
+            assert "multiple repos" in result.output
+            assert "Queued compass task" not in result.output
             assert not list(Path(know).rglob("compass/*.md"))
 
     def test_repo_scoped_generation_passes_critic(self):

--- a/tests/test_compass_generator.py
+++ b/tests/test_compass_generator.py
@@ -1,18 +1,10 @@
 """Module resolution for `cairn compass generate` in multi-repo workspaces.
 
-Reported symptoms (2026-09-03, polaris workspace) — two root causes, three
-surfaces:
-1. A bare module name (`app`) matched same-named directories in EVERY repo
-   via an unanchored `%app%` path LIKE, mixing both repos' facts into one
-   compass (polaris-app + polaris-api both have `app/`).
-2. The unanchored LIKE also matched unrelated paths that merely contain the
-   module name as a substring (`trapper/...` for module `app`).
-3. The deterministic template's repo-qualified cross-dep labels
-   (`polaris-api/app/adk`) were rejected by the critic's file_exists, so the
-   generator failed its own gate whenever cross-module deps existed.
-
-files.path is repo-relative in these fixtures (the current scanner contract);
-test_compass_critic.py covers the legacy absolute-path storage form.
+- bare module names resolve to one repo; ambiguity raises
+- matching is segment-anchored, never substring
+- one concept identity across all generation paths
+- files.path is repo-relative here; test_compass_critic.py covers the
+  legacy absolute-path form
 """
 from __future__ import annotations
 
@@ -87,8 +79,7 @@ def conn(fresh_db) -> sqlite3.Connection:
 
 class TestModuleResolution:
     def test_bare_ambiguous_module_raises(self, conn):
-        # The reported bug: bare `app` silently dropped the repo filter and
-        # mixed polaris-app + polaris-api facts. It must now fail loudly.
+        # Ambiguous bare name fails loudly instead of mixing repos.
         with pytest.raises(ModuleResolutionError) as exc:
             generate_compass("app", conn, OKFBundle("/tmp/k"))
         msg = str(exc.value)
@@ -101,19 +92,17 @@ class TestModuleResolution:
         assert _infer_repo(conn, "trapper") == "polaris-app"
 
     def test_repo_prefixed_module_infers_and_normalizes(self, conn):
-        # `polaris-app/app` names polaris-app's app module; queries must use
-        # the repo-relative form.
+        # `repo/module` resolves to (repo, repo-relative module).
         assert _resolve_module(conn, "polaris-app/app", None) == ("polaris-app", "app")
 
     def test_substring_path_not_matched(self, conn):
-        # `app` must not match `trapper/decoy.py` (unanchored `%app%` did).
+        # `app` must not match `trapper/decoy.py`.
         syms = _symbols_in_module(conn, "app", "polaris-app")
         names = {s["name"] for s in syms}
         assert names == {"agent_run"}
 
     def test_module_like_wildcards_are_literal(self, conn):
-        # A module's '%'/'_' must not act as wildcards: unescaped,
-        # `%/graph_core/%` would match `graph/core/...` ('_' matches '/').
+        # '%'/'_' in a module name are literals.
         _row(conn, "files", id="f9", repo_id="polaris-app", path="graph/core/mod.py", language="python")
         _row(conn, "symbols", id="s9", file_id="f9", name="core_fn", qualified_name="core.core_fn", kind="function", line_start=1, line_end=5)
         conn.commit()
@@ -144,10 +133,7 @@ class TestGenerateCompass:
         assert "api_handler" not in concept.body
 
     def test_llm_path_identity_matches_deterministic(self, conn, tmp_path):
-        # The LLM path must derive its concept identity (resource,
-        # concept_id, tags) from the resolved repo + repo-relative module,
-        # so one module gets ONE compass file whichever path generated it
-        # (a diverged identity also never satisfies detect_gaps coverage).
+        # One module, one concept identity, regardless of generation path.
         bundle = OKFBundle(str(tmp_path / "k"))
         det = generate_compass("polaris-app/app", conn, bundle)
         fallback = generate_compass_with_llm("polaris-app/app", conn, bundle, client=None)
@@ -166,9 +152,7 @@ class TestGenerateCompass:
 
 
 def test_no_match_module_reports_empty_not_cross_repo(fresh_db, tmp_path):
-    # Single-repo workspace, module matching nothing: the only repo is
-    # still inferred so the compass reports "(no symbols detected ...)"
-    # rather than silently querying across repos.
+    # Single-repo workspace: a no-match module still infers the repo.
     _row(fresh_db, "repos", id="solo", name="solo", path="/work/solo")
     _row(fresh_db, "files", id="sf1", repo_id="solo", path="app/agent.py", language="python")
     _row(fresh_db, "symbols", id="ss1", file_id="sf1", name="solo_fn", qualified_name="solo.solo_fn", kind="function", line_start=1, line_end=5)
@@ -221,9 +205,7 @@ class TestCompassGenerateCLI:
             assert not list(Path(know).rglob("compass/*.md"))
 
     def test_use_llm_queue_path_ambiguity_fails_at_enqueue(self):
-        # Default file-queue backend: ambiguity must fail at ENQUEUE time
-        # (the except covers the _gather_facts call), not later during
-        # task completion.
+        # File-queue backend: ambiguity fails at enqueue time.
         runner = CliRunner()
         with tempfile.TemporaryDirectory() as tmp:
             db, know = self._setup(tmp)

--- a/tests/test_compass_generator.py
+++ b/tests/test_compass_generator.py
@@ -1,0 +1,169 @@
+"""Module resolution for `cairn compass generate` in multi-repo workspaces.
+
+Two reported bugs (2026-09-03, polaris workspace):
+1. A bare module name (`app`) matched same-named directories in EVERY repo
+   via an unanchored `%app%` path LIKE, mixing both repos' facts into one
+   compass (polaris-app + polaris-api both have `app/`).
+2. The unanchored LIKE also matched unrelated paths that merely contain the
+   module name as a substring (`trapper/...` for module `app`).
+3. The deterministic template's repo-qualified cross-dep labels
+   (`polaris-api/app/adk`) were rejected by the critic's file_exists, so the
+   generator failed its own gate whenever cross-module deps existed.
+
+files.path is repo-relative in these fixtures (the current scanner contract);
+test_compass_critic.py covers the legacy absolute-path storage form.
+"""
+from __future__ import annotations
+
+import sqlite3
+import tempfile
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from cairn.compass.generator import (
+    ModuleResolutionError,
+    _cross_module_deps,
+    _infer_repo,
+    _resolve_module,
+    _symbols_in_module,
+    generate_compass,
+)
+from cairn.okf.bundle import OKFBundle
+
+
+def _row(conn, table, **cols):
+    keys = ", ".join(cols)
+    placeholders = ", ".join("?" for _ in cols)
+    conn.execute(f"INSERT INTO {table} ({keys}) VALUES ({placeholders})", list(cols.values()))
+
+
+def _seed_workspace(conn: sqlite3.Connection) -> None:
+    """Two repos sharing a directory name (`app`), plus a substring decoy.
+
+    polaris-app: app/adk/agent.py, happy/utils.py, trapper/decoy.py
+    polaris-api: app/adk/api.py
+    edges: agent_run -> api_handler (cross-repo), agent_run -> util_fn.
+    """
+    _row(conn, "repos", id="polaris-app", name="polaris-app", path="/work/polaris-app")
+    _row(conn, "repos", id="polaris-api", name="polaris-api", path="/work/polaris-api")
+    _row(conn, "files", id="f1", repo_id="polaris-app", path="app/adk/agent.py", language="python")
+    _row(conn, "files", id="f2", repo_id="polaris-app", path="happy/utils.py", language="python")
+    _row(conn, "files", id="f3", repo_id="polaris-app", path="trapper/decoy.py", language="python")
+    _row(conn, "files", id="f4", repo_id="polaris-api", path="app/adk/api.py", language="python")
+    _row(conn, "symbols", id="s1", file_id="f1", name="agent_run", qualified_name="adk.agent_run", kind="function", line_start=1, line_end=10)
+    _row(conn, "symbols", id="s2", file_id="f2", name="util_fn", qualified_name="happy.util_fn", kind="function", line_start=1, line_end=10)
+    _row(conn, "symbols", id="s3", file_id="f3", name="decoy_fn", qualified_name="trap.decoy_fn", kind="function", line_start=1, line_end=10)
+    _row(conn, "symbols", id="s4", file_id="f4", name="api_handler", qualified_name="adk.api_handler", kind="function", line_start=1, line_end=10)
+    _row(conn, "edges", id="e1", source_id="s1", target_id="s4", target_name="api_handler", kind="call", line=5, column=0, resolution="exact")
+    _row(conn, "edges", id="e2", source_id="s1", target_id="s2", target_name="util_fn", kind="call", line=6, column=0, resolution="exact")
+    conn.commit()
+
+
+@pytest.fixture
+def conn(fresh_db) -> sqlite3.Connection:
+    _seed_workspace(fresh_db)
+    return fresh_db
+
+
+class TestModuleResolution:
+    def test_bare_ambiguous_module_raises(self, conn):
+        # The reported bug: bare `app` silently dropped the repo filter and
+        # mixed polaris-app + polaris-api facts. It must now fail loudly.
+        with pytest.raises(ModuleResolutionError) as exc:
+            generate_compass("app", conn, OKFBundle("/tmp/k"))
+        msg = str(exc.value)
+        assert "polaris-app" in msg and "polaris-api" in msg
+        assert "--repo" in msg
+
+    def test_module_unique_to_one_repo_infers(self, conn):
+        # A bare name that exists in exactly one repo resolves to it.
+        assert _infer_repo(conn, "happy") == "polaris-app"
+        assert _infer_repo(conn, "trapper") == "polaris-app"
+
+    def test_repo_prefixed_module_infers_and_normalizes(self, conn):
+        # `polaris-app/app` names polaris-app's app module; queries must use
+        # the repo-relative form.
+        assert _resolve_module(conn, "polaris-app/app", None) == ("polaris-app", "app")
+
+    def test_substring_path_not_matched(self, conn):
+        # `app` must not match `trapper/decoy.py` (unanchored `%app%` did).
+        syms = _symbols_in_module(conn, "app", "polaris-app")
+        names = {s["name"] for s in syms}
+        assert names == {"agent_run"}
+
+
+class TestGenerateCompass:
+    def test_repo_scoped_compass_not_polluted(self, conn, tmp_path):
+        bundle = OKFBundle(str(tmp_path / "k"))
+        concept = generate_compass("app", conn, bundle, repo="polaris-app")
+        assert concept.tags[0] == "polaris-app"
+        assert concept.resource == "app"
+        assert "agent_run" in concept.body
+        assert "api_handler" not in concept.body
+        assert "decoy" not in concept.body
+
+    def test_repo_prefixed_module_generates(self, conn, tmp_path):
+        bundle = OKFBundle(str(tmp_path / "k"))
+        concept = generate_compass("polaris-app/app", conn, bundle)
+        assert concept.resource == "app"
+        assert concept.tags[0] == "polaris-app"
+        assert "agent_run" in concept.body
+        assert "api_handler" not in concept.body
+
+
+class TestCrossModuleDeps:
+    def test_scoped_to_module_repo_with_labeled_cross_repo_target(self, conn):
+        deps = _cross_module_deps(conn, "app", "polaris-app")
+        # The cross-repo target keeps its repo-qualified label; the in-repo
+        # target names the module it lives in.
+        assert set(deps) == {"polaris-api/app/adk", "polaris-app/happy/utils.py"}
+
+    def test_deterministic_template_passes_own_critic(self, conn, tmp_path):
+        # The template backticks the repo-qualified dep labels; the critic's
+        # repo bridge must validate them (previously: hallucinated path).
+        from cairn.compass.critic import critic_concept
+
+        bundle = OKFBundle(str(tmp_path / "k"))
+        concept = generate_compass("app", conn, bundle, repo="polaris-app")
+        result = critic_concept(concept, conn)
+        assert result.errors == [], f"critic rejected graph-sourced body: {result.errors}"
+        assert result.passed is True
+
+
+class TestCompassGenerateCLI:
+    def _setup(self, tmpdir: str):
+        db = str(Path(tmpdir) / "test.db")
+        know = str(Path(tmpdir) / ".knowledge")
+        Path(know).mkdir(parents=True, exist_ok=True)
+        from cairn.graph.schema import get_db
+        c = get_db(db)
+        _seed_workspace(c)
+        c.close()
+        return db, know
+
+    def test_ambiguous_bare_module_exits_with_guidance(self):
+        runner = CliRunner()
+        with tempfile.TemporaryDirectory() as tmp:
+            db, know = self._setup(tmp)
+            from cairn.cli import main
+            result = runner.invoke(main, ["compass", "generate", "app", "--db", db, "--knowledge", know])
+            assert result.exit_code == 1
+            assert "multiple repos" in result.output
+            assert "--repo" in result.output
+            # Nothing written.
+            assert not list(Path(know).rglob("compass/*.md"))
+
+    def test_repo_scoped_generation_passes_critic(self):
+        runner = CliRunner()
+        with tempfile.TemporaryDirectory() as tmp:
+            db, know = self._setup(tmp)
+            from cairn.cli import main
+            result = runner.invoke(
+                main,
+                ["compass", "generate", "app", "--repo", "polaris-app",
+                 "--db", db, "--knowledge", know, "--dry-run"],
+            )
+            assert result.exit_code == 0, result.output
+            assert "passed: True" in result.output

--- a/tests/test_dashboard_app.py
+++ b/tests/test_dashboard_app.py
@@ -902,8 +902,9 @@ def test_database_route_excludes_vec_ann_internals(tmp_path):
     (``vec_<model>`` + shadows) whose module is not loaded on the
     dashboard's plain read-only connection — introspecting them crashed
     the whole view with "no such module: vec0". The ANN internals are
-    excluded like the FTS shadows, and an unavailable module can never
-    kill the view (fts5 stands in for an exotic module here)."""
+    excluded by name like the FTS shadows. (The fts5 tables stand in for
+    the vec0 shapes only; the never-fatal introspection skip is covered by
+    test_database_schema_reports_skipped_tables.)"""
     db = tmp_path / "vectors.db"
     conn = sqlite3.connect(db)
     conn.executescript(
@@ -922,6 +923,37 @@ def test_database_route_excludes_vec_ann_internals(tmp_path):
     marker = '<script id="db-graph-data" type="application/json">'
     payload = json.loads(resp.text.split(marker, 1)[1].split("</script>", 1)[0])
     assert [t["name"] for t in payload["tables"]] == ["repos"]
+
+
+def test_database_schema_reports_skipped_tables(tmp_path):
+    """A table whose introspection raises (module unavailable, transient
+    lock, ...) is skipped without killing the view AND is reported in the
+    ``skipped`` payload — the omission is observable, never silent. A
+    connection factory stands in for the un-loadable module, since a
+    module-less virtual table cannot be created in-process."""
+    from cairn.dashboard.data import get_database_schema
+
+    db = tmp_path / "broken.db"
+    seed = sqlite3.connect(db)
+    seed.execute("CREATE TABLE repos(id INTEGER PRIMARY KEY)")
+    seed.execute("CREATE TABLE zzz_broken(id INTEGER PRIMARY KEY)")
+    seed.commit()
+    seed.close()
+
+    class _BrokenTableConn(sqlite3.Connection):
+        def execute(self, sql, params=()):
+            if "zzz_broken" in sql:
+                raise sqlite3.OperationalError("no such module: vec0")
+            return super().execute(sql, params)
+
+    conn = sqlite3.connect(db, factory=_BrokenTableConn)
+    try:
+        schema = get_database_schema(conn)
+    finally:
+        conn.close()
+    assert [t["name"] for t in schema["tables"]] == ["repos"]
+    assert [s["name"] for s in schema["skipped"]] == ["zzz_broken"]
+    assert "vec0" in schema["skipped"][0]["reason"]
 
 
 def test_memory_route_empty_knowledge_dir_renders_empty_state(tmp_path):

--- a/tests/test_dashboard_app.py
+++ b/tests/test_dashboard_app.py
@@ -897,6 +897,33 @@ def test_database_route_empty_store_renders_empty_state(tmp_path):
     assert "No tables" in resp.text
 
 
+def test_database_route_excludes_vec_ann_internals(tmp_path):
+    """Stores with embeddings carry sqlite-vec ``vec0`` virtual tables
+    (``vec_<model>`` + shadows) whose module is not loaded on the
+    dashboard's plain read-only connection — introspecting them crashed
+    the whole view with "no such module: vec0". The ANN internals are
+    excluded like the FTS shadows, and an unavailable module can never
+    kill the view (fts5 stands in for an exotic module here)."""
+    db = tmp_path / "vectors.db"
+    conn = sqlite3.connect(db)
+    conn.executescript(
+        """
+        CREATE TABLE repos(id INTEGER PRIMARY KEY);
+        CREATE VIRTUAL TABLE vec_BAAI_bge_m3 USING fts5(chunk);
+        CREATE VIRTUAL TABLE vec_hash_256_v1_chunks USING fts5(chunk);
+        """
+    )
+    conn.commit()
+    conn.close()
+    client = _panel_client(tmp_path, str(db), str(tmp_path / "missing"))
+    resp = client.get("/database")
+    assert resp.status_code == 200
+
+    marker = '<script id="db-graph-data" type="application/json">'
+    payload = json.loads(resp.text.split(marker, 1)[1].split("</script>", 1)[0])
+    assert [t["name"] for t in payload["tables"]] == ["repos"]
+
+
 def test_memory_route_empty_knowledge_dir_renders_empty_state(tmp_path):
     client = _panel_client(
         tmp_path,

--- a/tests/test_dashboard_app.py
+++ b/tests/test_dashboard_app.py
@@ -898,13 +898,9 @@ def test_database_route_empty_store_renders_empty_state(tmp_path):
 
 
 def test_database_route_excludes_vec_ann_internals(tmp_path):
-    """Stores with embeddings carry sqlite-vec ``vec0`` virtual tables
-    (``vec_<model>`` + shadows) whose module is not loaded on the
-    dashboard's plain read-only connection — introspecting them crashed
-    the whole view with "no such module: vec0". The ANN internals are
-    excluded by name like the FTS shadows. (The fts5 tables stand in for
-    the vec0 shapes only; the never-fatal introspection skip is covered by
-    test_database_schema_reports_skipped_tables.)"""
+    """sqlite-vec internals (``vec_*``) are excluded by name like the FTS
+    shadows. Introspection-skip coverage:
+    test_database_schema_reports_skipped_tables."""
     db = tmp_path / "vectors.db"
     conn = sqlite3.connect(db)
     conn.executescript(
@@ -926,11 +922,8 @@ def test_database_route_excludes_vec_ann_internals(tmp_path):
 
 
 def test_database_schema_reports_skipped_tables(tmp_path):
-    """A table whose introspection raises (module unavailable, transient
-    lock, ...) is skipped without killing the view AND is reported in the
-    ``skipped`` payload — the omission is observable, never silent. A
-    connection factory stands in for the un-loadable module, since a
-    module-less virtual table cannot be created in-process."""
+    """An unintrospectable table is skipped (never fatal) and reported in
+    ``skipped``. The connection factory simulates an unloadable module."""
     from cairn.dashboard.data import get_database_schema
 
     db = tmp_path / "broken.db"

--- a/tests/test_logging_config.py
+++ b/tests/test_logging_config.py
@@ -169,3 +169,51 @@ def test_module_logger_inherits_level(reset_cairn_logger):
     configure_logging()
     child = logging.getLogger("cairn.graph.semantic")
     assert child.getEffectiveLevel() == logging.DEBUG
+
+
+# --- server-noise suppression ----------------------------------------------
+
+@pytest.fixture
+def reset_noisy_loggers():
+    """Restore the third-party loggers quiet_server_noise() mutates."""
+    saved = {n: logging.getLogger(n).level for n in ("huggingface_hub", "mcp")}
+    yield
+    for n, lvl in saved.items():
+        logging.getLogger(n).setLevel(lvl)
+
+
+class TestQuietServerNoise:
+    def test_noisy_loggers_raised_to_error(self, reset_noisy_loggers, monkeypatch):
+        monkeypatch.delenv("TQDM_DISABLE", raising=False)
+        from cairn.utils.logging import quiet_server_noise
+
+        quiet_server_noise()
+        for name in ("huggingface_hub", "mcp"):
+            assert logging.getLogger(name).level == logging.ERROR
+        assert os.environ["TQDM_DISABLE"] == "1"
+
+    def test_existing_tqdm_disable_respected(self, reset_noisy_loggers, monkeypatch):
+        monkeypatch.setenv("TQDM_DISABLE", "0")
+        from cairn.utils.logging import quiet_server_noise
+
+        quiet_server_noise()
+        assert os.environ["TQDM_DISABLE"] == "0"
+
+    def test_warnings_suppressed_at_source(self, reset_noisy_loggers, monkeypatch, caplog):
+        monkeypatch.delenv("TQDM_DISABLE", raising=False)
+        from cairn.utils.logging import quiet_server_noise
+
+        quiet_server_noise()
+        with caplog.at_level(logging.WARNING):
+            logging.getLogger("huggingface_hub").warning("hub hint")
+            logging.getLogger("mcp").warning("pre-init request")
+        assert caplog.records == []
+
+    def test_errors_still_propagate(self, reset_noisy_loggers, monkeypatch, caplog):
+        monkeypatch.delenv("TQDM_DISABLE", raising=False)
+        from cairn.utils.logging import quiet_server_noise
+
+        quiet_server_noise()
+        with caplog.at_level(logging.ERROR):
+            logging.getLogger("huggingface_hub").error("real failure")
+        assert len(caplog.records) == 1


### PR DESCRIPTION
## Summary

Two bugfixes in one branch:

1. **Compass generation in multi-repo workspaces** (reported from the polaris workspace): the critic rejected backtick-quoted *directory* paths (`app/adk`, `tests/unit`) as "hallucinated file path" even off a fresh build — directories are never graph rows, they exist only as prefixes of `files.path`. Separately, a bare module name (`app`) mixed facts from every repo with a same-named directory (polaris-app + polaris-api) via an unanchored `%app%` path LIKE with a silently-dropped repo predicate.
2. **Dashboard database view**: stores with sqlite-vec embeddings crashed the `/database` view with "no such module: vec0" — the `vec0` virtual tables and their shadows are now excluded like FTS shadows, and per-table introspection is never fatal.

## Change type

- [ ] Feature / improvement
- [x] Bugfix
- [ ] Refactor (no behavior change)
- [ ] Docs / chore / CI

## Audit checklist

Author — confirm before requesting review (procedure: `docs/review-checklist.md`):

- [x] **Blast radius checked** — all `file_exists` consumers traced (compass critic, memory scoring refs-verified fraction, wiki sources/refine, task gate, knowledge workflow): the change strictly widens path acceptance (directories + repo-qualified refs), which all consumers inherit deliberately. Module-resolution changes are internal to compass generation; `ModuleResolutionError` is a new symbol, no existing signature changed; no public API touched.
- [x] **Layering respected** — the fix lives in `refs.py` (the neutral shared layer) and `compass/generator.py`; critic/scoring keep importing from `refs` unchanged.
- [x] **Graph updated** — `cairn update` ran after the fix.
- [x] **Memory recorded** — decision memory recorded (directory/repo-bridge validation + repo-scoped resolution, incl. the "how to apply" rule for future path joins).
- [x] **Fallback/perf paths** — `cairn doctor` exit 0; the validation adds one extra indexed query per *unresolved* ref only.
- [x] **Tests** — new `tests/test_compass_generator.py` (13 tests: resolution, repo scoping, substring-decoy regression, cross-deps, CLI) + 5 new critic cases (directory refs, segment boundary, repo bridge, hallucinated-dir rejection, integration). Hermetic in-memory fixtures only.
- [x] **CHANGELOG** — `[Unreleased]` → `### Fixed` entries added for both fixes.
- [x] **Gates green** — pre-commit passed on every changed file; mypy clean on changed sources; conventional PR title.

## Blast-radius note

`refs.file_exists` is the widest touchpoint: every consumer listed above now also accepts directory-prefix refs and repo-qualified refs — deliberate (a memory citing `src/cairn/compass/` now counts as graph-verified). Cross-module deps keep repo-qualified labels, which the bridged validator now accepts; a same-named directory in another repo counts as a cross-module target rather than being silently dropped or mixed in.

## Verification

- `pytest -q -m "not infra"` (the PR-leg CI command): **2449 passed**, 4 failed, 201 deselected. The 4 failures are `tests/test_ensure_semantic_deps.py` and are pre-existing on this machine (identical at the base commit in a detached worktree): the local venv already satisfies the semantic deps, so the mocked verification-failure path never runs; CI's clean legs pass them.
- mypy on changed sources: no issues. pre-commit: all hooks passed.
- `cairn update` + `cairn doctor`: exit 0 (PASS).
- End-to-end on the real cairn graph: `cairn compass generate src/cairn/compass --dry-run` → `passed: True quality: 1.00 errors: 0` (the deterministic generator now survives its own critic with cross-deps present).
- Dashboard fix covered by `test_database_route_excludes_vec_ann_internals` (in 174a8ba).
