### PR TITLE
fix(agents): align droid MCP registration with the documented CLI contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   seeds); in-flight legacy tasks complete normally.
 
 ### Fixed
+- Agent install (droid): `droid mcp add` matches the documented stdio
+  shape (the full server command as one argument, `--type stdio`) and
+  pins a non-default home via the CLI's `--env` flag (replacing the
+  "no verified env mechanism" warning). A non-zero CLI exit is reported
+  as a WARNING naming the exit code and stderr, and falls back to the
+  `.factory/mcp.json` file registration; `droid mcp remove` reports
+  non-zero exits instead of staying silent. The user-scope
+  registration file (`~/.factory/mcp.json`) is now read by
+  `check_installed` and the doctor's registration audit, matching the
+  other clients' global configs.
 - Agent install (`install-agents --scope global`, Claude Code): the
   `claude mcp add` registration places `-e` entries before a `--`
   separator so server commands carrying flags (the

--- a/src/cairn/agent_install/clients/droid.py
+++ b/src/cairn/agent_install/clients/droid.py
@@ -2,7 +2,7 @@
 
 Droid reads the ``.factory/`` tree (skills, commands, droids) and registers
 MCP via ``droid mcp add`` when the CLI is present, falling back to a
-``.factory/mcp.json`` file otherwise.
+``.factory/mcp.json`` file when the CLI is absent or the add fails.
 """
 from __future__ import annotations
 
@@ -50,29 +50,45 @@ def install_droid(workspace: str, force: bool, dry_run: bool,
     _write_file(ws / ".factory" / "droids" / "knowledge-steward.md",
                 _claude_agent_md("cursor/knowledge-steward.json"), force, res, dry_run=dry_run)
 
-    # MCP: prefer `droid mcp add` if the CLI is available; else write a config file.
+    # MCP: prefer `droid mcp add` if the CLI is available; a failed CLI add
+    # falls back to the .factory/mcp.json file so the registration lands
+    # either way (droid reads both; uninstall strips both).
     if shutil.which("droid") and not dry_run:
-        home_env: dict[str, str] = {}
         if transport == "sse":
             url = default_sse_url(sse_url)
             argv = ["droid", "mcp", "add", "cairn", url, "--type", "sse"]
         else:
-            cmd = resolve_cg_command()
-            argv = ["droid", "mcp", "add", "cairn", *cmd, "serve"]
-            home_env = cairn_home_env()
+            # Documented stdio shape: the full server command arrives as ONE
+            # argument (droid splits it), so server-command flags are never
+            # parsed as droid options. `--env` entries persist into the
+            # registration; a non-default home must ride along or the
+            # spawned server resolves the default store.
+            argv = ["droid", "mcp", "add", "cairn",
+                    " ".join([*resolve_cg_command(), "serve"]),
+                    "--type", "stdio"]
+            for key, value in cairn_home_env().items():
+                argv += ["--env", f"{key}={value}"]
+        registered = False
         try:
-            subprocess.run(argv, capture_output=True, timeout=10, check=False)
-            res.notes.append("Registered MCP via `droid mcp add`.")
-            if home_env:
+            proc = subprocess.run(argv, capture_output=True, timeout=10, check=False,
+                                  text=True, errors="replace")
+            registered = proc.returncode == 0
+            if registered:
+                res.notes.append("Registered MCP via `droid mcp add`.")
+            else:
+                err = (proc.stderr or proc.stdout or "").strip()
                 res.notes.append(
-                    "WARNING: the `droid mcp add` registration embeds no CAIRN_HOME "
-                    "env (the CLI has no verified env mechanism), so on a custom "
-                    "home the registered server may resolve the default store; a "
-                    "workspace-scope install writes a .factory/mcp.json registration "
-                    "that embeds the environment instead."
-                )
-        except (subprocess.SubprocessError, OSError):
-            res.notes.append("`droid mcp add` failed; no config file written for MCP.")
+                    f"WARNING: `droid mcp add` exited {proc.returncode}: "
+                    f"{err[:200]}.")
+        except (subprocess.SubprocessError, OSError) as e:
+            res.notes.append(f"WARNING: `droid mcp add` failed ({e}).")
+        if not registered:
+            _merge_json_file(ws / ".factory" / "mcp.json",
+                             mcp_config_json(transport, sse_url), force, res,
+                             dry_run=False)
+            res.notes.append(
+                "Wrote .factory/mcp.json so the registration is present on "
+                "the next droid run.")
     elif not shutil.which("droid"):
         # No droid CLI: write a .factory/mcp.json so it's present when droid is installed.
         _merge_json_file(ws / ".factory" / "mcp.json", mcp_config_json(transport, sse_url), force, res, dry_run=dry_run)
@@ -94,13 +110,21 @@ def _mcp_remove_droid(res: InstallResult) -> None:
     if not shutil.which("droid"):
         return
     try:
-        subprocess.run(
+        proc = subprocess.run(
             ["droid", "mcp", "remove", "cairn"],
             capture_output=True, timeout=10, check=False,
+            text=True, errors="replace",
         )
+    except (subprocess.SubprocessError, OSError) as e:
+        res.notes.append(f"WARNING: `droid mcp remove cairn` failed ({e}); the registration may remain.")
+        return
+    if proc.returncode == 0:
         res.notes.append("Removed MCP registration via `droid mcp remove cairn`.")
-    except (subprocess.SubprocessError, OSError):
-        res.notes.append("`droid mcp remove cairn` failed; the registration may remain.")
+    else:
+        err = (proc.stderr or proc.stdout or "").strip()
+        res.notes.append(
+            f"WARNING: `droid mcp remove cairn` exited {proc.returncode}: "
+            f"{err[:200]}; the registration may remain.")
 
 
 def uninstall(ws: Path, res: InstallResult, scope: str = "workspace") -> None:

--- a/src/cairn/agent_install/detect.py
+++ b/src/cairn/agent_install/detect.py
@@ -177,8 +177,13 @@ def check_installed(workspace: str) -> dict[str, bool]:
         or _json_has_cairn(home / ".cursor" / "mcp.json")
     )
 
-    # droid: .factory/skills/cairn/ exists
-    result["droid"] = (ws / ".factory" / "skills" / "cairn" / "SKILL.md").exists()
+    # droid: .factory/skills/cairn/ or .factory/mcp.json in the workspace, or
+    # the user-scope ~/.factory/mcp.json registration (`droid mcp add`)
+    result["droid"] = (
+        (ws / ".factory" / "skills" / "cairn" / "SKILL.md").exists()
+        or _json_has_cairn(ws / ".factory" / "mcp.json")
+        or _json_has_cairn(home / ".factory" / "mcp.json")
+    )
 
     # zcode: .zcode/config.json (workspace) or ~/.zcode/cli/config.json
     # (global, current) has cairn entry; ~/.zcode/config.json is legacy global.

--- a/src/cairn/cli/system.py
+++ b/src/cairn/cli/system.py
@@ -1345,13 +1345,11 @@ def _check_config() -> dict:
 # --------------------------------------------------------------------------
 
 # Per-client MCP registration files the doctor audits -- exactly the config
-# paths ``check_installed`` consults (agent_install/detect.py), i.e. the files
-# ``install-agents`` writes. Workspace files are cwd-relative; home files are
-# relative to Path.home(). claude's user-scope registration is written by
-# `claude mcp add --scope user` into ~/.claude.json and is read here like any
-# home-level config. Registrations made through external CLIs into files that
-# hold no readable cairn entry (droid via ``droid mcp add``) stay outside
-# these files, matching D-006: the audit covers what check_installed can read.
+# paths ``check_installed`` consults (agent_install/detect.py): the files
+# ``install-agents`` writes plus each client CLI's own registration file
+# (claude via ``claude mcp add --scope user`` -> ~/.claude.json, droid via
+# ``droid mcp add`` -> ~/.factory/mcp.json). Workspace files are
+# cwd-relative; home files are relative to Path.home().
 _REG_WS_FILES: dict[str, str] = {
     "claude": ".mcp.json",
     "cursor": ".cursor/mcp.json",
@@ -1364,6 +1362,7 @@ _REG_WS_FILES: dict[str, str] = {
 _REG_HOME_FILES: dict[str, tuple[str, ...]] = {
     "claude": ("~/.claude.json",),
     "cursor": ("~/.cursor/mcp.json",),
+    "droid": ("~/.factory/mcp.json",),
     "zcode": ("~/.zcode/config.json", "~/.zcode/cli/config.json"),
     "agy": ("~/.gemini/config/mcp_config.json",),
     "opencode": ("~/.config/opencode/opencode.json",),

--- a/tests/test_install_uninstall_fidelity.py
+++ b/tests/test_install_uninstall_fidelity.py
@@ -986,6 +986,28 @@ class TestClaudeGlobalMcpRegistration:
                        if c == "claude"]
         assert ("claude", "~/.claude.json", entry) in claude_hits
 
+    def test_doctor_reads_droid_user_scope_registration(
+            self, fake_home, tmp_path):
+        """The user-scope file `droid mcp add` writes (~/.factory/mcp.json)
+        is one of the configs the registration audit reads, and it alone
+        marks droid installed."""
+        from cairn.agent_install import check_installed
+        from cairn.cli.system import _enumerate_registrations
+
+        ws = tmp_path / "ws"
+        ws.mkdir()
+        entry = {"type": "stdio", "command": "/bin/echo", "args": ["serve"]}
+        user_cfg = fake_home / ".factory" / "mcp.json"
+        user_cfg.parent.mkdir(parents=True)
+        user_cfg.write_text(json.dumps({"mcpServers": {"cairn": entry}}),
+                            encoding="utf-8")
+
+        assert check_installed(str(ws))["droid"] is True
+
+        droid_hits = [(c, d, e) for c, d, e in _enumerate_registrations()
+                      if c == "droid"]
+        assert ("droid", "~/.factory/mcp.json", entry) in droid_hits
+
     @pytest.mark.skipif(
         not os.environ.get("CAIRN_TEST_CLAUDE_CLI") or not shutil.which("claude"),
         reason="opt-in end-to-end probe (CAIRN_TEST_CLAUDE_CLI=1); needs the real claude CLI",
@@ -1018,3 +1040,96 @@ class TestClaudeGlobalMcpRegistration:
         assert entry["type"] == "stdio"
         assert entry["command"] == cmd[0]
         assert entry["args"] == [*cmd[1:], "serve"]
+
+
+# --------------------------------------------------------------------------
+# Droid CLI registration (`droid mcp add`)
+# --------------------------------------------------------------------------
+
+class TestDroidCliRegistration:
+    """`droid mcp add` is a subprocess whose outcome must be reported
+    honestly and whose argv must match the documented stdio shape (the full
+    server command as ONE argument). A failed add falls back to the
+    .factory/mcp.json file so the registration lands either way."""
+
+    def test_stdio_argv_passes_server_command_as_one_argument(
+            self, tmp_path, monkeypatch):
+        from cairn.agent_install.clients import droid as droid_mod
+
+        _cli_at(monkeypatch, "droid")
+        calls = _spy_subprocess(monkeypatch)
+        monkeypatch.delenv("CAIRN_HOME", raising=False)
+        monkeypatch.setattr(droid_mod, "resolve_cg_command",
+                            lambda: ["/usr/bin/python3", "-m", "cairn.cli.main"])
+        ws = tmp_path / "ws"
+        ws.mkdir()
+
+        install(str(ws), clients=["droid"], transport="stdio")
+
+        assert calls == [["droid", "mcp", "add", "cairn",
+                          "/usr/bin/python3 -m cairn.cli.main serve",
+                          "--type", "stdio"]]
+        assert not (ws / ".factory" / "mcp.json").exists()
+
+    def test_stdio_argv_pins_home_env(self, tmp_path, monkeypatch):
+        from cairn.agent_install.clients import droid as droid_mod
+
+        _cli_at(monkeypatch, "droid")
+        calls = _spy_subprocess(monkeypatch)
+        monkeypatch.setattr(droid_mod, "resolve_cg_command", lambda: ["/fake/cairn"])
+        monkeypatch.setattr(droid_mod, "cairn_home_env",
+                            lambda: {"CAIRN_HOME": "/custom/home"})
+        ws = tmp_path / "ws"
+        ws.mkdir()
+
+        install(str(ws), clients=["droid"], transport="stdio")
+
+        add = calls[0]
+        assert add[-2:] == ["--env", "CAIRN_HOME=/custom/home"]
+
+    def test_failed_add_warns_and_falls_back_to_file(
+            self, tmp_path, monkeypatch):
+        import cairn.agent_install._common as common_mod
+        from cairn.agent_install.clients import droid as droid_mod
+
+        _cli_at(monkeypatch, "droid")
+        monkeypatch.delenv("CAIRN_HOME", raising=False)
+        # Both argv build and file fallback resolve the command independently.
+        monkeypatch.setattr(common_mod, "resolve_cg_command", lambda: ["/fake/cairn"])
+        monkeypatch.setattr(droid_mod, "resolve_cg_command", lambda: ["/fake/cairn"])
+
+        class _R:
+            returncode = 1
+            stdout = ""
+            stderr = "error: server cairn already exists"
+
+        monkeypatch.setattr(subprocess, "run", lambda *a, **k: _R())
+        ws = tmp_path / "ws"
+        ws.mkdir()
+
+        rep = install(str(ws), clients=["droid"], transport="stdio")
+
+        res = next(r for r in rep.results if r.client == "droid")
+        assert not any("Registered MCP via" in n for n in res.notes)
+        assert any("exited 1" in n and "already exists" in n for n in res.notes)
+        fallback = json.loads((ws / ".factory" / "mcp.json").read_text(encoding="utf-8"))
+        assert fallback["mcpServers"]["cairn"]["command"] == "/fake/cairn"
+
+    def test_remove_nonzero_exit_reports_warning(
+            self, fake_home, tmp_path, monkeypatch):
+        _cli_at(monkeypatch, "droid")
+
+        class _R:
+            returncode = 1
+            stdout = ""
+            stderr = "error: server cairn not found"
+
+        monkeypatch.setattr(subprocess, "run", lambda *a, **k: _R())
+        ws = tmp_path / "ws"
+        ws.mkdir()
+
+        rep = uninstall(str(ws), clients=["droid"])
+
+        res = next(r for r in rep.results if r.client == "droid")
+        assert not any("Removed MCP registration" in n for n in res.notes)
+        assert any("exited 1" in n and "not found" in n for n in res.notes)


### PR DESCRIPTION
## Summary

Audited all 9 supported agent clients for the MCP-registration bug class fixed for Claude Code in #104 (dishonest subprocess outcome, option-parser-hostile argv, unauditable registration). Only **droid** had remaining issues; this PR fixes them against Factory's documented CLI contract. The 7 file-based clients (claude-desktop, cursor, zcode, agy, opencode, kilo, omp) are clean.

## Change type

- [x] Bugfix

## Audit checklist

Author — confirm before requesting review (procedure: `docs/review-checklist.md`):

- [x] **Blast radius checked** — changed symbols: `install_droid` (MCP block), `_mcp_remove_droid`, `check_installed` (droid entry), `_REG_HOME_FILES` (droid added). `install_droid` dispatches only via `agent_install.install`; `check_installed` consumers read the dict as booleans; `_enumerate_registrations` consumes the new home-level path through the existing shape-aware parser (flat `mcpServers`). No signature changes; no cross-repo consumers.
- [x] **Layering respected** — change stays inside `agent_install` + `cli/system.py`'s existing audit tables; no new cross-layer imports.
- [x] **Graph updated** — `cairn update` ran on the branch.
- [x] **Memory recorded** — decision memory: droid registration follows the documented `droid mcp add` contract (confidence 0.9).
- [x] **Fallback/perf paths** — the module-fallback registration path changed shape (single-string command per docs) and gained a file fallback on CLI failure; targeted suites, mypy, and the full local suite are green.
- [x] **Tests** — full suite green (2652 passed, 4 skipped; the 2 pre-existing environmental numpy failures excluded as on main). New droid tests hermetic: fake CLI via `_cli_at`, spied/patched subprocess, throwaway homes.
- [x] **CHANGELOG** — `[Unreleased] → Fixed` entry added.
- [x] **Gates green** — `pre-commit run --all-files` passes; mypy clean (pinned 2.3.0); PR title is conventional.

## Blast-radius note

`check_installed`'s droid result can newly flip to True from a user-scope `~/.factory/mcp.json` registration — intended (a registration IS installed wiring). The doctor can now WARN on an env-less droid user-scope registration, the same uniform rule every other client is subject to (TC-015). The SSE argv (`--type sse`) is unchanged and pinned by the existing test.

## Verification

- Droid behavior verified against Factory's official MCP docs (docs.factory.ai/harness/mcp): documented stdio shape (`droid mcp add <name> "<command>" --type stdio`, "quote the command if it contains spaces"), `--env KEY=VALUE` (stdio, repeatable), and the config-file table (`~/.factory/mcp.json` = user config; `droid mcp add` always writes there).
- `pytest tests/test_install_uninstall_fidelity.py` → 43 passed incl. 5 new droid tests (single-string argv, `--env` pinning, failure-WARNING + file fallback, remove WARNING, doctor enumeration of `~/.factory/mcp.json`).
- Full local suite, `mypy --ignore-missing-imports src`, and `pre-commit run --all-files` green.