### PR TITLE
feat(graph): enrich relationship kinds across extraction and dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Relationship-kind enrichment across extraction and display. The graph's
+  canonical edge-kind vocabulary is now `calls`, `extends`, `implements`,
+  `embeds`, `with`, `references`, `decorates`, `imports`, `contains`.
+  - Python base classes emit `extends` (was `implements`); decorators emit
+    `decorates`; signature type annotations emit `references`. Swift splits
+    a class's first inheritance target to `extends` (the superclass) from
+    protocol conformances (`implements`). Go struct/interface embedding
+    emits `embeds`. Kotlin type annotations emit `references`.
+  - Every build synthesizes one `module` symbol per file (dotted
+    repo-relative qualified name), derives `contains` edges for nesting
+    (module → top-level, parent → nested), gives module-level code an edge
+    owner, and materializes `imports` module-to-module edges from the
+    imports table by longest-suffix path matching (ambiguous and external
+    imports are skipped). Incremental syncs refresh the affected repo's
+    `imports` edges.
+  - The dashboard graph canvas colors and dash-patterns edges by kind from
+    new `--edge-*` theme tokens, renders an edge-kind legend whose chips
+    filter whole kinds, and the symbol/neighbors/inspect views pass the
+    stored edge kind through verbatim (previously every edge rendered and
+    labeled as `calls`).
+  - Resolution semantics preserved: module symbols are excluded from the
+    resolver's candidate indexes (a file named after its single class
+    would otherwise make same-name references ambiguous), `embeds` joins
+    `extends`/`implements` in the receiver-dispatch ancestor index, and
+    the new kinds stay outside `STRUCTURAL_EDGE_KINDS` so impact/trace
+    radius is unchanged. Requires a rebuild (`cairn build`) to take
+    effect.
+
 ### Fixed
 - The doc-link completion gate now confines proposed edges to the
   completing task's island members: a result naming an existing doc

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     `extends`/`implements` in the receiver-dispatch ancestor index, and
     the new kinds stay outside `STRUCTURAL_EDGE_KINDS` so impact/trace
     radius is unchanged. Requires a rebuild (`cairn build`) to take
-    effect.
+    effect. The DS-v2 ground-truth seal's recorded per-corpus build
+    facts are re-pinned to the new deterministic counts (558/558
+    expectations and tree_hash pins unchanged).
 
 ### Fixed
 - The doc-link completion gate now confines proposed edges to the

--- a/benchmarks/datasource/ds2/ground_truth/AUTHORING.md
+++ b/benchmarks/datasource/ds2/ground_truth/AUTHORING.md
@@ -39,9 +39,11 @@ Per batch (~22-38 queries), after landing:
 2. Fresh scratch builds, one per corpus, mirroring
    `scripts/verify_ground_truth.py:build_fresh_graph` (copy to a throwaway
    workspace, `.git` scanner marker on the COPY only, `build_graph` over the
-   workspace):
-   - attrs: repos=1 files=50 symbols=1672 edges=4174 parse_errors=0
-   - yarl:  repos=1 files=24 symbols=1066 edges=2432 parse_errors=0
+   workspace) — facts re-pinned when the edge-kind enrichment changed the
+   deterministic per-corpus build output (one module symbol per file;
+   contains/imports/references/decorates/extends edges):
+   - attrs: repos=1 files=50 symbols=1722 edges=6239 parse_errors=0
+   - yarl:  repos=1 files=24 symbols=1090 edges=4112 parse_errors=0
 3. Resolution gate (STRONGER than the brief's >=10 spot-check): every one of
    the 392 expectations resolved tier-1-exact against its corpus inventory —
    exact symbol-name equality plus exact repo-relative file-path equality

--- a/benchmarks/datasource/ds2/verify_dataset.py
+++ b/benchmarks/datasource/ds2/verify_dataset.py
@@ -60,7 +60,7 @@ CORPORA = {
         "source": DS2_ROOT / "second-corpus" / "attrs-26.1.0",
         "prefix": "attrs-26.1.0/",
         "recorded_facts": {
-            "repos": 1, "files": 50, "symbols": 1672, "edges": 4174,
+            "repos": 1, "files": 50, "symbols": 1722, "edges": 6239,
             "parse_errors": 0,
         },
     },
@@ -68,7 +68,7 @@ CORPORA = {
         "source": REPO_ROOT / "benchmarks" / "datasource" / "t2" / "yarl",
         "prefix": "yarl/",
         "recorded_facts": {
-            "repos": 1, "files": 24, "symbols": 1066, "edges": 2432,
+            "repos": 1, "files": 24, "symbols": 1090, "edges": 4112,
             "parse_errors": 0,
         },
     },

--- a/src/cairn/dashboard/data.py
+++ b/src/cairn/dashboard/data.py
@@ -196,7 +196,12 @@ def inspect_symbol(conn: sqlite3.Connection, name: str) -> Dict:
         truncated = len(fetched) > INSPECT_NEIGHBOR_CAP
         return (
             [
-                {"name": r["name"], "kind": r["kind"], "file": r["file"]}
+                {
+                    "name": r["name"],
+                    "kind": r["kind"],
+                    "file": r["file"],
+                    "edge_kind": r["ekind"],
+                }
                 for r in fetched[:INSPECT_NEIGHBOR_CAP]
             ],
             truncated,
@@ -204,13 +209,13 @@ def inspect_symbol(conn: sqlite3.Connection, name: str) -> Dict:
 
     cap = INSPECT_NEIGHBOR_CAP + 1
     callers, callers_truncated = _neighbors(
-        f"SELECT s.name, s.kind, f.path AS file "
+        f"SELECT s.name, s.kind, f.path AS file, e.kind AS ekind "
         f"FROM edges e JOIN symbols s ON e.source_id = s.id "
         f"JOIN files f ON s.file_id = f.id "
         f"WHERE e.target_id = ? LIMIT {cap}"
     )
     callees, callees_truncated = _neighbors(
-        f"SELECT t.name, t.kind, f.path AS file "
+        f"SELECT t.name, t.kind, f.path AS file, e.kind AS ekind "
         f"FROM edges e JOIN symbols t ON e.target_id = t.id "
         f"JOIN files f ON t.file_id = f.id "
         f"WHERE e.source_id = ? LIMIT {cap}"

--- a/src/cairn/dashboard/static/app.css
+++ b/src/cairn/dashboard/static/app.css
@@ -37,6 +37,15 @@
   --kind-enum: #f472b6;
   --kind-module: #fbbf24;
   --kind-external: #8b9bb4;
+  --edge-calls: #7aa2f7;
+  --edge-extends: #c084fc;
+  --edge-implements: #34d399;
+  --edge-embeds: #2dd4bf;
+  --edge-with: #f472b6;
+  --edge-references: #8a8f98;
+  --edge-decorates: #fbbf24;
+  --edge-imports: #fb923c;
+  --edge-contains: #62666d;
   color-scheme: dark;
 }
 
@@ -63,6 +72,15 @@
   --kind-enum: #f472b6;
   --kind-module: #fbbf24;
   --kind-external: #8b9bb4;
+  --edge-calls: #7aa2f7;
+  --edge-extends: #c084fc;
+  --edge-implements: #34d399;
+  --edge-embeds: #2dd4bf;
+  --edge-with: #f472b6;
+  --edge-references: #8a8f98;
+  --edge-decorates: #fbbf24;
+  --edge-imports: #fb923c;
+  --edge-contains: #62666d;
   color-scheme: dark;
 }
 
@@ -89,6 +107,15 @@
   --kind-enum: #db2777;
   --kind-module: #b45309;
   --kind-external: #6b7280;
+  --edge-calls: #4c6ef5;
+  --edge-extends: #9333ea;
+  --edge-implements: #059669;
+  --edge-embeds: #0d9488;
+  --edge-with: #db2777;
+  --edge-references: #6b7280;
+  --edge-decorates: #b45309;
+  --edge-imports: #c2410c;
+  --edge-contains: #9ca3af;
   color-scheme: light;
 }
 

--- a/src/cairn/dashboard/static/app.js
+++ b/src/cairn/dashboard/static/app.js
@@ -14,7 +14,10 @@
      method, class, interface, enum, module, external) from the same
      palette the legend renders; legend items are clickable filters
      that hide/show every node of that kind — vis hides connected
-     edges with their endpoints.
+     edges with their endpoints. Edges color and dash by edge kind
+     (calls, extends, implements, embeds, with, references, decorates,
+     imports, contains) from the --edge-* tokens; the edge legend's
+     chips filter whole edge kinds the same way.
    - Label discipline: dense graphs (>30 nodes with edges) label only
      the top quarter by degree; edgeless or small graphs label
      everything. Zooming out past 0.45 strips labels graph-wide (the
@@ -115,6 +118,78 @@
       highlight: { background: c, border: cssVar("--text-1") },
       hover: { background: c, border: cssVar("--text-1") }
     };
