### PR TITLE
docs: sync shipped instructions and cli reference with current behavior

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -68,7 +68,7 @@ Group: `cairn memory …`
 |---|---|
 | `cairn serve run|start|stop|status|restart` | MCP server (stdio foreground / SSE daemon `:9876`). `start`/`stop`/`restart` manage the macOS launchd LaunchAgent; `start` embeds `CAIRN_HOME`/`CAIRN_WORKSPACE`/`CAIRN_DB`/`CAIRN_KNOWLEDGE` into the plist when a custom home is in effect. On Linux these exit 1 — run `cairn serve --port 9876` under a process supervisor, or prefer stdio. |
 | `cairn dashboard [--db] [--port]` | loopback dashboard `:8765` (read-only views + Settings) |
-| `cairn install-agents` / `uninstall-agents` | wire cairn into AI clients (claude, droid, zcode, cursor, opencode, kilo, omp, agy, claude-desktop). With a custom `CAIRN_HOME`, generated stdio registrations embed `env.CAIRN_HOME` (claude global scope via `claude mcp add -e`), hook commands embed the assignment, and each written stdio registration is spawn-verified — the report shows per-client `verify: PASS/FAIL` naming both stores on mismatch. SSE and CLI-registered clients are skipped with a note; `--dry-run` never spawns. |
+| `cairn install-agents` / `uninstall-agents` | wire cairn into AI clients (claude, droid, zcode, cursor, opencode, kilo, omp, agy, claude-desktop). With a custom `CAIRN_HOME`, generated stdio registrations embed `env.CAIRN_HOME` (CLI-registered clients carry it too: claude global scope via `claude mcp add -e`, droid via `droid mcp add --env`), hook commands embed the assignment, and each written stdio registration is spawn-verified — the report shows per-client `verify: PASS/FAIL` naming both stores on mismatch. SSE and CLI-registered clients are skipped with a note; `--dry-run` never spawns. |
 
 ## Compass / wiki / tasks / dataflow
 

--- a/src/cairn/agent_install/_common.py
+++ b/src/cairn/agent_install/_common.py
@@ -357,8 +357,8 @@ When fuzzy is right: auditing, dead-code hunting, exploring unfamiliar code.
 | `ask_compass` | Routes correctly but returns empty body skeletons when wiki/compass coverage is thin. | Drill down with the specific layer tool; don't treat empty response as "no info exists". |
 | `recall_memory` | Multi-token lexical matching, with a semantic fallback when lexical search comes up empty. | Natural-language and multi-token queries ("backoff retry policy") work, not just single symbol tokens. |
 | `impact_analysis` | Within-repo by default, but includes cross-repo consumer reach in its output. Precise mode only follows resolved edges, so common names can under-report. | Pair with `cross_repo_deps(repo)` for the full picture. Use `fuzzy=True` when precise impact looks suspiciously small for a widely-used symbol. |
-| `search_symbols` | FTS5 + phrase splitting handles underscored tokens (`*core_ui_v4*` matches correctly). For camelCase or non-prefix substring patterns, unions in a LIKE-based substring pass (FTS5's `*` is prefix-only; unicode61 doesn't split camelCase). | Wildcards and substring queries both work, on underscored and camelCase names alike. |
-| `get_callers`/`impact_analysis` on a Kotlin class invoked via `operator fun invoke` | A bare `someUseCase(params)` call (DI-injected property, the standard Android UseCase idiom) resolves the call edge to the *local property* in the calling file, not the class. The parser retargets these bare-call edges to the callee's declared type. | Both bare `someUseCase(params)` and explicit-receiver `this.someUseCase(params)` shapes retarget correctly (regression-tested). |
+| `search_symbols` | FTS5 + phrase splitting handles underscored tokens (`*core_ui_v4*` matches). Substring and camelCase patterns also match via a LIKE-based pass (the FTS5 `*` wildcard is prefix-only and the tokenizer doesn't split camelCase, so non-prefix queries fall back to LIKE). | Wildcards and substring queries both work, on underscored and camelCase names. |
+| `get_callers`/`impact_analysis` on a Kotlin class invoked via `operator fun invoke` | Bare calls of the standard Android UseCase idiom (`someUseCase(params)` against a DI-injected property) resolve to the callee's declared type. | Both bare `someUseCase(params)` and explicit-receiver `this.someUseCase(params)` shapes retarget correctly (regression-tested). |
 | `semantic_search` | Defaults to RRF fusion (BM25 + vector, `CAIRN_FUSION=1` default): the returned `score` is a rank-fusion number (~0.01-0.02), not cosine similarity, regardless of the `threshold` argument. Real cosine scores (0.3-0.6+ for genuinely on-topic hits with `local`/`BAAI/bge-m3`) only show when fusion is off. | Rank order is meaningful either way. Set `CAIRN_FUSION=0` if you need the score to reflect actual match strength (e.g. deciding how confident a hit is), not just relative order. |
 | `ann_backend_enabled` | On by default: `CAIRN_ANN_BACKEND` unset resolves to `sqlite-vec`. It degrades silently to the brute-force cosine scan if the extension fails to load. | Set `CAIRN_ANN_BACKEND=off` to force the brute-force scan. |
 
@@ -374,7 +374,7 @@ task first with `--refine-catalog`); work them through the task queue:
 - `cairn task claim <id>` -> write the page -> `cairn task complete <id> --result-file <path>`;
   the result body must end with a `## Sources` footer -- the deterministic critic
   fact-checks it against the graph before the page is promoted.
