### PR TITLE
fix(agents): register Claude Code global MCP via separated argv

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   seeds); in-flight legacy tasks complete normally.
 
 ### Fixed
+- Agent install (`install-agents --scope global`, Claude Code): the
+  `claude mcp add` registration places `-e` entries before a `--`
+  separator so server commands carrying flags (the
+  `python -m cairn.cli.main` fallback) register instead of being
+  rejected as unknown options, and a non-zero CLI exit is reported as a
+  WARNING naming the exit code and stderr instead of a success note.
+  The user-scope registration file (`~/.claude.json`) is now read by
+  `check_installed` and the doctor's registration audit (env-staleness
+  check + spawn probe), matching the other clients' global configs.
 - Server boot (`cairn serve` / MCP stdio): non-actionable third-party
   output suppressed — HF Hub unauthenticated-request warnings, MCP
   pre-initialization request warnings, model-loading progress bars.

--- a/src/cairn/agent_install/clients/claude.py
+++ b/src/cairn/agent_install/clients/claude.py
@@ -108,7 +108,8 @@ def install_claude(workspace: str, force: bool, dry_run: bool,
                     argv += ["-e", f"{key}={value}"]
                 argv += ["--", *resolve_cg_command(), "serve"]
             try:
-                proc = subprocess.run(argv, capture_output=True, timeout=15, check=False)
+                proc = subprocess.run(argv, capture_output=True, timeout=15, check=False,
+                                      text=True, errors="replace")
             except (subprocess.SubprocessError, OSError) as e:
                 res.notes.append(
                     f"WARNING: `claude mcp add --scope user` failed ({e}); "

--- a/src/cairn/agent_install/clients/claude.py
+++ b/src/cairn/agent_install/clients/claude.py
@@ -97,22 +97,35 @@ def install_claude(workspace: str, force: bool, dry_run: bool,
                 argv = ["claude", "mcp", "add", "--transport", "sse",
                         "--scope", "user", "cairn", url]
             else:
-                cmd = resolve_cg_command()
-                argv = ["claude", "mcp", "add", "cairn", "--scope", "user", *cmd, "serve"]
-                # `claude mcp add` persists -e/--env KEY=value into the
-                # user-scope registration; a non-default home must ride along
-                # or the spawned server resolves the default store.
+                # `claude mcp add <name> [-e KEY=value] -- <command> [args...]`:
+                # `--` ends option parsing; everything after it is the server
+                # command stored verbatim as the registration argv. `-e`
+                # entries persist into the user-scope registration's env
+                # block; a non-default home must ride along or the spawned
+                # server resolves the default store.
+                argv = ["claude", "mcp", "add", "cairn", "--scope", "user"]
                 for key, value in cairn_home_env().items():
                     argv += ["-e", f"{key}={value}"]
+                argv += ["--", *resolve_cg_command(), "serve"]
             try:
-                subprocess.run(argv, capture_output=True, timeout=15, check=False)
-                res.notes.append("Registered MCP globally via `claude mcp add --scope user`.")
+                proc = subprocess.run(argv, capture_output=True, timeout=15, check=False)
             except (subprocess.SubprocessError, OSError) as e:
                 res.notes.append(
                     f"WARNING: `claude mcp add --scope user` failed ({e}); "
                     "MCP not registered globally. Re-run with the claude CLI on PATH "
                     "or install per-workspace (scope=workspace)."
                 )
+            else:
+                if proc.returncode == 0:
+                    res.notes.append("Registered MCP globally via `claude mcp add --scope user`.")
+                else:
+                    err = (proc.stderr or proc.stdout or "").strip()
+                    res.notes.append(
+                        f"WARNING: `claude mcp add --scope user` exited "
+                        f"{proc.returncode}: {err[:200]}; MCP not registered "
+                        "globally. Re-run with the claude CLI on PATH or install "
+                        "per-workspace (scope=workspace)."
+                    )
         else:
             res.notes.append(
                 "WARNING: global MCP requires the `claude` CLI on PATH "

--- a/src/cairn/agent_install/detect.py
+++ b/src/cairn/agent_install/detect.py
@@ -158,11 +158,13 @@ def check_installed(workspace: str) -> dict[str, bool]:
     home = Path.home()
     result: dict[str, bool] = {}
 
-    # claude: .mcp.json has cairn OR .claude/skills/cairn/ exists
+    # claude: .mcp.json has cairn OR .claude/skills/cairn/ exists OR the
+    # user-scope ~/.claude.json registration has cairn
     result["claude"] = (
         _json_has_cairn(ws / ".mcp.json")
         or (ws / ".claude" / "skills" / "cairn" / "SKILL.md").exists()
         or _json_has_cairn(home / ".claude" / "settings.json")
+        or _json_has_cairn(home / ".claude.json")
     )
 
     # claude-desktop: global config has cairn in mcpServers

--- a/src/cairn/cli/system.py
+++ b/src/cairn/cli/system.py
@@ -1347,9 +1347,11 @@ def _check_config() -> dict:
 # Per-client MCP registration files the doctor audits -- exactly the config
 # paths ``check_installed`` consults (agent_install/detect.py), i.e. the files
 # ``install-agents`` writes. Workspace files are cwd-relative; home files are
-# relative to Path.home(). Registrations made through external CLIs without a
-# file this installer wrote (droid via ``droid mcp add``) stay outside these
-# files, matching D-006: the audit covers what check_installed can read.
+# relative to Path.home(). claude's user-scope registration is written by
+# `claude mcp add --scope user` into ~/.claude.json and is read here like any
+# home-level config. Registrations made through external CLIs into files that
+# hold no readable cairn entry (droid via ``droid mcp add``) stay outside
+# these files, matching D-006: the audit covers what check_installed can read.
 _REG_WS_FILES: dict[str, str] = {
     "claude": ".mcp.json",
     "cursor": ".cursor/mcp.json",
@@ -1360,6 +1362,7 @@ _REG_WS_FILES: dict[str, str] = {
     "omp": ".omp/mcp.json",
 }
 _REG_HOME_FILES: dict[str, tuple[str, ...]] = {
+    "claude": ("~/.claude.json",),
     "cursor": ("~/.cursor/mcp.json",),
     "zcode": ("~/.zcode/config.json", "~/.zcode/cli/config.json"),
     "agy": ("~/.gemini/config/mcp_config.json",),

--- a/tests/test_install_uninstall_fidelity.py
+++ b/tests/test_install_uninstall_fidelity.py
@@ -17,7 +17,8 @@ Scope of this module:
 Safety: every global-scope test monkeypatches Path.home to a throwaway dir
 and every subprocess-spawning CLI (claude/droid) is mocked -- the real
 ~/.claude, ~/.cursor, ~/.zcode are never touched and no real `mcp add/remove`
-ever executes.
+ever executes. The one opt-in CLI integration test runs the real `claude`
+binary with HOME pointed at a throwaway dir (same guarantees).
 """
 from __future__ import annotations
 
@@ -647,7 +648,10 @@ class TestTransportDefault:
 
         add = [c for c in calls if c[:3] == ["claude", "mcp", "add"]]
         assert len(add) == 2
-        assert add[1][-2:] == ["-e", f"CAIRN_HOME={custom_home}"]
+        # -e entries precede the `--` separator; the server command follows it.
+        assert f"CAIRN_HOME={custom_home}" in add[1]
+        assert add[1].index(f"CAIRN_HOME={custom_home}") < add[1].index("--")
+        assert add[1][-1] == "serve"
 
 
 # --------------------------------------------------------------------------
@@ -874,3 +878,143 @@ class TestInstallVerification:
             assert str(resolved) in res.verification_detail, (
                 f"{res.client}: FAIL must name the store it actually "
                 f"resolved ({resolved})")
+
+
+# --------------------------------------------------------------------------
+# Claude Code global MCP registration (`claude mcp add --scope user`)
+# --------------------------------------------------------------------------
+
+# Pristine shutil.which, captured at import time -- before the hermetic
+# fixture swaps in its agent-CLI-blocking replacement.
+_PRISTINE_WHICH = shutil.which
+
+
+class TestClaudeGlobalMcpRegistration:
+    """`install-agents --scope global` registers Claude Code's MCP via the
+    `claude` CLI (Claude Code reads no global ~/.mcp.json file). The spawned
+    argv must survive the CLI's own option parser and the outcome must be
+    reported honestly."""
+
+    def test_stdio_argv_ends_option_parsing_before_server_command(
+            self, fake_home, tmp_path, monkeypatch):
+        """Module-fallback command shape (`python -m cairn.cli.main serve`):
+        `--` must separate it from claude's own options, or the CLI parses
+        the server command's flags as its own and the add fails."""
+        from cairn.agent_install.clients import claude as claude_mod
+
+        monkeypatch.delenv("CAIRN_HOME", raising=False)
+        _cli_at(monkeypatch, "claude")
+        calls = _spy_subprocess(monkeypatch)
+        monkeypatch.setattr(claude_mod, "resolve_cg_command",
+                            lambda: ["/usr/bin/python3", "-m", "cairn.cli.main"])
+
+        ws = tmp_path / "ws"
+        ws.mkdir()
+        rep = install(str(ws), clients=["claude"], scope="global", transport="stdio")
+
+        assert calls == [["claude", "mcp", "add", "cairn", "--scope", "user",
+                          "--", "/usr/bin/python3", "-m", "cairn.cli.main",
+                          "serve"]]
+        res = next(r for r in rep.results if r.client == "claude")
+        assert any("Registered MCP globally" in n for n in res.notes)
+
+    def test_stdio_argv_pins_home_env_before_separator(
+            self, fake_home, tmp_path, monkeypatch):
+        """A non-default home rides along as -e entries placed before `--`;
+        everything after `--` is the server command verbatim."""
+        from cairn.agent_install.clients import claude as claude_mod
+
+        _cli_at(monkeypatch, "claude")
+        calls = _spy_subprocess(monkeypatch)
+        monkeypatch.setattr(claude_mod, "resolve_cg_command", lambda: ["/fake/cairn"])
+        monkeypatch.setattr(claude_mod, "cairn_home_env",
+                            lambda: {"CAIRN_HOME": "/custom/home"})
+
+        ws = tmp_path / "ws"
+        ws.mkdir()
+        install(str(ws), clients=["claude"], scope="global", transport="stdio")
+
+        assert calls == [["claude", "mcp", "add", "cairn", "--scope", "user",
+                          "-e", "CAIRN_HOME=/custom/home",
+                          "--", "/fake/cairn", "serve"]]
+
+    def test_stdio_nonzero_exit_reports_warning_not_success(
+            self, fake_home, tmp_path, monkeypatch):
+        """A failed `claude mcp add` (non-zero exit) must surface as a
+        WARNING naming the exit code and the CLI's stderr -- never as the
+        success note."""
+        from cairn.agent_install.clients import claude as claude_mod
+
+        _cli_at(monkeypatch, "claude")
+        monkeypatch.setattr(claude_mod, "resolve_cg_command",
+                            lambda: ["/usr/bin/python3", "-m", "cairn.cli.main"])
+
+        class _R:
+            returncode = 1
+            stdout = ""
+            stderr = "error: unknown option '-m'"
+
+        monkeypatch.setattr(subprocess, "run", lambda *a, **k: _R())
+
+        ws = tmp_path / "ws"
+        ws.mkdir()
+        rep = install(str(ws), clients=["claude"], scope="global", transport="stdio")
+
+        res = next(r for r in rep.results if r.client == "claude")
+        assert not any("Registered MCP globally" in n for n in res.notes)
+        assert any("exited 1" in n and "unknown option '-m'" in n
+                   for n in res.notes)
+
+    def test_doctor_reads_claude_user_scope_registration(
+            self, fake_home, tmp_path):
+        """The user-scope file `claude mcp add --scope user` writes
+        (~/.claude.json) is one of the configs the registration audit reads,
+        and it alone marks claude installed."""
+        from cairn.agent_install import check_installed
+        from cairn.cli.system import _enumerate_registrations
+
+        ws = tmp_path / "ws"
+        ws.mkdir()
+        entry = {"type": "stdio", "command": "/bin/echo", "args": ["serve"]}
+        user_cfg = fake_home / ".claude.json"
+        user_cfg.write_text(json.dumps({"mcpServers": {"cairn": entry}}),
+                            encoding="utf-8")
+
+        assert check_installed(str(ws))["claude"] is True
+
+        claude_hits = [(c, d, e) for c, d, e in _enumerate_registrations()
+                       if c == "claude"]
+        assert ("claude", "~/.claude.json", entry) in claude_hits
+
+    @pytest.mark.skipif(
+        not os.environ.get("CAIRN_TEST_CLAUDE_CLI") or not shutil.which("claude"),
+        reason="opt-in end-to-end probe (CAIRN_TEST_CLAUDE_CLI=1); needs the real claude CLI",
+    )
+    def test_claude_cli_global_registration_end_to_end(
+            self, tmp_path, monkeypatch):
+        """The real `claude mcp add` accepts the spawned argv and stores the
+        full server command (with its flags) as the registration. HOME is
+        pointed at a throwaway dir, so the real ~/.claude is never touched."""
+        from cairn.agent_install._common import resolve_cg_command
+
+        # Unblock the hermetic fixture's which() for claude only; the
+        # throwaway-HOME sandbox still applies to everything else.
+        monkeypatch.setattr(
+            shutil, "which",
+            lambda name, *a, **k: _PRISTINE_WHICH(name, *a, **k) if name == "claude" else None)
+
+        home = tmp_path / "claude_home"
+        home.mkdir()
+        ws = tmp_path / "ws"
+        ws.mkdir()
+        monkeypatch.setattr(Path, "home", lambda *a, **k: home)
+        monkeypatch.setenv("HOME", str(home))
+
+        install(str(ws), clients=["claude"], scope="global", transport="stdio")
+
+        cfg = json.loads((home / ".claude.json").read_text(encoding="utf-8"))
+        entry = cfg["mcpServers"]["cairn"]
+        cmd = resolve_cg_command()
+        assert entry["type"] == "stdio"
+        assert entry["command"] == cmd[0]
+        assert entry["args"] == [*cmd[1:], "serve"]


### PR DESCRIPTION
## Summary

`install-agents --scope global` did not register MCP for Claude Code in environments where `cairn` is not on PATH: the spawned `claude mcp add` argv lacked the `--` separator the CLI requires before the server command, so the `python -m cairn.cli.main` fallback was rejected (`error: unknown option '-m'`, exit 1) while the tool reported success. The user-scope registration file (`~/.claude.json`) was also invisible to `check_installed` and the doctor's registration audit.

## Change type

- [x] Bugfix

## Audit checklist

Author — confirm before requesting review (procedure: `docs/review-checklist.md`):

- [x] **Blast radius checked** — changed symbols: `install_claude` (global stdio branch), `check_installed` (claude entry), `_REG_HOME_FILES` / `_client_config_paths` consumers (`_enumerate_registrations` → `_registration_findings` → `_check_environment`). Caller review: `install_claude` is dispatched only via `agent_install.install`; `check_installed` consumers are `install-agents` CLI, `_enumerate_registrations`, and tests — all read the returned dict generically, no shape change. No public API signatures changed; no cross-repo consumers (MCP tools unavailable in-session; verified by direct caller grep + reading all call sites).
- [x] **Layering respected** — change stays inside `agent_install` (client integration) and `cli/system.py`'s existing registration-audit tables; no new cross-layer imports.
- [x] **Graph updated** — `cairn update` ran on the branch.
- [x] **Memory recorded** — decision (argv contract + `~/.claude.json` audit), mistake (unconditional success note after `check=False`), pattern (testing a real CLI under the hermetic which-blocking conftest) recorded with confidence 0.9–0.95.
- [x] **Fallback/perf paths** — the change modifies the module-fallback (`python -m`) registration path of the Claude installer. The doctor's registration-consistency audit (`_registration_findings` / `_enumerate_registrations`) was exercised directly against the real machine's registrations post-change: the claude user-scope entry is enumerated, env-inspected, and spawn-probed (WARN verdict consistent with TC-015); full `cairn doctor` suite unchanged elsewhere.
- [x] **Tests** — full suite green (2648 passed, 4 skipped; the two environmental numpy failures — `tests/test_vector_scan.py` collection and `test_retrieval.py::test_fallback_agrees_with_numpy_path_when_numpy_present` — fail identically on clean `main` with the changes stashed). New tests are hermetic: throwaway `Path.home`/env via existing fixtures and mocked subprocess; the single real-CLI integration test is opt-in (`CAIRN_TEST_CLAUDE_CLI=1`) and points HOME at a throwaway dir.
- [x] **CHANGELOG** — `[Unreleased] → Fixed` entry added.
- [x] **Gates green** — `pre-commit run --all-files` passes (ruff, gitleaks, hygiene hooks); PR title is conventional.

## Blast-radius note

No signature changes. `check_installed`'s claude result can newly flip to True when only a user-scope `~/.claude.json` registration exists — intended (a registration IS installed wiring); consumers treat the dict as booleans only. The doctor can now WARN on an env-less user-scope registration, which is the same uniform rule every other client's registration is already subject to (TC-015).

## Verification

- Reproduced the original failure with the real `claude` CLI (v2.1.260) in an isolated HOME: `claude mcp add cairn --scope user <python> -m cairn.cli.main serve` → exit 1, nothing registered; with `--` → exit 0, correct argv stored.
- `pytest tests/test_install_uninstall_fidelity.py` → 39 passed incl. the opt-in end-to-end probe (`CAIRN_TEST_CLAUDE_CLI=1`), which round-trips the real `claude mcp add` in a throwaway HOME and asserts the stored registration.
- Full suite, `pytest -m core`, and `pre-commit run --all-files` green.
- Doctor audit functions exercised against the live machine: claude user-scope registration enumerated from `~/.claude.json` and audited.