+  }
+
+  /* ---- Edge-kind coloring & filters ---- */
+
+  /* Edge kinds map to --edge-* theme tokens the same way node kinds map
+     to --kind-*; unknown kinds fall back to the hairline token (the
+     pre-token single-color rendering). Dash patterns separate the
+     structural kinds (solid) from the softer ones (containment, typing,
+     decoration, module imports). */
+  var EDGE_KIND_TOKENS = {
+    calls: "--edge-calls",
+    extends: "--edge-extends",
+    implements: "--edge-implements",
+    embeds: "--edge-embeds",
+    with: "--edge-with",
+    references: "--edge-references",
+    decorates: "--edge-decorates",
+    imports: "--edge-imports",
+    contains: "--edge-contains"
+  };
+  var EDGE_KIND_DASHES = {
+    extends: false,
+    implements: false,
+    embeds: false,
+    references: [4, 3],
+    with: [2, 2],
+    decorates: [1, 3],
+    imports: [6, 4],
+    contains: [2, 4]
+  };
+  function edgeColor(kind) {
+    var token = EDGE_KIND_TOKENS[kind];
+    return (token && cssVar(token)) || cssVar("--line-1");
+  }
+  function edgeDashes(kind) {
+    return EDGE_KIND_DASHES[kind] !== undefined
+      ? EDGE_KIND_DASHES[kind]
+      : false;
+  }
+
+  var idEdgeKind = {};
+  var edgeKindCounts = {};
+  var hiddenEdgeKinds = {};
+
+  function edgeView(e, id) {
+    var kind = e.kind || "";
+    var c = edgeColor(kind);
+    return {
+      id: id,
+      from: e.source,
+      to: e.target,
+      title: [e.kind, e.label].filter(Boolean).join(" — "),
+      dashes: edgeDashes(kind),
+      color: {
+        color: c,
+        highlight: cssVar("--accent"),
+        hover: cssVar("--accent")
+      },
+      hidden: !!hiddenEdgeKinds[kind]
+    };
+  }
+  function setEdgeKindHidden(kind, hidden) {
+    hiddenEdgeKinds[kind] = hidden;
+    var updates = [];
+    edges.get().forEach(function (edge) {
+      if (idEdgeKind[edge.id] === kind) {
+        updates.push({ id: edge.id, hidden: hidden });
+      }
+    });
+    if (updates.length) {
+      edges.update(updates);
+    }
   }
 
   /* Legend items double as filters: toggling a kind hides every node
@@ -221,12 +296,11 @@
       return;
     }
     edgeKeys[key] = true;
-    edgeViews.push({
-      id: edgeViews.length,
-      from: e.source,
-      to: e.target,
-      title: [e.kind, e.label].filter(Boolean).join(" — ")
-    });
+    var id = edgeViews.length;
+    edgeViews.push(edgeView(e, id));
+    var ek = e.kind || "";
+    idEdgeKind[id] = ek;
+    edgeKindCounts[ek] = (edgeKindCounts[ek] || 0) + 1;
   });
   var edges = new vis.DataSet(edgeViews);
   var nextEdgeId = edges.length;
@@ -452,6 +526,69 @@
   }
   renderLegend();
 
+  /* ---- Edge-kind legend: line-style chips with counts, as filters ---- */
+
+  function renderEdgeLegend() {
+    var el = document.getElementById("edge-legend");
+    if (!el) {
+      return;
+    }
+    el.textContent = "";
+    var kinds = Object.keys(edgeKindCounts).filter(function (k) {
+      return k !== "";
+    });
+    if (!kinds.length) {
+      el.hidden = true;
+      return;
+    }
+    kinds
+      .sort(function (a, b) {
+        return edgeKindCounts[b] - edgeKindCounts[a] || (a < b ? -1 : 1);
+      })
+      .forEach(function (k) {
+        var item = document.createElement("button");
+        item.type = "button";
+        item.className = "legend-item" + (hiddenEdgeKinds[k] ? " off" : "");
+        item.setAttribute("data-edge-kind", k);
+        item.title = "toggle " + k + " edges";
+        var line = document.createElement("span");
+        line.className =
+          "legend-line" + (edgeDashes(k) ? " legend-line-dashed" : "");
+        line.style.borderColor = edgeColor(k);
+        var name = document.createElement("span");
+        name.className = "legend-name";
+        name.textContent = k;
+        var count = document.createElement("span");
+        count.className = "legend-count";
+        count.textContent = edgeKindCounts[k];
+        item.appendChild(line);
+        item.appendChild(name);
+        item.appendChild(count);
+        el.appendChild(item);
+      });
+    el.hidden = false;
+  }
+
+  var edgeLegendBar = document.getElementById("edge-legend");
+  if (edgeLegendBar) {
+    edgeLegendBar.addEventListener("click", function (event) {
+      var item =
+        event.target && event.target.closest
+          ? event.target.closest(".legend-item")
+          : null;
+      if (!item || !edgeLegendBar.contains(item)) {
+        return;
+      }
+      var kind = item.getAttribute("data-edge-kind");
+      if (!kind || !(kind in edgeKindCounts)) {
+        return;
+      }
+      setEdgeKindHidden(kind, !hiddenEdgeKinds[kind]);
+      renderEdgeLegend();
+    });
+  }
+  renderEdgeLegend();
+
   /* A theme flip re-colors the live network: theme-derived options via
      setOptions, node colors via a single batched update from the token
      palette, then the legend re-renders. The flip arrives as the shell's
@@ -469,7 +606,26 @@
     if (updates.length) {
       nodes.update(updates);
     }
+    var edgeUpdates = [];
+    edges.get().forEach(function (edge) {
+      var k = idEdgeKind[edge.id];
+      if (k !== undefined) {
+        var c = edgeColor(k);
+        edgeUpdates.push({
+          id: edge.id,
+          color: {
+            color: c,
+            highlight: cssVar("--accent"),
+            hover: cssVar("--accent")
+          }
+        });
+      }
+    });
+    if (edgeUpdates.length) {
+      edges.update(edgeUpdates);
+    }
     renderLegend();
+    renderEdgeLegend();
   }
   document.addEventListener("cairn:theme-changed", applyTheme);
   var pending = {};
@@ -507,18 +663,17 @@
         return;
       }
       edgeKeys[key] = true;
-      added.push({
-        id: nextEdgeId,
-        from: e.source,
-        to: e.target,
-        title: [e.kind, e.label].filter(Boolean).join(" — ")
-      });
+      added.push(edgeView(e, nextEdgeId));
+      var ek = e.kind || "";
+      idEdgeKind[nextEdgeId] = ek;
+      edgeKindCounts[ek] = (edgeKindCounts[ek] || 0) + 1;
       nextEdgeId += 1;
     });
     if (added.length) {
       edges.add(added);
     }
     renderLegend();
+    renderEdgeLegend();
     refreshCounts(!!(result && result.metadata && result.metadata.truncated));
   }
 

--- a/src/cairn/dashboard/templates/graph.html
+++ b/src/cairn/dashboard/templates/graph.html
@@ -71,6 +71,11 @@
   {% if graph.nodes %}
   <p class="graph-legend muted" id="graph-legend" hidden></p>
   {% endif %}
+  {#- Edge-kind legend mirrors the node legend: app.js fills it from the
+      edges' kinds (color + dash preview per chip), doubling as filters. -#}
+  {% if graph.edges %}
+  <p class="graph-legend muted" id="edge-legend" hidden></p>
+  {% endif %}
   <p class="muted" id="graph-counts">
     scope <strong>{{ scope }}</strong> —
     {{ graph.metadata.get("node_count", graph.nodes | length) }} nodes,

--- a/src/cairn/dashboard/templates/graph_inspect_panel.html
+++ b/src/cairn/dashboard/templates/graph_inspect_panel.html
@@ -23,6 +23,7 @@
     {% for n in callers %}
     <li class="panel-row">
       <a class="panel-name" href="{{ links.url('/graph', {'scope': 'symbol', 'focus': n.name}) }}">{{ n.name }}</a>
+      {% if n.edge_kind %}<span class="panel-note">{{ n.edge_kind }}</span>{% endif %}
       {% if n.file %}<span class="panel-sub">{{ n.file }}</span>{% endif %}
     </li>
     {% else %}
@@ -37,6 +38,7 @@
     {% for n in callees %}
     <li class="panel-row">
       <a class="panel-name" href="{{ links.url('/graph', {'scope': 'symbol', 'focus': n.name}) }}">{{ n.name }}</a>
+      {% if n.edge_kind %}<span class="panel-note">{{ n.edge_kind }}</span>{% endif %}
       {% if n.file %}<span class="panel-sub">{{ n.file }}</span>{% endif %}
     </li>
     {% else %}

--- a/src/cairn/graph/builder.py
+++ b/src/cairn/graph/builder.py
@@ -539,6 +539,16 @@ def _build_graph_impl(
     # Third pass: resolve all edge targets
     resolution_stats = _resolve_all(conn, repo_edges_by_file, in_memory, verbose, progress)
 
+    # Fourth pass: materialize module->module imports edges from the imports
+    # table (needs every file's module symbol present, so it runs after the
+    # insert+resolve passes; kind='imports' stays outside
+    # STRUCTURAL_EDGE_KINDS, so traversal semantics are unchanged).
+    try:
+        import_edges = materialize_import_edges(conn)
+        log(f"  materialized {import_edges} module imports edges")
+    except Exception as e:
+        log(f"  imports-edge materialization failed: {e}")
+
     # SCIP post-resolve hook: import pre-built indexes for languages whose
     # files were skipped above. SCIP's exact edges aren't re-resolved, so this
     # runs AFTER _resolve_all (tree-sitter's resolver would otherwise try to
@@ -1026,6 +1036,8 @@ def insert_parsed_file(
     file_imports_summary = ", ".join(
         imp.imported_path for imp in pf.imports[:20]
     ) or None  # file-level summary, identical for every symbol in this file
+    # qualified_name -> symbol id, for contains-edge parent resolution.
+    qname_ids: Dict[str, str] = {}
     for sym in pf.symbols:
         sym_id = _new_id()
         # Enclosing scope is everything before the last "." of the qualified
@@ -1035,6 +1047,8 @@ def insert_parsed_file(
             sym.parent_scope = sym.qualified_name.rsplit(".", 1)[0]
         if sym.imports_summary is None:
             sym.imports_summary = file_imports_summary
+        if sym.qualified_name:
+            qname_ids.setdefault(sym.qualified_name, sym_id)
         sym_rows.append((
             sym_id,
             file_id,
@@ -1056,6 +1070,36 @@ def insert_parsed_file(
         ))
         name_to_symbol_ids.setdefault(sym.name, []).append((sym_id, repo, file_id))
 
+    # --- module symbol: one per file ----------------------------------------
+    # Owns module-level code (edges with no enclosing symbol) and the file's
+    # import edges materialized post-resolution. Name is the file stem;
+    # qualified name is the dotted repo-relative path so import statements
+    # can be mapped onto it. Appended AFTER the declared symbols so a code
+    # symbol sharing the stem name wins edge ownership (first-wins lookup).
+    module_id = _new_id()
+    module_name = Path(rel_path).stem
+    module_qname = _module_dotted(rel_path)
+    sym_rows.append((
+        module_id,
+        file_id,
+        module_name,
+        module_qname,
+        "module",
+        1,
+        1,
+        0,
+        0,
+        None,
+        "[]",
+        None,
+        None,
+        None,
+        None,
+        file_imports_summary,
+        None,
+    ))
+    name_to_symbol_ids.setdefault(module_name, []).append((module_id, repo, file_id))
+
     # --- imports ------------------------------------------------------------
     for imp in pf.imports:
         imp_rows.append((_new_id(), file_id, imp.imported_path, None, imp.line))
@@ -1065,9 +1109,33 @@ def insert_parsed_file(
     # name_to_symbol_ids accumulator (which would make this O(total_symbols)
     # per file -> O(N^2) overall). The keys are exactly the names this file
     # declared, and the values are their symbol ids in this file.
+    # (zip stops at pf.symbols, so the module row appended above is excluded.)
     in_file: Dict[str, List[str]] = {}
     for sym, row in zip(pf.symbols, sym_rows):
         in_file.setdefault(sym.name, []).append(row[0])
+    # The module symbol's entry lands last: a code symbol with the same name
+    # keeps first-wins ownership of that name's edges.
+    in_file.setdefault(module_name, []).append(module_id)
+
+    # --- contains edges: parent -> nested, module -> top-level --------------
+    # Targets are pinned in-file (qualified-name keyed, bare-name fallback),
+    # so these rows skip the resolver round-trip entirely (resolution='exact')
+    # and never enter repo_edges_by_file.
+    for sym, row in zip(pf.symbols, sym_rows):
+        child_id = row[0]
+        if sym.parent_scope:
+            parent_id = qname_ids.get(sym.parent_scope)
+            if parent_id is None:
+                parent_id = in_file.get(
+                    sym.parent_scope.rsplit(".", 1)[-1], [None]
+                )[0]
+        else:
+            parent_id = module_id
+        if parent_id:
+            edge_rows.append((
+                _new_id(), parent_id, child_id, sym.name, "contains",
+                sym.line_start, sym.column_start, "exact",
+            ))
 
     # --- edges: source resolved now; target left NULL for the resolver -----
     file_edges = repo_edges_by_file.setdefault(repo, {}).setdefault(file_id, [])
@@ -1075,7 +1143,11 @@ def insert_parsed_file(
         source_ids = in_file.get(edge.source_name, [])
         source_id = source_ids[0] if source_ids else None
         if source_id is None:
-            continue  # file-level call with no owning symbol; cannot attach
+            if not edge.source_name:
+                # Module-level code: attach to the file's module symbol.
+                source_id = module_id
+            else:
+                continue  # owner name not declared in this file; cannot attach
         edge_id = _new_id()
         edge_rows.append((
             edge_id, source_id, None, edge.target_name, edge.kind,
@@ -1113,6 +1185,185 @@ def insert_parsed_file(
         )
 
     return len(sym_rows), len(edge_rows), len(imp_rows)
+
+
+def _module_dotted(rel_path: str) -> str:
+    """Dotted form of a repo-relative file path ("src/a/b.py" -> "src.a.b").
+
+    Package initializer files ("__init__.py") collapse to their directory
+    ("pkg/__init__.py" -> "pkg") so package imports match the module.
+    """
+    parts = list(Path(rel_path).with_suffix("").parts)
+    if len(parts) > 1 and parts[-1] == "__init__":
+        parts = parts[:-1]
+    return ".".join(parts)
+
+
+def _norm_module_token(token: str) -> str:
+    """Normalize one import path token to a dotted module path.
+
+    Separators become dots and relative markers ("./", "../") drop out:
+    "../utils/heap" -> "utils.heap", "cairn/graph/queries" ->
+    "cairn.graph.queries".
+    """
+    t = token.strip().strip("'\"").replace("\\", ".")
+    segs = [s for s in t.replace("/", ".").split(".") if s and set(s) != {"."}]
+    return ".".join(segs)
+
+
+def _dotted_suffixes(dotted: str) -> List[str]:
+    """All dotted suffixes, longest first ("a.b.c" -> ["a.b.c", "b.c", "c"])."""
+    segs = [s for s in dotted.split(".") if s]
+    return [".".join(segs[i:]) for i in range(len(segs))]
+
+
+def _import_module_bases(raw: str) -> List[str]:
+    """Base module paths derived from one raw import statement/path.
+
+    Handles the shapes the parsers store verbatim: Python
+    "from X import a, b" (bases X.a, X.b, X), "import X.Y" (base X.Y);
+    TypeScript/JS "import {a} from './m'" and "import x from './m'"
+    (bases m.a/m.x, m); Java/Kotlin "import x.y.Z" / "import static x.y.Z"
+    (base x.y.Z); bare paths for Go and C-family includes. Alias suffixes
+    ("a as b") and brace noise are stripped.
+    """
+    text = raw.strip().rstrip(";").strip()
+    bases: List[str] = []
+
+    def _add(module_token: str, name_tokens: List[str]) -> None:
+        module = _norm_module_token(module_token)
+        if not module:
+            return
+        for name in name_tokens:
+            n = name.strip().strip("{}").split(" as ")[0].strip()
+            if n:
+                bases.append(f"{module}.{_norm_module_token(n)}")
+        bases.append(module)
+
+    if text.startswith("from "):
+        rest = text[len("from "):].strip()
+        module_tok, sep, names_part = rest.partition(" import ")
+        _add(module_tok, names_part.split(",") if sep else [])
+    elif text.startswith("import "):
+        rest = text[len("import "):].strip()
+        if " from " in rest:
+            names_part, _, module_tok = rest.partition(" from ")
+            _add(module_tok, names_part.strip("{} \t").split(","))
+        else:
+            rest = rest.split(" as ")[0].strip()
+            if rest.startswith("static "):
+                rest = rest[len("static "):].strip()
+            bases.append(_norm_module_token(rest))
+    else:
+        bases.append(_norm_module_token(text))
+    return [b for b in bases if b]
+
+
+def materialize_import_edges(
+    conn,
+    repo: Optional[str] = None,
+    file_ids: Optional[List[str]] = None,
+) -> int:
+    """(Re)build ``kind='imports'`` module-to-module edges from the imports table.
+
+    Every indexed file carrying a module symbol (kind='module') indexes its
+    dotted path suffixes; each import row's normalized module bases match
+    longest-suffix-first, and the first candidate matching exactly one indexed
+    file wins. Ambiguous matches and external/unmatched imports are skipped
+    (single-segment candidates can false-positive onto same-named files; they
+    stay because a unique same-named file is usually the right target).
+    Existing imports edges sourced from the affected module symbols are
+    deleted first, so the pass is idempotent per rebuild. Scope with ``repo``
+    or an explicit ``file_ids`` list; neither recomputes the whole store.
+
+    Returns the number of edges inserted.
+    """
+    scope = ""
+    params: List[str] = []
+    if repo is not None:
+        scope = " AND f.repo_id = ?"
+        params.append(repo)
+    elif file_ids is not None:
+        ph = ",".join("?" for _ in file_ids)
+        scope = f" AND f.id IN ({ph})"
+        params.extend(file_ids)
+
+    module_rows = conn.execute(
+        f"""SELECT s.id AS mid, f.id AS fid, f.path
+            FROM symbols s JOIN files f ON s.file_id = f.id
+            WHERE s.kind = 'module'{scope}""",
+        params,
+    ).fetchall()
+
+    source_ids = [r["mid"] for r in module_rows]
+    if not source_ids:
+        return 0
+
+    # candidate -> [file ids]; module symbol per file (first wins on the
+    # impossible-in-practice duplicate-module-per-file case).
+    module_by_fid: Dict[str, str] = {}
+    files_by_candidate: Dict[str, List[str]] = {}
+    module_qname_by_fid: Dict[str, str] = {}
+    for r in module_rows:
+        fid, mid = r["fid"], r["mid"]
+        if fid in module_by_fid:
+            continue
+        module_by_fid[fid] = mid
+        module_qname_by_fid[fid] = _module_dotted(r["path"])
+        for cand in _dotted_suffixes(_module_dotted(r["path"])):
+            files_by_candidate.setdefault(cand, []).append(fid)
+
+    imp_scope = ""
+    imp_params: List[str] = []
+    if repo is not None:
+        imp_scope = " WHERE i.file_id IN (SELECT id FROM files WHERE repo_id = ?)"
+        imp_params.append(repo)
+    elif file_ids is not None:
+        ph = ",".join("?" for _ in file_ids)
+        imp_scope = f" WHERE i.file_id IN ({ph})"
+        imp_params.extend(file_ids)
+    import_rows = conn.execute(
+        f"SELECT i.file_id, i.imported_path, i.line FROM imports i{imp_scope}",
+        imp_params,
+    ).fetchall()
+
+    ph = ",".join("?" for _ in source_ids)
+    conn.execute(
+        f"DELETE FROM edges WHERE kind = 'imports' AND source_id IN ({ph})",
+        source_ids,
+    )
+
+    edge_rows: List[tuple] = []
+    for r in import_rows:
+        source_mid = module_by_fid.get(r["file_id"])
+        if not source_mid:
+            continue
+        for base in _import_module_bases(r["imported_path"]):
+            matched: Optional[str] = None
+            for cand in _dotted_suffixes(base):
+                fids = files_by_candidate.get(cand)
+                if not fids:
+                    continue  # try a shorter suffix
+                if len(fids) == 1:
+                    matched = fids[0]
+                    break
+                break  # ambiguous at this length; shorter is never safer
+            if matched is None or matched == r["file_id"]:
+                continue
+            edge_rows.append((
+                _new_id(), source_mid, module_by_fid[matched],
+                module_qname_by_fid[matched], "imports",
+                r["line"] or 0, 0, "exact",
+            ))
+            break  # first base that resolves wins
+    if edge_rows:
+        conn.executemany(
+            """INSERT INTO edges
+               (id, source_id, target_id, target_name, kind, line, column, resolution)
+               VALUES (?,?,?,?,?,?,?,?)""",
+            edge_rows,
+        )
+    return len(edge_rows)
 
 
 def insert_parse_error(cur, repo: str, path: str, error_message: str, stack_trace: str | None = None):

--- a/src/cairn/graph/incremental.py
+++ b/src/cairn/graph/incremental.py
@@ -296,6 +296,17 @@ def reindex_paths(
         except Exception as e:
             errors.append(f"repair/{repo_name}: {e}")
 
+    # Imports-edge refresh: the reindexed files' module symbols and their
+    # import rows changed, so recompute the repo's kind='imports' edges
+    # (delete+reinsert per materialize_import_edges' idempotence contract).
+    from .builder import materialize_import_edges
+    for repo_name in repo_edges_by_file:
+        try:
+            materialize_import_edges(conn, repo=repo_name)
+            conn.commit()
+        except Exception as e:
+            errors.append(f"imports-edges/{repo_name}: {e}")
+
     return {"reindexed": reindexed, "deleted": deleted, "errors": errors}
 
 

--- a/src/cairn/graph/resolver.py
+++ b/src/cairn/graph/resolver.py
@@ -18,12 +18,16 @@ def build_symbol_index(conn: sqlite3.Connection) -> Dict[str, List[Tuple[str, st
     """Build a global bare-name -> symbol index.
 
     Returns ``{name: [(symbol_id, repo, file_id, qualified_name), ...]}``.
+    Module symbols (kind='module') are excluded: they are structural nodes
+    (contains/imports endpoints), not resolution targets -- a file named after
+    its single class would otherwise make every same-name reference ambiguous.
     """
     index: Dict[str, List[Tuple[str, str, str, str]]] = {}
     rows = conn.execute(
         """SELECT s.id AS sid, s.name AS name, s.qualified_name AS qname,
                   f.repo_id AS repo, f.id AS file_id
-           FROM symbols s JOIN files f ON s.file_id = f.id"""
+           FROM symbols s JOIN files f ON s.file_id = f.id
+           WHERE s.kind != 'module'"""
     ).fetchall()
     for r in rows:
         index.setdefault(r["name"], []).append(
@@ -82,14 +86,16 @@ def build_members_index(
         repo_where = " AND f.repo_id = ?"
         params = (repo_id,)
 
-    # Names of symbols that are types (anything not a member kind). Packages are
-    # not symbols, so a package segment never lands in this set.
+    # Names of symbols that are types (anything not a member kind; module
+    # symbols are structural nodes, never types). Packages are not symbols,
+    # so a package segment never lands in this set.
     placeholders = ",".join("?" * len(_MEMBER_KINDS))
     type_names = {
         r["name"]
         for r in conn.execute(
             f"SELECT DISTINCT s.name AS name FROM symbols s{repo_join} "
-            f"WHERE s.kind NOT IN ({placeholders}){repo_where}",
+            f"WHERE s.kind NOT IN ({placeholders}) AND s.kind != 'module'"
+            f"{repo_where}",
             (*_MEMBER_KINDS, *params),
         ).fetchall()
     }
@@ -126,7 +132,7 @@ def build_ancestor_index(
                FROM edges e JOIN symbols src ON e.source_id = src.id
                JOIN files f ON src.file_id = f.id
                WHERE f.repo_id = ?
-                 AND e.kind IN ('extends', 'implements')
+                 AND e.kind IN ('extends', 'implements', 'embeds')
                  AND e.target_name IS NOT NULL""",
             (repo_id,),
         ).fetchall()
@@ -134,7 +140,7 @@ def build_ancestor_index(
         rows = conn.execute(
             """SELECT src.name AS child, e.target_name AS parent
                FROM edges e JOIN symbols src ON e.source_id = src.id
-               WHERE e.kind IN ('extends', 'implements')
+               WHERE e.kind IN ('extends', 'implements', 'embeds')
                  AND e.target_name IS NOT NULL"""
         ).fetchall()
     for r in rows:

--- a/src/cairn/parsers/base.py
+++ b/src/cairn/parsers/base.py
@@ -41,7 +41,12 @@ class Symbol:
 @dataclass
 class Edge:
     source_name: str  # name of the enclosing symbol that owns this edge
-    kind: str  # calls|imports|implements|extends|uses_type|references
+    # Canonical kinds: calls | extends | implements | embeds | with |
+    # references | decorates | imports | contains (tree-sitter SCIP edges
+    # additionally use call | reference | import). Only calls/call and
+    # extends/implements are structural (traversal); the rest are display
+    # and resolution signals.
+    kind: str
     target_name: str  # unresolved name (resolved to symbol_id later by builder)
     line: int
     column: int = 0

--- a/src/cairn/parsers/go.py
+++ b/src/cairn/parsers/go.py
@@ -1,8 +1,8 @@
 """Tree-sitter Go parser.
 
 Extracts structs, interfaces, type aliases, functions, methods (with their
-receiver type as ``parent_scope``), call expressions, and imports into the
-shared ParsedFile model.
+receiver type as ``parent_scope``), call expressions, struct/interface
+embedding (``embeds`` edges), and imports into the shared ParsedFile model.
 
 Go-specific shape notes:
 
@@ -74,6 +74,10 @@ class GoParser(BaseParser, TreeSitterParserBase):
                 sym = self._parse_type_spec(spec, source)
                 if sym:
                     pf.symbols.append(sym)
+                    # Embedding: anonymous struct fields and interface
+                    # type elements become `embeds` edges.
+                    for embed_edge in self._parse_embeds(spec, source, sym.name):
+                        pf.edges.append(embed_edge)
                     # Push scope and walk inside (e.g. struct fields, methods).
                     self._scope.append(sym.name)
                     self._walk(spec, source, pf)
@@ -138,6 +142,50 @@ class GoParser(BaseParser, TreeSitterParserBase):
             column_start=node.start_point[1],
             column_end=node.end_point[1],
         )
+
+    def _parse_embeds(self, node: Node, source: bytes, owner: str) -> List[Edge]:
+        """`embeds` edges for one ``type_spec``.
+
+        Struct embedding: a ``field_declaration`` with no ``field_identifier``
+        (``*Base``, ``pkg.Config``, ``Base``). Interface embedding: a
+        ``type_elem`` among the interface's elements (``io.Writer``). Named
+        fields and method elements are members, not embeds, and are skipped.
+        Qualified and pointer embeds contribute their bare type name (the same
+        convention call targets use).
+        """
+        edges: List[Edge] = []
+        struct = self._child_of_type(node, _STRUCT_TYPE)
+        iface = self._child_of_type(node, _INTERFACE_TYPE)
+        if struct is not None:
+            fdl = self._child_of_type(struct, "field_declaration_list")
+            if fdl is None:
+                return edges
+            candidates = [
+                f
+                for f in fdl.children
+                if f.type == "field_declaration"
+                and self._child_of_type(f, "field_identifier") is None
+            ]
+        elif iface is not None:
+            candidates = [
+                c for c in iface.children if c.type in ("type_elem", "type_identifier", "qualified_type")
+            ]
+        else:
+            return edges
+        for elem in candidates:
+            target = self._first_descendant_of_type(
+                elem, "type_identifier", source
+            )
+            if target:
+                edges.append(
+                    Edge(
+                        source_name=owner,
+                        kind="embeds",
+                        target_name=target,
+                        line=elem.start_point[0] + 1,
+                    )
+                )
+        return edges
 
     # ------------------------------------------------------- function parsing
 
@@ -354,6 +402,18 @@ class GoParser(BaseParser, TreeSitterParserBase):
 
     def _has_child(self, node: Node, *types: str) -> bool:
         return any(c.type in types for c in node.children)
+
+    def _first_descendant_of_type(
+        self, node: Node, type_: str, source: bytes
+    ) -> Optional[str]:
+        """Text of the first descendant of ``type_`` (breadth-first), if any."""
+        stack = list(node.children)
+        while stack:
+            cur = stack.pop(0)
+            if cur.type == type_:
+                return self._node_text(cur, source).strip()
+            stack.extend(cur.children)
+        return None
 
 
 # Tree-sitter node kinds that represent a type reference in Go. Used by the

--- a/src/cairn/parsers/kotlin.py
+++ b/src/cairn/parsers/kotlin.py
@@ -290,6 +290,7 @@ class KotlinParser(BaseParser, TreeSitterParserBase):
             column_end=node.end_point[1],
             modifiers=mods,
         )
+        self._emit_type_references(node, source, name)
         return sym
 
     def _parse_property(self, node: Node, source: bytes) -> Optional[Symbol]:
@@ -322,7 +323,38 @@ class KotlinParser(BaseParser, TreeSitterParserBase):
             column_end=node.end_point[1],
             modifiers=mods,
         )
+        self._emit_type_references(node, source, name)
         return sym
+
+    def _emit_type_references(self, node: Node, source: bytes, owner: str) -> None:
+        """`references` edges for ``user_type`` annotations on a declaration's
+        signature (value parameters, return type, property/constructor
+        parameter types). Declaration bodies are excluded — local statements
+        are not part of the API surface, and body-level user_types (local
+        variable types) would dwarf the signature signal.
+        """
+        for child in node.children:
+            if child.type in (
+                "function_body", "class_body", "enum_class_body", "statements",
+            ):
+                continue
+            self._collect_user_types(child, source, owner)
+
+    def _collect_user_types(self, node: Node, source: bytes, owner: str) -> None:
+        if node.type == "user_type":
+            name = self._extract_usertype_name(node, source)
+            if name:
+                self._pending_edges.append(
+                    Edge(
+                        source_name=owner,
+                        kind="references",
+                        target_name=name,
+                        line=node.start_point[0] + 1,
+                    )
+                )
+            return
+        for child in node.children:
+            self._collect_user_types(child, source, owner)
 
     def _parse_class_parameter(self, node: Node, source: bytes) -> Optional[Symbol]:
         """Constructor parameter: [modifiers] (val|var) name : Type.
@@ -340,6 +372,7 @@ class KotlinParser(BaseParser, TreeSitterParserBase):
         if not name or not has_val_or_var:
             return None  # plain ctor param, not a property
         mods = self._collect_modifiers(node, source)
+        self._emit_type_references(node, source, name)
         return Symbol(
             name=name,
             kind="property",

--- a/src/cairn/parsers/python_parser.py
+++ b/src/cairn/parsers/python_parser.py
@@ -1,16 +1,29 @@
 """Tree-sitter Python parser.
 
-Extracts class/function definitions, calls, imports, and base classes (inheritance)
-into the shared ParsedFile model.
+Extracts class/function definitions, calls, imports, base classes (inheritance
+as `extends` edges), decorators (`decorates`), and signature type annotations
+(`references`) into the shared ParsedFile model.
 """
 from __future__ import annotations
 
+import re
 from typing import List, Optional
 
 from tree_sitter import Node
 
 from ._registry import get_parser as _get_ts_parser
 from .base import BaseParser, Edge, Import, ParsedFile, Symbol, TreeSitterParserBase
+
+# Annotation tokens that never name a repo symbol; excluded from references
+# edges so builtin typing shapes stay out of the graph.
+_BUILTIN_TYPE_TOKENS = frozenset({
+    "any", "bool", "bytes", "callable", "class", "cls", "dict", "final",
+    "float", "frozenset", "int", "iterable", "list", "mapping", "none",
+    "optional", "self", "sequence", "set", "str", "tuple", "type", "typing",
+    "union",
+})
+
+_IDENT_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_]*")
 
 
 class PythonParser(BaseParser, TreeSitterParserBase):
@@ -20,6 +33,10 @@ class PythonParser(BaseParser, TreeSitterParserBase):
         super().__init__()
         self._parser = _get_ts_parser("python")
         self._pending_edges: List[Edge] = []
+        # Decorators sit on the `decorated_definition` wrapper, not on the
+        # inner class/function_definition node. Set while the wrapper's
+        # children are visited so the definition handlers can read them.
+        self._active_decorators: List[Node] = []
 
     def parse(self, path: str) -> ParsedFile:
         import hashlib
@@ -35,6 +52,7 @@ class PythonParser(BaseParser, TreeSitterParserBase):
         # Parsers are cached singletons reused across files, so reset all
         # per-file accumulators here.
         self._pending_edges = []
+        self._active_decorators = []
         self._scope = []
         self._callable_scope = []
         self._walk(tree.root_node, source, pf)
@@ -48,10 +66,28 @@ class PythonParser(BaseParser, TreeSitterParserBase):
     def _visit(self, node: Node, source: bytes, pf: ParsedFile):
         t = node.type
 
-        if t in ("import_statement", "import_from_statement"):
+        if t == "import_statement" or t == "import_from_statement":
             imp = self._parse_import(node, source)
             if imp:
                 pf.imports.append(imp)
+            return
+
+        if t == "decorated_definition":
+            # (decorator ... definition): make the wrapper's decorators
+            # visible to the inner definition's parse, then descend.
+            self._active_decorators = [
+                c for c in node.children if c.type == "decorator"
+            ]
+            try:
+                self._walk(node, source, pf)
+            finally:
+                self._active_decorators = []
+            return
+
+        if t == "decorator":
+            # The decorator->definition relationship is captured as a
+            # `decorates` edge; walking in would duplicate it as a stray
+            # module-level `calls` edge.
             return
 
         if t == "class_definition":
@@ -94,7 +130,8 @@ class PythonParser(BaseParser, TreeSitterParserBase):
                 break
         if not name:
             return None
-        # Inheritance: argument_list holds base classes.
+        # Inheritance: argument_list holds base classes (class inheritance —
+        # `extends`, matching the other parsers' convention).
         for child in node.children:
             if child.type == "argument_list":
                 for arg in child.children:
@@ -102,11 +139,12 @@ class PythonParser(BaseParser, TreeSitterParserBase):
                         self._pending_edges.append(
                             Edge(
                                 name,
-                                "implements",
+                                "extends",
                                 self._node_text(arg, source).strip(),
                                 node.start_point[0] + 1,
                             )
                         )
+        self._emit_decorator_edges(node, source, name)
         # decorators as modifiers
         mods = self._collect_decorators(node, source)
         doc = self._extract_docstring(node, source)
@@ -141,6 +179,8 @@ class PythonParser(BaseParser, TreeSitterParserBase):
             grandparent = parent.parent
             if grandparent is not None and grandparent.type == "class_definition":
                 kind = "method"
+        self._emit_decorator_edges(node, source, name)
+        self._emit_type_references(node, source, name)
         mods = self._collect_decorators(node, source)
         doc = self._extract_docstring(node, source)
         # async detection
@@ -181,12 +221,81 @@ class PythonParser(BaseParser, TreeSitterParserBase):
                     return text if text else None
         return None
 
+    def _decorator_nodes(self, node: Node) -> List[Node]:
+        """Decorators for a definition: the enclosing decorated_definition's
+        wrapper-level decorators, plus any directly on the node."""
+        nodes = list(getattr(self, "_active_decorators", []))
+        nodes.extend(c for c in node.children if c.type == "decorator")
+        return nodes
+
     def _collect_decorators(self, node: Node, source: bytes) -> List[str]:
         mods = []
-        for child in node.children:
-            if child.type == "decorator":
-                mods.append(self._node_text(child, source).strip())
+        for child in self._decorator_nodes(node):
+            mods.append(self._node_text(child, source).strip())
         return mods
+
+    def _emit_decorator_edges(self, node: Node, source: bytes, owner: str) -> None:
+        """`decorates` edges: owner -> each decorator's callable name.
+
+        `@app.route("/x")` -> target `route` (the attribute tail, matching
+        how call edges name their targets); `@functools.lru_cache` ->
+        `lru_cache`. Decorators that don't resolve to a symbol simply stay
+        unresolved edges, like builtin callees.
+        """
+        for child in self._decorator_nodes(node):
+            text = self._node_text(child, source).strip().lstrip("@")
+            name = text.split("(", 1)[0].strip()
+            if "." in name:
+                name = name.rsplit(".", 1)[-1]
+            if name and _IDENT_RE.fullmatch(name):
+                self._pending_edges.append(
+                    Edge(
+                        owner,
+                        "decorates",
+                        name,
+                        child.start_point[0] + 1,
+                    )
+                )
+
+    def _emit_type_references(self, node: Node, source: bytes, owner: str) -> None:
+        """`references` edges: owner -> classes named in signature annotations.
+
+        Covers typed parameters and the return annotation of
+        function/method definitions. Subscripted shapes (`Optional[Foo]`,
+        `list[Bar]`) contribute their inner identifier tokens; builtin
+        typing tokens are filtered. Dotted paths contribute their segments
+        (the tail usually resolves; the qualifier usually does not).
+        """
+        type_nodes: List[Node] = []
+        params = node.child_by_field_name("parameters")
+        if params is not None:
+            for child in params.children:
+                ann = child.child_by_field_name("type")
+                if ann is not None:
+                    type_nodes.append(ann)
+        ret = node.child_by_field_name("return_type")
+        if ret is not None:
+            type_nodes.append(ret)
+        seen = set()
+        for ann in type_nodes:
+            text = self._node_text(ann, source)
+            for tok in _IDENT_RE.findall(text):
+                lowered = tok.lower()
+                if (
+                    lowered in _BUILTIN_TYPE_TOKENS
+                    or tok == owner
+                    or tok in seen
+                ):
+                    continue
+                seen.add(tok)
+                self._pending_edges.append(
+                    Edge(
+                        owner,
+                        "references",
+                        tok,
+                        ann.start_point[0] + 1,
+                    )
+                )
 
     def _parse_import(self, node: Node, source: bytes) -> Optional[Import]:
         text = self._node_text(node, source).replace("\n", " ").strip()

--- a/src/cairn/parsers/swift.py
+++ b/src/cairn/parsers/swift.py
@@ -235,29 +235,46 @@ class SwiftParser(BaseParser, TreeSitterParserBase):
         )
 
     def _parse_inheritance(self, node: Node, source: bytes, child_name: str):
-        for child in node.children:
-            if child.type == "type_inheritance_clause" or (
-                child.type == "inheritance_specifier"
-            ):
-                self._collect_inh_targets(child, source, child_name)
+        """Inheritance-clause targets as ordered `extends`/`implements` edges.
 
-    def _collect_inh_targets(
-        self, node: Node, source: bytes, child_name: str
-    ):
-        if node is None:
-            return
-        if node.type == "type_identifier":
+        A class/actor's first listed type is its superclass (`extends`);
+        every other target, and every target on structs/enums/protocols
+        (where inheritance is protocol conformance only), is `implements`.
+        """
+        specifiers: List[Node] = []
+        for child in node.children:
+            if child.type in ("type_inheritance_clause", "inheritance_specifier"):
+                self._collect_specifiers(child, specifiers)
+        # A grammar build may parse `struct`/`enum` declarations under
+        # class_declaration; the keyword child distinguishes them (the same
+        # inspection _classify_type uses). Only a true class/actor has a
+        # superclass; structs/enums conform to protocols only.
+        keyword_children = {
+            self._node_text(c, source).strip() for c in node.children
+        }
+        superclass_first = node.type == "actor_declaration" or (
+            node.type == "class_declaration"
+            and not keyword_children & {"struct", "enum"}
+        )
+        for i, spec in enumerate(specifiers):
+            name = self._node_text(spec, source).strip().split("<", 1)[0].strip()
+            if not name:
+                continue
             self._pending_edges.append(
                 Edge(
                     child_name,
-                    "implements",
-                    self._node_text(node, source).strip(),
-                    node.start_point[0] + 1,
+                    "extends" if (superclass_first and i == 0) else "implements",
+                    name,
+                    spec.start_point[0] + 1,
                 )
             )
+
+    def _collect_specifiers(self, node: Node, out: List[Node]) -> None:
+        if node.type == "inheritance_specifier":
+            out.append(node)
             return
         for child in node.children:
-            self._collect_inh_targets(child, source, child_name)
+            self._collect_specifiers(child, out)
 
     def _parse_call(self, node: Node, source: bytes) -> Optional[Edge]:
         # call_expression: the called function is the first child; for

--- a/src/cairn/viz/query.py
+++ b/src/cairn/viz/query.py
@@ -28,26 +28,26 @@ def get_symbol_graph(conn: sqlite3.Connection, name: str, depth: int = 1) -> Dic
 
     # Callers (1-hop).
     for r in cur.execute(
-        "SELECT s.name AS caller, s.kind AS ckind, f.path, f.repo_id "
+        "SELECT s.name AS caller, s.kind AS ckind, f.path, f.repo_id, e.kind AS ekind "
         "FROM edges e JOIN symbols s ON e.source_id = s.id "
         "JOIN files f ON s.file_id = f.id "
         "WHERE e.target_id IN (SELECT id FROM symbols WHERE name = ?) LIMIT 30",
         (name,),
     ).fetchall():
         _add_node(nodes, r["caller"], r["ckind"], r["path"], r["repo_id"])
-        edges.append({"source": r["caller"], "target": name, "kind": "calls"})
+        edges.append({"source": r["caller"], "target": name, "kind": r["ekind"]})
 
     # Callees (1-hop).
     for r in cur.execute(
         "SELECT COALESCE(t.name, e.target_name) AS callee, t.kind, f.path, f.repo_id, "
-        "e.target_id AS resolved FROM edges e JOIN symbols s ON e.source_id = s.id "
+        "e.target_id AS resolved, e.kind AS ekind FROM edges e JOIN symbols s ON e.source_id = s.id "
         "LEFT JOIN symbols t ON e.target_id = t.id "
         "LEFT JOIN files f ON t.file_id = f.id WHERE s.name = ? LIMIT 30",
         (name,),
     ).fetchall():
         if r["callee"]:
             _add_node(nodes, r["callee"], r["kind"] or "external", r["path"], r["repo_id"])
-            edges.append({"source": name, "target": r["callee"], "kind": "calls"})
+            edges.append({"source": name, "target": r["callee"], "kind": r["ekind"]})
 
     return {"nodes": list(nodes.values()), "edges": edges,
             "metadata": {"scope": "symbol", "symbol": name, "node_count": len(nodes), "edge_count": len(edges)}}
@@ -86,7 +86,7 @@ def get_symbol_neighbors(conn: sqlite3.Connection,
             _add_node(nodes, focal["name"], focal["kind"], focal["path"], focal["repo_id"])
             # Callers (1-hop), keyed to this focal row; fetch cap+1 to flag truncation.
             callers = cur.execute(
-                "SELECT s.name AS caller, s.kind AS ckind, f.path, f.repo_id "
+                "SELECT s.name AS caller, s.kind AS ckind, f.path, f.repo_id, e.kind AS ekind "
                 "FROM edges e JOIN symbols s ON e.source_id = s.id "
                 "JOIN files f ON s.file_id = f.id "
                 f"WHERE e.target_id = ? LIMIT {_NEIGHBOR_CAP + 1}",
@@ -97,10 +97,11 @@ def get_symbol_neighbors(conn: sqlite3.Connection,
                 callers = callers[:_NEIGHBOR_CAP]
             for r in callers:
                 _add_node(nodes, r["caller"], r["ckind"], r["path"], r["repo_id"])
-                edges.append({"source": r["caller"], "target": focal["name"], "kind": "calls"})
+                edges.append({"source": r["caller"], "target": focal["name"], "kind": r["ekind"]})
             # Callees (1-hop); unresolved targets fall back to kind "external".
             callees = cur.execute(
-                "SELECT COALESCE(t.name, e.target_name) AS callee, t.kind, f.path, f.repo_id "
+                "SELECT COALESCE(t.name, e.target_name) AS callee, t.kind, f.path, f.repo_id, "
+                "e.kind AS ekind "
                 "FROM edges e LEFT JOIN symbols t ON e.target_id = t.id "
                 "LEFT JOIN files f ON t.file_id = f.id "
                 f"WHERE e.source_id = ? LIMIT {_NEIGHBOR_CAP + 1}",
@@ -112,7 +113,7 @@ def get_symbol_neighbors(conn: sqlite3.Connection,
             for r in callees:
                 if r["callee"]:
                     _add_node(nodes, r["callee"], r["kind"] or "external", r["path"], r["repo_id"])
-                    edges.append({"source": focal["name"], "target": r["callee"], "kind": "calls"})
+                    edges.append({"source": focal["name"], "target": r["callee"], "kind": r["ekind"]})
     return {"nodes": list(nodes.values()), "edges": edges,
             "metadata": {"scope": "neighbors", "requested": requested,
                          "node_count": len(nodes), "edge_count": len(edges),
@@ -257,6 +258,9 @@ def get_module_graph(
                     continue
                 seen_edges.add(key)
                 edges.append({"source": r["src"], "target": r["tgt"], "kind": r["kind"]})
+    edge_kinds: dict[str, int] = {}
+    for e in edges:
+        edge_kinds[e["kind"]] = edge_kinds.get(e["kind"], 0) + 1
     return {
         "nodes": list(nodes.values()),
         "edges": edges,
@@ -265,6 +269,7 @@ def get_module_graph(
             "module": module,
             "node_count": len(nodes),
             "edge_count": len(edges),
+            "edge_kinds": edge_kinds,
             "tests_included": include_tests,
             "truncated": eligible > _MODULE_CAP,
             "vendored_excluded": vendored_excluded,

--- a/tests/fixtures/golden/go/expected.json
+++ b/tests/fixtures/golden/go/expected.json
@@ -108,6 +108,14 @@
       "receiver_type": null
     },
     {
+      "source_name": "User",
+      "kind": "embeds",
+      "target_name": "BaseEntity",
+      "line": 25,
+      "column": 0,
+      "receiver_type": null
+    },
+    {
       "source_name": "helperCall",
       "kind": "calls",
       "target_name": "Println",

--- a/tests/fixtures/golden/kotlin/expected.json
+++ b/tests/fixtures/golden/kotlin/expected.json
@@ -176,10 +176,82 @@
       "receiver_type": null
     },
     {
+      "source_name": "helperCall",
+      "kind": "references",
+      "target_name": "String",
+      "line": 23,
+      "column": 0,
+      "receiver_type": null
+    },
+    {
+      "source_name": "helperCall",
+      "kind": "references",
+      "target_name": "String",
+      "line": 23,
+      "column": 0,
+      "receiver_type": null
+    },
+    {
+      "source_name": "id",
+      "kind": "references",
+      "target_name": "String",
+      "line": 6,
+      "column": 0,
+      "receiver_type": null
+    },
+    {
+      "source_name": "id",
+      "kind": "references",
+      "target_name": "String",
+      "line": 15,
+      "column": 0,
+      "receiver_type": null
+    },
+    {
+      "source_name": "name",
+      "kind": "references",
+      "target_name": "String",
+      "line": 13,
+      "column": 0,
+      "receiver_type": null
+    },
+    {
+      "source_name": "name",
+      "kind": "references",
+      "target_name": "String",
+      "line": 15,
+      "column": 0,
+      "receiver_type": null
+    },
+    {
       "source_name": "process",
       "kind": "calls",
       "target_name": "helperCall",
       "line": 20,
+      "column": 0,
+      "receiver_type": null
+    },
+    {
+      "source_name": "process",
+      "kind": "references",
+      "target_name": "String",
+      "line": 19,
+      "column": 0,
+      "receiver_type": null
+    },
+    {
+      "source_name": "status",
+      "kind": "references",
+      "target_name": "Status",
+      "line": 16,
+      "column": 0,
+      "receiver_type": null
+    },
+    {
+      "source_name": "tag",
+      "kind": "references",
+      "target_name": "String",
+      "line": 17,
       "column": 0,
       "receiver_type": null
     }

--- a/tests/fixtures/golden/python/expected.json
+++ b/tests/fixtures/golden/python/expected.json
@@ -89,7 +89,7 @@
   "edges": [
     {
       "source_name": "Status",
-      "kind": "implements",
+      "kind": "extends",
       "target_name": "Enum",
       "line": 5,
       "column": 0,
@@ -97,7 +97,7 @@
     },
     {
       "source_name": "User",
-      "kind": "implements",
+      "kind": "extends",
       "target_name": "BaseEntity",
       "line": 13,
       "column": 0,

--- a/tests/fixtures/golden/swift/expected.json
+++ b/tests/fixtures/golden/swift/expected.json
@@ -91,7 +91,7 @@
     },
     {
       "source_name": "User",
-      "kind": "implements",
+      "kind": "extends",
       "target_name": "BaseEntity",
       "line": 19,
       "column": 0,

--- a/tests/test_build_scip_hybrid.py
+++ b/tests/test_build_scip_hybrid.py
@@ -76,8 +76,11 @@ def test_scip_coexists_with_tree_sitter(tmp_path):
     conn.row_factory = sqlite3.Row
 
     # Foo is merged: one row, source='merged', tree-sitter kind preserved.
+    # (Module symbols are excluded: the file-stem module row for Foo.kt is
+    # a structural node, not a merge candidate.)
     foo_rows = conn.execute(
-        "SELECT name, source, kind FROM symbols WHERE name = 'Foo'"
+        "SELECT name, source, kind FROM symbols WHERE name = 'Foo' "
+        "AND kind != 'module'"
     ).fetchall()
     assert len(foo_rows) == 1, f"expected 1 merged Foo, got {len(foo_rows)}"
     assert foo_rows[0]["source"] == "merged"
@@ -85,7 +88,7 @@ def test_scip_coexists_with_tree_sitter(tmp_path):
 
     # Python still went through tree-sitter (no SCIP index for it).
     bar = conn.execute(
-        "SELECT source FROM symbols WHERE name = 'bar'"
+        "SELECT source FROM symbols WHERE name = 'bar' AND kind != 'module'"
     ).fetchone()
     assert bar is not None
     assert bar["source"] == "tree_sitter"

--- a/tests/test_dashboard_app.py
+++ b/tests/test_dashboard_app.py
@@ -2066,6 +2066,44 @@ def test_inspect_target_url_renders_symbol_neighborhood(tmp_path):
     }
 
 
+@requires_vis_network
+def test_graph_page_renders_edge_kind_legend_and_passthrough(tmp_path):
+    """Edge-kind enrichment: the /graph page carries the edge-legend element
+    app.js fills with per-kind filter chips, and the symbol scope passes the
+    DB's real edge kind through (an extends edge renders as extends, not the
+    pre-enrichment hardcoded calls)."""
+    db_path = _graph_db_file(tmp_path, seed=True)
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        "INSERT INTO symbols (id, file_id, name, qualified_name, kind) "
+        "VALUES ('s4', 'f1', 'Base', 'demo.core.Base', 'class')"
+    )
+    conn.execute(
+        "INSERT INTO edges (id, source_id, target_id, kind) "
+        "VALUES ('e3', 's1', 's4', 'extends')"
+    )
+    conn.commit()
+    conn.close()
+
+    pytest.importorskip("httpx")
+    from starlette.testclient import TestClient
+
+    from cairn.dashboard.app import create_app
+
+    client = TestClient(create_app(db_path=db_path))
+
+    page = client.get("/graph")
+    assert page.status_code == 200
+    assert 'id="edge-legend"' in page.text
+
+    payload = _embedded_graph(
+        client.get("/graph?scope=symbol&focus=demo_main").text
+    )
+    kinds = {(e["source"], e["target"], e["kind"]) for e in payload["edges"]}
+    assert ("demo_main", "demo_helper", "calls") in kinds
+    assert ("demo_main", "Base", "extends") in kinds
+
+
 def test_nav_and_landing_page_each_link_to_graph(tmp_path):
     """FR-006 / US3 / TC-006: /graph is no orphan — the shared nav carries
     it on every page (base.html) and the landing page's link list repeats

--- a/tests/test_dashboard_theme.py
+++ b/tests/test_dashboard_theme.py
@@ -55,6 +55,15 @@ _THEME_TOKENS = (
     "--kind-enum",
     "--kind-module",
     "--kind-external",
+    "--edge-calls",
+    "--edge-extends",
+    "--edge-implements",
+    "--edge-embeds",
+    "--edge-with",
+    "--edge-references",
+    "--edge-decorates",
+    "--edge-imports",
+    "--edge-contains",
 )
 
 _DARK_BG_0 = "#08090a"

--- a/tests/test_graph_relationship_kinds.py
+++ b/tests/test_graph_relationship_kinds.py
@@ -1,0 +1,467 @@
+"""Relationship-kind enrichment: parser extraction, builder derivation,
+imports-edge materialization, ancestor-index coverage, traversal exclusion,
+and viz-layer kind passthrough.
+
+Covers the canonical edge-kind vocabulary beyond `calls`:
+- parsers: extends (python base classes, swift superclass-first),
+  implements (swift protocol conformance), embeds (go struct/interface
+  embedding), decorates (python decorators), references (python signature
+  annotations, kotlin type annotations)
+- builder: contains (module->top-level, parent->nested), module symbols,
+  module-level edge ownership, imports edges (module->module)
+- resolver: embeds joins extends/implements in the ancestor index
+- traversal: the new kinds stay outside STRUCTURAL_EDGE_KINDS
+- viz: symbol/neighbors scopes pass the DB's edge kind through verbatim
+"""
+from __future__ import annotations
+
+import sqlite3
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from cairn.graph.schema import _apply_schema
+
+
+def _parse(parser_cls, source: bytes, suffix: str):
+    """Parse ``source`` with ``parser_cls`` via a temp file. Returns ParsedFile."""
+    with tempfile.NamedTemporaryFile(suffix=suffix, delete=False, mode="wb") as f:
+        f.write(source)
+        path = f.name
+    try:
+        return parser_cls().parse(path)
+    finally:
+        Path(path).unlink(missing_ok=True)
+
+
+def _edges(pf):
+    """{(source, kind, target)} from a ParsedFile."""
+    return {(e.source_name, e.kind, e.target_name) for e in pf.edges}
+
+
+# ---------------------------------------------------------------------------
+# Python: extends / decorates / references
+# ---------------------------------------------------------------------------
+
+class TestPythonRelationshipEdges:
+    def test_base_classes_are_extends(self):
+        from cairn.parsers.python_parser import PythonParser
+
+        pf = _parse(PythonParser, b"class Repo(Base, Serializable):\n    pass\n", ".py")
+        assert ("Repo", "extends", "Base") in _edges(pf)
+        assert ("Repo", "extends", "Serializable") in _edges(pf)
+        assert not any(k == "implements" for _, k, _ in _edges(pf))
+
+    def test_decorators_emit_decorates_edges(self):
+        from cairn.parsers.python_parser import PythonParser
+
+        src = (
+            b"@dataclass(frozen=True)\n"
+            b"@app.route('/x')\n"
+            b"class Repo:\n"
+            b"    @property\n"
+            b"    def id(self):\n"
+            b"        return 0\n"
+        )
+        pf = _parse(PythonParser, src, ".py")
+        assert ("Repo", "decorates", "dataclass") in _edges(pf)
+        assert ("Repo", "decorates", "route") in _edges(pf)
+        assert ("id", "decorates", "property") in _edges(pf)
+
+    def test_signature_annotations_emit_references(self):
+        from cairn.parsers.python_parser import PythonParser
+
+        src = (
+            b"def load(path: Path, limit: int = 10) -> Repo:\n"
+            b"    return Repo(path)\n"
+        )
+        pf = _parse(PythonParser, src, ".py")
+        assert ("load", "references", "Path") in _edges(pf)
+        assert ("load", "references", "Repo") in _edges(pf)
+        # builtin typing tokens stay out
+        assert ("load", "references", "int") not in _edges(pf)
+
+    def test_subscripted_annotations_contribute_inner_names(self):
+        from cairn.parsers.python_parser import PythonParser
+
+        pf = _parse(PythonParser, b"def f() -> dict[str, Repo]:\n    pass\n", ".py")
+        assert ("f", "references", "Repo") in _edges(pf)
+        assert ("f", "references", "dict") not in _edges(pf)
+
+
+# ---------------------------------------------------------------------------
+# Go: embeds
+# ---------------------------------------------------------------------------
+
+class TestGoEmbedsEdges:
+    def test_struct_embedding(self):
+        from cairn.parsers.go import GoParser
+
+        src = (
+            b"package main\n"
+            b"type Base struct{ ID int }\n"
+            b"type S struct {\n"
+            b"	*Base\n"
+            b"	Name string\n"
+            b"	pkg.Config\n"
+            b"}\n"
+        )
+        pf = _parse(GoParser, src, ".go")
+        assert ("S", "embeds", "Base") in _edges(pf)
+        assert ("S", "embeds", "Config") in _edges(pf)
+        # named fields are members, not embeds
+        assert ("S", "embeds", "Name") not in _edges(pf)
+
+    def test_interface_embedding(self):
+        from cairn.parsers.go import GoParser
+
+        src = (
+            b"package main\n"
+            b"type Reader interface {\n"
+            b"	Read() error\n"
+            b"	io.Writer\n"
+            b"}\n"
+        )
+        pf = _parse(GoParser, src, ".go")
+        assert ("Reader", "embeds", "Writer") in _edges(pf)
+        # method elements are members, not embeds
+        assert ("Reader", "embeds", "Read") not in _edges(pf)
+
+
+# ---------------------------------------------------------------------------
+# Swift: extends (superclass) / implements (protocol conformance)
+# ---------------------------------------------------------------------------
+
+class TestSwiftInheritanceSplit:
+    def test_class_first_target_extends_rest_implements(self):
+        from cairn.parsers.swift import SwiftParser
+
+        pf = _parse(
+            SwiftParser,
+            b"class MyView: BaseView, UITableViewDelegate {\n func r() {}\n}\n",
+            ".swift",
+        )
+        assert ("MyView", "extends", "BaseView") in _edges(pf)
+        assert ("MyView", "implements", "UITableViewDelegate") in _edges(pf)
+
+    def test_struct_and_enum_targets_all_implement(self):
+        from cairn.parsers.swift import SwiftParser
+
+        pf = _parse(
+            SwiftParser,
+            b"struct Price: Codable, Hashable {}\nenum Coin: Int {}\n",
+            ".swift",
+        )
+        assert ("Price", "implements", "Codable") in _edges(pf)
+        assert ("Price", "implements", "Hashable") in _edges(pf)
+        assert not any(k == "extends" for _, k, _ in _edges(pf))
+
+
+# ---------------------------------------------------------------------------
+# Kotlin: references from type annotations
+# ---------------------------------------------------------------------------
+
+class TestKotlinTypeReferences:
+    def test_param_return_and_property_types(self):
+        from cairn.parsers.kotlin import KotlinParser
+
+        src = (
+            b"class UseCase {\n"
+            b"    private val repo: Repo = Repo()\n"
+            b"    fun execute(user: User): Result {\n"
+            b"        return repo.load(user.id)\n"
+            b"    }\n"
+            b"}\n"
+        )
+        pf = _parse(KotlinParser, src, ".kt")
+        assert ("execute", "references", "User") in _edges(pf)
+        assert ("execute", "references", "Result") in _edges(pf)
+        assert ("repo", "references", "Repo") in _edges(pf)
+
+
+# ---------------------------------------------------------------------------
+# Builder: module symbols, contains edges, module-level ownership
+# ---------------------------------------------------------------------------
+
+_PY_FIXTURE = {
+    "pkg/__init__.py": "",
+    "pkg/models.py": (
+        "class Model:\n"
+        "    def validate(self) -> bool:\n"
+        "        return True\n"
+        "\n"
+        "    class Meta:\n"
+        "        verbose = True\n"
+    ),
+    "pkg/store.py": (
+        "from pkg.models import Model\n"
+        "\n"
+        "validate_all = len([1, 2])\n"
+        "\n"
+        "class Store:\n"
+        "    def load(self) -> Model:\n"
+        "        return Model()\n"
+),
+}
+
+
+def _make_workspace(tmp_path, name="ws"):
+    workspace = tmp_path / name
+    repo = workspace / "demo"
+    (repo / ".git").mkdir(parents=True)
+    for fname, contents in _PY_FIXTURE.items():
+        target = repo / fname
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(contents)
+    return str(workspace)
+
+
+@pytest.fixture()
+def built_db(tmp_path):
+    from cairn.graph.builder import build_graph
+
+    ws = _make_workspace(tmp_path)
+    db_path = str(tmp_path / "graph.db")
+    build_graph(workspace=ws, db_path=db_path, verbose=False)
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    try:
+        yield conn
+    finally:
+        conn.close()
+
+
+def _kinds(conn) -> dict:
+    return dict(conn.execute("SELECT kind, COUNT(*) FROM edges GROUP BY kind").fetchall())
+
+
+class TestBuilderModuleAndContains:
+    def test_module_symbol_per_file(self, built_db):
+        modules = built_db.execute(
+            "SELECT s.name, f.path FROM symbols s JOIN files f ON s.file_id = f.id "
+            "WHERE s.kind = 'module'"
+        ).fetchall()
+        by_path = {m["path"]: m["name"] for m in modules}
+        assert by_path.get("pkg/models.py") == "models"
+        assert by_path.get("pkg/store.py") == "store"
+        # __init__.py still yields a module symbol named after the file stem
+        assert by_path.get("pkg/__init__.py") == "__init__"
+
+    def test_contains_module_to_top_level(self, built_db):
+        row = built_db.execute(
+            """SELECT COUNT(*) FROM edges e
+               JOIN symbols src ON e.source_id = src.id
+               JOIN symbols tgt ON e.target_id = tgt.id
+               WHERE e.kind = 'contains' AND src.kind = 'module'
+                 AND src.file_id = (SELECT id FROM files WHERE path = 'pkg/models.py')
+                 AND tgt.name = 'Model'"""
+        ).fetchone()
+        assert row[0] == 1
+
+    def test_contains_parent_to_nested(self, built_db):
+        row = built_db.execute(
+            """SELECT e.resolution FROM edges e
+               JOIN symbols src ON e.source_id = src.id
+               JOIN symbols tgt ON e.target_id = tgt.id
+               WHERE e.kind = 'contains' AND src.name = 'Model' AND tgt.name = 'Meta'"""
+        ).fetchone()
+        assert row is not None
+        assert row[0] == "exact"
+
+    def test_module_level_edge_attaches_to_module(self, built_db):
+        # `len(...)` runs at module level in store.py: the edge's source is
+        # the store module symbol, not dropped on the floor.
+        row = built_db.execute(
+            """SELECT src.name FROM edges e
+               JOIN symbols src ON e.source_id = src.id
+               WHERE e.kind = 'calls' AND e.target_name = 'len'"""
+        ).fetchone()
+        assert row is not None
+        assert row[0] == "store"
+
+
+class TestBuilderImportsEdges:
+    def test_intra_repo_import_edge(self, built_db):
+        rows = built_db.execute(
+            """SELECT src.name AS src_name, e.target_name, e.resolution
+               FROM edges e JOIN symbols src ON e.source_id = src.id
+               WHERE e.kind = 'imports'"""
+        ).fetchall()
+        assert rows, "expected at least one imports edge from `from pkg.models import Model`"
+        store_edges = [r for r in rows if r["src_name"] == "store"]
+        assert any(
+            r["target_name"] == "pkg.models" and r["resolution"] == "exact"
+            for r in store_edges
+        )
+
+    def test_materialize_is_idempotent(self, built_db):
+        from cairn.graph.builder import materialize_import_edges
+
+        before = built_db.execute(
+            "SELECT COUNT(*) FROM edges WHERE kind = 'imports'"
+        ).fetchone()[0]
+        again = materialize_import_edges(built_db)
+        after = built_db.execute(
+            "SELECT COUNT(*) FROM edges WHERE kind = 'imports'"
+        ).fetchone()[0]
+        assert again == before
+        assert after == before
+
+    def test_ambiguous_import_target_skipped(self, tmp_path):
+        # Two files share the bare candidate "models": the import resolves
+        # only through a longer suffix, which the longest-first pass finds.
+        from cairn.graph.builder import build_graph
+
+        workspace = tmp_path / "ws2"
+        repo = workspace / "demo"
+        (repo / ".git").mkdir(parents=True)
+        (repo / "a").mkdir()
+        (repo / "a" / "models.py").write_text("X = 1\n")
+        (repo / "b").mkdir()
+        (repo / "b" / "models.py").write_text("Y = 2\n")
+        (repo / "main.py").write_text("import a.models\nimport b.models\n")
+        db_path = str(tmp_path / "graph2.db")
+        build_graph(workspace=str(workspace), db_path=db_path, verbose=False)
+        conn = sqlite3.connect(db_path)
+        conn.row_factory = sqlite3.Row
+        try:
+            targets = [
+                r[0]
+                for r in conn.execute(
+                    "SELECT target_name FROM edges WHERE kind = 'imports'"
+                ).fetchall()
+            ]
+            assert sorted(targets) == ["a.models", "b.models"]
+        finally:
+            conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Resolver + traversal semantics
+# ---------------------------------------------------------------------------
+
+class TestAncestorIndexAndTraversal:
+    def test_ancestor_index_includes_embeds(self):
+        from cairn.graph.resolver import build_ancestor_index
+
+        conn = sqlite3.connect(":memory:")
+        conn.row_factory = sqlite3.Row
+        _apply_schema(conn)
+        conn.executemany(
+            "INSERT INTO symbols (id, file_id, name, kind) VALUES (?, ?, ?, ?)",
+            [
+                ("s1", "f1", "Base", "class"),
+                ("s2", "f1", "S", "class"),
+                ("s3", "f1", "Iface", "interface"),
+            ],
+        )
+        conn.execute("INSERT INTO files (id, repo_id, path, language) VALUES ('f1', 'r', 'a.go', 'go')")
+        conn.executemany(
+            "INSERT INTO edges (id, source_id, target_id, target_name, kind) VALUES (?, ?, ?, ?, ?)",
+            [
+                ("e1", "s2", "s1", "Base", "embeds"),
+                ("e2", "s2", "s3", "Iface", "implements"),
+            ],
+        )
+        conn.commit()
+        anc = build_ancestor_index(conn)
+        assert set(anc.get("S", [])) == {"Base", "Iface"}
+
+    def test_new_kinds_stay_unstructural(self):
+        from cairn.graph.traversal import STRUCTURAL_EDGE_KINDS
+
+        for kind in ("contains", "imports", "references", "decorates", "embeds", "with"):
+            assert kind not in STRUCTURAL_EDGE_KINDS
+
+    def test_impact_does_not_traverse_contains(self, built_db):
+        from cairn.graph.queries import impact_analysis
+
+        # Store.load calls Model; impact over `load` must reach its caller
+        # kinds, but contains/imports edges must never widen the blast
+        # radius: `Model.Meta` is reachable only via contains from Model.
+        result = impact_analysis(built_db, "Model")
+        impacted = {r["symbol"] for r in result["impacted"]}
+        # Nothing calls Model()... store.load does (Model() constructor call).
+        assert "load" in impacted
+        # Meta hangs off Model only through contains: not an impact entry.
+        assert "Meta" not in impacted
+        assert "store" not in impacted  # imports edge is not traversal
+
+
+# ---------------------------------------------------------------------------
+# Viz layer: kind passthrough
+# ---------------------------------------------------------------------------
+
+def _seed_viz(conn):
+    conn.executemany(
+        "INSERT INTO symbols (id, file_id, name, kind) VALUES (?, ?, ?, ?)",
+        [
+            ("s1", "f1", "main", "function"),
+            ("s2", "f1", "helper", "function"),
+            ("s3", "f1", "Base", "class"),
+        ],
+    )
+    conn.execute("INSERT INTO files (id, repo_id, path, language) VALUES ('f1', 'r', 'a.py', 'python')")
+    conn.executemany(
+        "INSERT INTO edges (id, source_id, target_id, target_name, kind) VALUES (?, ?, ?, ?, ?)",
+        [
+            ("e1", "s1", "s2", "helper", "calls"),
+            ("e2", "s1", "s3", "Base", "extends"),
+            ("e3", "s3", "s1", "main", "references"),
+        ],
+    )
+    conn.commit()
+
+
+@pytest.fixture()
+def viz_conn():
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    _apply_schema(conn)
+    _seed_viz(conn)
+    try:
+        yield conn
+    finally:
+        conn.close()
+
+
+class TestVizKindPassthrough:
+    def test_symbol_scope_passes_kind_through(self, viz_conn):
+        from cairn.viz.query import get_symbol_graph
+
+        graph = get_symbol_graph(viz_conn, "main")
+        kinds = {(e["source"], e["target"], e["kind"]) for e in graph["edges"]}
+        assert ("main", "helper", "calls") in kinds
+        assert ("main", "Base", "extends") in kinds
+
+    def test_symbol_scope_caller_keeps_real_kind(self, viz_conn):
+        from cairn.viz.query import get_symbol_graph
+
+        graph = get_symbol_graph(viz_conn, "main")
+        kinds = {(e["source"], e["target"], e["kind"]) for e in graph["edges"]}
+        # Base --references--> main shows as references, not calls.
+        assert ("Base", "main", "references") in kinds
+
+    def test_neighbors_passes_kind_through(self, viz_conn):
+        from cairn.viz.query import get_symbol_neighbors
+
+        graph = get_symbol_neighbors(viz_conn, ["main"])
+        kinds = {(e["source"], e["target"], e["kind"]) for e in graph["edges"]}
+        assert ("main", "helper", "calls") in kinds
+        assert ("main", "Base", "extends") in kinds
+        assert ("Base", "main", "references") in kinds
+
+    def test_inspect_payload_carries_edge_kind(self, viz_conn):
+        from cairn.dashboard.data import inspect_symbol
+
+        data = inspect_symbol(viz_conn, "main")
+        caller_kinds = {(c["name"], c["edge_kind"]) for c in data["callers"]}
+        assert ("Base", "references") in caller_kinds
+        callee_kinds = {(c["name"], c["edge_kind"]) for c in data["callees"]}
+        assert ("helper", "calls") in callee_kinds
+        assert ("Base", "extends") in callee_kinds
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

Widens the graph's relationship vocabulary from `calls`/`extends`/`implements` to the full canonical set — `calls, extends, implements, embeds, with, references, decorates, imports, contains` — so the dashboard graph view shows the relationship types the code actually has. Fixes both halves of "I can't see many relationship types": the viz layer was flattening every edge to `calls`, and extraction never captured most relationship kinds in the first place.

### Display layer
- `viz/query.py`: symbol/neighbors scopes SELECT and pass the stored `e.kind` through (previously hardcoded `"calls"`); module scope reports `metadata.edge_kinds` counts.
- `dashboard/data.py` + inspect panel: callers/callees carry `edge_kind`, rendered as badges.
- `app.js`/`app.css`: per-kind edge colors and dash patterns from new `--edge-*` theme tokens (all three theme blocks, enforced by the theme test), plus an edge-kind legend whose chips filter whole kinds client-side (same pattern as the node-kind legend and `knowledge-graph.js`). Theme flips re-color edges live.

### Extraction layer
- **Python**: base classes emit `extends` (was `implements`); decorators emit `decorates` (now correctly read off the `decorated_definition` wrapper — they previously never even reached modifiers); signature type annotations emit `references` (builtin typing tokens filtered).
- **Swift**: a class/actor's first inheritance target is `extends` (superclass), the rest and all struct/enum/protocol targets are `implements` (protocol conformance).
- **Go**: anonymous struct fields (`*Base`, `pkg.Config`) and interface `type_elem`s emit `embeds`; named fields/method elements excluded.
- **Kotlin**: value-parameter/return/property/constructor-parameter `user_type` annotations emit `references` (bodies excluded).
- **Builder**: one `kind='module'` symbol per file (dotted repo-relative qualified name; `__init__.py` collapses to the package); `contains` edges derived for nesting (module→top-level, parent→nested, pinned in-file with `resolution='exact'`); module-level code edges attach to the module symbol instead of being dropped; `imports` module→module edges materialized from the imports table by longest-suffix dotted-path matching (external/ambiguous imports skipped; idempotent delete+reinsert; refreshed per repo on incremental sync).

### Semantics preserved
- `STRUCTURAL_EDGE_KINDS` unchanged: impact/trace_flow/transitive-closure/dataflow ignore the new kinds (regression-tested).
- Module symbols are excluded from the resolver's candidate indexes (`build_symbol_index`, `build_members_index` type-name set): a file named after its single class (Kotlin/Java convention) would otherwise make every same-name edge ambiguous.
- `embeds` joins `extends`/`implements` in `build_ancestor_index` (Go embedding is inheritance-like for receiver dispatch).
- SCIP coexistence verified (merge unaffected; test updated to tolerate module symbols in name queries).

## Change type

- [x] Feature / improvement
- [ ] Bugfix
- [ ] Refactor (no behavior change)
- [ ] Docs / chore / CI

## Audit checklist

Author — confirm before requesting review (procedure: `docs/review-checklist.md`):

- [x] **Blast radius checked** — `cairn impact insert_parsed_file` (151 impacted: builder/incremental/watcher/CLI chain + their tests, all covered by suites run) and `cairn impact build_symbol_index` (154: resolver consumers). No public-API signature changes; new symbols only (`materialize_import_edges`, parser helpers).
- [x] **Layering respected** — parsers→ParsedFile model→builder→resolver/viz/dashboard flow unchanged; new display tokens live in the existing theme blocks; no documented-boundary crossings.
- [x] **Graph updated** — `cairn update` ran (incremental; the 14 edited files carry module symbols + contains/imports/references/decorates/extends edges, verified by direct store query).
- [x] **Memory recorded** — decision recorded: module symbols excluded from resolver indexes + edge-kind vocabulary/traversal rules (`memory/tribal/edge-kind-enrichment-module-symbols-excluded-from-resolver-i-c441ae`).
- [x] **Fallback/perf paths** — `cairn doctor` exit 0 (PASS/WARN; only pre-existing registration-shape WARN). Resolution fallback tiers unchanged; new ambiguity risk addressed by the module-symbol exclusion.
- [x] **Tests** — new `tests/test_graph_relationship_kinds.py` (23 tests: parsers, builder contains/module/imports, ancestor index, traversal exclusion, viz passthrough) + dashboard edge-legend/passthrough test + theme-token test extension. Full suite: 3062 passed / 4 skipped, 1 pre-existing failure (`test_metrics_extensions.py::test_builds_human_shows_resolution_mix`) that also fails on clean `main` (verified via worktree; terminal-width-dependent rich table rendering, unrelated). Golden parser snapshots regenerated (only python/kotlin/swift/go diverged; other 10 byte-identical).
- [x] **CHANGELOG** — `[Unreleased]` entry added.
- [x] **Gates green** — pre-commit all-files passed (ruff, secrets, yaml/toml, conflicts, large files); mypy clean on changed modules (remaining 18 findings are optional-dependency import stubs, same set as main); conventional commit + PR title.

## Blast-radius note

No signature changes to existing public functions. `insert_parsed_file` gained behavior (module symbol + contains rows in its returned counts); its two callers (`_insert_results`, `reindex_paths`) consume counts opaquely. New module symbols are visible to name-based consumers — resolver indexes exclude them (see above), and the two test adjustments (SCIP hybrid, inspect/`WHERE name=` queries) document the new invariant.

## Verification

- `pytest tests/` → 3062 passed, 4 skipped, 1 pre-existing main failure (noted above)
- `pre-commit run --all-files` → passed
- `mypy` on changed modules → clean
- Manual store verification after `cairn update`: edge kinds `{calls: 37652, contains: 492, implements: 215, references: 200, imports: 42, extends: 22, decorates: 19}` on the incrementally reindexed files; imports edges spot-checked (builder.py → parsers/*.py etc.)
- **Note**: extraction changes require a rebuild (`cairn build`) post-merge to populate the whole store; the incremental path already produces the new kinds for touched files.

🤖 Generated with [Factory Droid](https://docs.factory.ai/droid)