-- `cairn wiki status` -- per-page state (queued / in-progress / promoted / failed) with counts
+- `cairn wiki status` -- per-page state, derived at read time (planned / queued / in-progress / promoted / failed / dropped) with counts
 - `cairn wiki retry` -- re-queue failed pages as fresh task chains
 - `cairn wiki export --dir DIR` -- write every promoted page out as markdown
 - `cairn wiki enrich [<page-id>]` -- queue an append-only extension of a promoted page


### PR DESCRIPTION
## Summary

Full markdown audit of all 56 tracked `.md` files against the current code state. Verified 54 as current; two files had drifted and are updated here:

- `src/cairn/agent_install/_common.py` (`_INSTRUCTIONS_BODY` — the instructions shipped into every client workspace by `install-agents`): the `cairn wiki status` line now carries the current derived-at-read-time states (planned/queued/in-progress/promoted/failed/dropped), and the `search_symbols` / Kotlin `operator fun invoke` quirk rows match the maintained AGENTS.md wording.
- `docs/cli-reference.md`: the `install-agents` row now names both CLI env mechanisms (claude `mcp add -e`, droid `mcp add --env`) per #104/#105.

The repo-specific sections AGENTS.md carries (PR review gate, comment/doc style) intentionally stay out of the shipped template — they reference cairn-repo paths.

## Change type

- [x] Docs / chore / CI

## Audit checklist

- [x] **Blast radius checked** — `_INSTRUCTIONS_BODY` is a string constant consumed by `_claude_instructions`/`_agents_instructions`; no signature changes. `docs/cli-reference.md` is documentation-only.
- [x] **Layering respected** — no import or boundary changes.
- [x] **Graph updated** — `cairn update` ran.
- [x] **Memory recorded** — no new decision/pattern/mistake (doc sync; findings recorded in the PR body).
- [x] **Fallback/perf paths** — n/a (string content + docs).
- [x] **Tests** — `test_agent_surface.py` (includes the shipped-signature-vs-code sync guard), `test_agent_suite.py`, `test_install_uninstall_fidelity.py`: 69 passed; full local suite green on the parent commits; pre-commit green.
- [x] **CHANGELOG** — docs-only change; no entry per convention.
- [x] **Gates green** — pre-commit, conventional title.

## Verification (the audit itself)

- Tool inventory: 28 tools reconciled against `_EXPECTED_TOOL_COUNT` (graph 9, compass 5, memory 8, knowledge 5, wiki 1); all names present in `docs/mcp-tools.md`, `skill/references/tools.md`, `SKILL.md`; the signature-sync guard test passes.
- CLI surface: all 44 click commands verified present in `docs/cli-reference.md`; every `cairn <cmd>` reference across all tracked MDs resolves to a real command.
- Config: all 40 `CAIRN_*` env vars in code are documented in `docs/configuration.md` (1:1).
- Makefile targets referenced from MDs exist; `.knowledge/` layout claims match the store tiers (lazy-created dirs); PyPI/package/upgrade claims match pyproject and CLI.
- `specs/` left untouched (live pipeline state with in-flight edits); vendored benchmark corpus untouched.