### PR TITLE
chore(release): bump version to 0.19.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.19.1] - 2026-09-10
+
 ### Added
 - Relationship-kind enrichment across extraction and display. The graph's
   canonical edge-kind vocabulary is now `calls`, `extends`, `implements`,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "cairn-intel"
-version = "0.19.0"
+version = "0.19.1"
 description = "Local codebase intelligence system: structural graph + compass + wiki + agent memory"
 readme = "README.md"
 license = "MIT"
@@ -235,7 +235,7 @@ select = ["F"]
 # The custom template (.cz_templates/keepachangelog.j2) renders that draft in
 # the existing `## [X.Y.Z] - YYYY-MM-DD` format rather than commitizen's
 # default `## X.Y.Z (YYYY-MM-DD)`.
-version = "0.19.0"
+version = "0.19.1"
 version_scheme = "pep440"
 tag_format = "v$version"
 update_changelog_on_bump = false

--- a/src/cairn/__init__.py
+++ b/src/cairn/__init__.py
@@ -1,3 +1,3 @@
 """Cairn: local codebase intelligence system."""
-__version__ = "0.19.0"
+__version__ = "0.19.1"
 __package_name__ = "cairn-intel"

--- a/uv.lock
+++ b/uv.lock
@@ -202,7 +202,7 @@ filecache = [
 
 [[package]]
 name = "cairn-intel"
-version = "0.19.0"
+version = "0.19.1"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Patch release 0.19.1 — ships the edge-kind relationship enrichment merged in #111 and the DS-v2 seal facts re-pin.

## Summary

Three release commits following the documented 0.19.0 procedure:
1. `docs: prepare 0.19.1 changelog` — moves `[Unreleased]` entries under `## [0.19.1] - 2026-09-10`
2. `bump: version 0.19.0 → 0.19.1` — `version` in pyproject.toml (project + `[tool.commitizen]`) and `__version__` in `src/cairn/__init__.py`
3. `chore: sync uv.lock to 0.19.1` — regenerated via `uv lock`

No tag is pushed (matching 0.19.0/0.19.1-era practice); PyPI release via `release.yml` stays untriggered until a tag is pushed deliberately.

## Change type

- [ ] Feature / improvement
- [ ] Bugfix
- [ ] Refactor (no behavior change)
- [x] Docs / chore / CI

## Audit checklist

- [x] **Blast radius checked** — version constants only; no code paths read them at import time beyond `__version__` display.
- [x] **Layering respected** — n/a (release chore).
- [x] **Graph updated** — store rebuilt on main after #111; version bump doesn't affect the graph.
- [x] **Memory recorded** — n/a (no new decisions; procedure follows docs/release-checklist.md).
- [x] **Fallback/perf paths** — n/a.
- [x] **Tests** — release checklist tier run: `pytest tests/ -m infra` → 201 passed, 1 skipped (pre-existing skip), 2866 deselected; full suite ran green on this code in #111 (3062 passed / 4 skipped / 1 pre-existing main failure). Version-file changes are data-only.
- [x] **CHANGELOG** — `[0.19.1]` section cut from `[Unreleased]`; empty `[Unreleased]` header retained.
- [x] **Gates green** — pre-commit over changed files passed; conventional commits and PR title.

## Blast-radius note

None — no signatures or behavior changed; `uv lock` diff is the one-line project version.

## Verification

- `uv lock` → `Updated cairn-intel v0.19.0 -> v0.19.1`, lock diff is 1 line
- `grep 0.19.0` over pyproject.toml + `src/cairn/__init__.py` → 0 occurrences
- Infra test tier: 201 passed, 1 skipped

🤖 Generated with [Factory Droid](https://docs.factory.ai/droid)
