### PR TITLE
fix(dashboard): label the launch workspace and guide empty symbol scope

### DIFF
--- a/src/cairn/dashboard/app.py
+++ b/src/cairn/dashboard/app.py
@@ -353,6 +353,7 @@ def create_app(
                 enumerate_stores(Path(paths.CAIRN_HOME)),
                 context.get("store_key", ""),
                 request.url.path,
+                launch_db=db_path,
             )
         return templates.TemplateResponse(
             request, name, context, status_code=status_code
@@ -532,7 +533,8 @@ def create_app(
             request, db_path, knowledge_dir
         )
         palette = shell_context(
-            enumerate_stores(Path(paths.CAIRN_HOME)), store_key, "/"
+            enumerate_stores(Path(paths.CAIRN_HOME)), store_key, "/",
+            launch_db=db_path,
         )["palette"]
         lowered = query.lower()
         rows = [

--- a/src/cairn/dashboard/shell.py
+++ b/src/cairn/dashboard/shell.py
@@ -18,12 +18,12 @@ test). Two owners:
 """
 from __future__ import annotations
 
+from pathlib import Path
 from typing import List, Optional
 from urllib.parse import quote
 
-# The label shown for the no-selection option: the launch store the CLI
-# resolved (the dashboard process's own db), which the selector can always
-# return to.
+# Fallback label for the no-selection option: the launch db is a custom
+# path outside the store registry, so no workspace name is derivable.
 LAUNCH_LABEL = "Launch workspace"
 
 # Sidebar + palette view grouping. Order within a section is the display
@@ -75,6 +75,21 @@ def workspace_label(path: Optional[str], key: str) -> str:
     return key
 
 
+def launch_option_label(stores: List[dict], launch_db: Optional[str]) -> str:
+    """Label for the selector's no-selection option: the launch
+    workspace's own name when the launch db is a registered store, so a
+    dashboard launched from one workspace never reads as
+    workspace-agnostic; ``LAUNCH_LABEL`` stands in for a custom ``--db``
+    outside the registry."""
+    if not launch_db:
+        return LAUNCH_LABEL
+    key = Path(launch_db).parent.name
+    for row in stores:
+        if row["key"] == key and row.get("state") == "populated":
+            return f"{workspace_label(row.get('path'), key)} (launch)"
+    return LAUNCH_LABEL
+
+
 def selector_context(
     stores: List[dict], store_key: str
 ) -> dict:
@@ -102,7 +117,7 @@ def _populated_options(stores: List[dict]) -> List[dict]:
 
 
 def shell_context(
-    stores: List[dict], store_key: str, path: str
+    stores: List[dict], store_key: str, path: str, launch_db: Optional[str] = None
 ) -> dict:
     """Everything base.html's chrome renders from, for one request.
 
@@ -112,7 +127,9 @@ def shell_context(
     the request path exactly as the old hand-written startswith checks
     did. ``palette`` seeds the command palette: the same view list plus
     the populated workspaces (the palette switches stores through the
-    same URL-rewrite behavior as the topbar selector).
+    same URL-rewrite behavior as the topbar selector). ``launch_db`` is
+    the app factory's launch db path; when it names a registered store,
+    the selector's no-selection option carries that workspace's name.
     """
     nav_query = "?store=" + quote(store_key, safe="") if store_key else ""
     options = _populated_options(stores)
@@ -139,7 +156,7 @@ def shell_context(
         "selector": {
             "options": options,
             "selected": store_key,
-            "launch_label": LAUNCH_LABEL,
+            "launch_label": launch_option_label(stores, launch_db),
         },
         "nav": {"sections": sections},
         "palette": {"views": palette_views, "workspaces": options},

--- a/src/cairn/dashboard/templates/graph.html
+++ b/src/cairn/dashboard/templates/graph.html
@@ -109,7 +109,11 @@
     <aside id="graph-panel" class="graph-panel" aria-live="polite" hidden></aside>
   </div>
   {% else %}
+  {%- if scope == "symbol" and not focus %}
+  <p class="empty-state">Symbol scope centers on one symbol — search in the Symbol box above or enter a name in Focus, then Apply.</p>
+  {%- else %}
   <p class="empty-state">No nodes for this scope — adjust the controls above.</p>
+  {%- endif %}
   {% endif %}
   {#- FR-003: a selected store rides the page for app.js (search and
       expansion fetches stay on that store); no selection renders the tag

--- a/tests/test_dashboard_app.py
+++ b/tests/test_dashboard_app.py
@@ -248,6 +248,24 @@ def test_graph_route_unknown_scope_falls_back_to_module(tmp_path):
     assert _embedded_graph(resp.text)["metadata"]["scope"] == "module"
 
 
+@requires_vis_network
+def test_graph_route_symbol_scope_without_focus_guides_to_search(tmp_path):
+    """Symbol scope is focus-driven: with no focal name the empty state
+    says what to provide instead of the generic adjust-the-controls line
+    (which stays for every other scope/empty combination)."""
+    client = _client(tmp_path, seed=True)
+    resp = client.get("/graph", params={"scope": "symbol"})
+    assert resp.status_code == 200
+    assert "Symbol box above" in resp.text
+    assert "No nodes for this scope" not in resp.text
+
+    # A focus that names nothing is a searched-and-missed case, not a
+    # missing focus: the generic line applies.
+    resp = client.get("/graph", params={"scope": "symbol", "focus": "nope"})
+    assert resp.status_code == 200
+    assert "No nodes for this scope" in resp.text
+
+
 # ---------------------------------------------------------------------------
 # Layout persistence + option application (graph-nav FR-004 / US3 / TC-005):
 # /graph reads ``layout`` ∈ {force, hier} -- default force, bogus → force;
@@ -2806,6 +2824,32 @@ def test_workspace_selector_lists_populated_stores_only(tmp_path, monkeypatch):
     assert 'title="/workspaces/proj-alpha' in resp.text
     # The launch store is always reachable as the empty-value option.
     assert "<option value=\"\">Launch workspace</option>" in resp.text
+
+
+def test_workspace_selector_names_the_launch_workspace(tmp_path, monkeypatch):
+    """When the launch db is itself a registered store, the no-selection
+    option names that workspace — a dashboard launched from one workspace
+    must not read as workspace-agnostic."""
+    pytest.importorskip("httpx")
+    from starlette.testclient import TestClient
+
+    from cairn import paths
+    from cairn.dashboard.app import create_app
+
+    home = tmp_path / "cairn-home"
+    home.mkdir()
+    _seed_switch_store(
+        home / _SW_KEY_A / ".kg", "storeA", "store_a_tool", "2026-08-20T07:00:00Z"
+    )
+    (home / "workspaces.json").write_text(
+        json.dumps({"/workspaces/proj-alpha": _SW_KEY_A}), encoding="utf-8"
+    )
+    monkeypatch.setattr(paths, "CAIRN_HOME", home)
+    client = TestClient(create_app(db_path=str(home / _SW_KEY_A / ".kg")))
+
+    resp = client.get("/projects")
+    assert resp.status_code == 200
+    assert "<option value=\"\">proj-alpha (launch)</option>" in resp.text
 
 
 def test_workspace_selector_marks_the_selected_store(tmp_path, monkeypatch):

--- a/tests/test_dashboard_shell.py
+++ b/tests/test_dashboard_shell.py
@@ -6,8 +6,10 @@ hand-written anchors) and the workspace label policy.
 """
 
 from cairn.dashboard.shell import (
+    LAUNCH_LABEL,
     NAV_LABELS,
     NAV_SECTIONS,
+    launch_option_label,
     shell_context,
     workspace_label,
 )
@@ -102,3 +104,36 @@ def test_shell_context_selector_lists_populated_stores_only():
         "aaaaaaaaaaaaaaaa",
         "bbbbbbbbbbbbbbbb",
     ]
+
+
+def test_launch_option_label_names_the_registered_launch_workspace():
+    # The launch db lives inside a registered store dir: the option reads
+    # as that workspace's name, suffixed to distinguish it from the
+    # explicit switch target.
+    assert (
+        launch_option_label(_stores(), "/home/u/.cairn/aaaaaaaaaaaaaaaa/.kg")
+        == "alpha (launch)"
+    )
+
+
+def test_launch_option_label_falls_back_outside_the_registry():
+    # A custom --db path no store row names.
+    assert launch_option_label(_stores(), "/tmp/custom/proj/dash.db") == LAUNCH_LABEL
+    # A registered store that is not populated is no label source either.
+    assert (
+        launch_option_label(_stores(), "/home/u/.cairn/cccccccccccccccc/.kg")
+        == LAUNCH_LABEL
+    )
+    # No launch db resolved (create_app(None) callers).
+    assert launch_option_label(_stores(), None) == LAUNCH_LABEL
+    assert launch_option_label(_stores(), "") == LAUNCH_LABEL
+
+
+def test_shell_context_launch_label_rides_launch_db():
+    ctx = shell_context(
+        _stores(), "", "/graph", launch_db="/home/u/.cairn/aaaaaaaaaaaaaaaa/.kg"
+    )
+    assert ctx["selector"]["launch_label"] == "alpha (launch)"
+
+    ctx = shell_context(_stores(), "", "/graph")
+    assert ctx["selector"]["launch_label"] == LAUNCH_LABEL


### PR DESCRIPTION
## Summary

A dashboard launched from one workspace (say, `cairn dashboard` run inside polaris) serves that workspace's store as the launch store — but the topbar picker showed the generic, workspace-agnostic **"Launch workspace"** for it, so every view (graph tab included) silently read the wrong codebase with no visible hint. Reproduced live: with a polaris-launched dashboard, the graph tab's symbol search for a cairn symbol returned "no matching symbol" and `scope=symbol` rendered a generic empty state.

Two fixes:

- The picker's no-selection option now names the launch workspace — e.g. **"polaris (launch)"** — when the launch db is a registered store. The generic `Launch workspace` remains the fallback for custom `--db` paths outside the registry.
- The graph tab's `scope=symbol` without a focal name now renders targeted guidance ("search in the Symbol box above or enter a name in Focus, then Apply") instead of the generic "No nodes for this scope" line, which still covers every other empty case (searched-and-missed, other scopes).

## Change type

- [ ] Feature / improvement
- [x] Bugfix
- [ ] Refactor (no behavior change)
- [ ] Docs / chore / CI

## Audit checklist

- [x] **Blast radius checked** — `impact_analysis("shell_context")`: 41 impacted symbols, all within the dashboard package (render, palette route, shell/knowledge tests); `launch_option_label` is a new symbol with no callers beyond `shell_context`. No public API outside the package touched, so no `cross_repo_deps` surface.
- [x] **Layering respected** — `shell.py` gains only a `pathlib` import; it stays free of the server stack (pinned by `test_importing_dashboard_never_loads_server_stack`, green). (`ask_compass` MCP tool is currently degraded in this session — pipx 0.19.1 server import error — so layering was verified by inspection + the pinned import-guard tests.)
- [x] **Graph updated** — `cairn update` hit the known stale no-op; `cairn build` re-run, `cairn def launch_option_label` resolves.
- [x] **Memory recorded** — post-merge (below).
- [x] **Fallback/perf paths** — `launch_option_label` is a display-label fallback; `cairn doctor` run post-change: exit 0 (pre-existing WARN: claude stdio registration without env block, tracked via #70).
- [x] **Tests** — new: 3 shell unit tests (`launch_option_label` + `launch_db` passthrough), 1 page test (launch workspace named in the picker), 1 graph-page test (symbol-scope guidance vs generic empty state). Full suite: 3069 passed, 4 skipped.
- [ ] **CHANGELOG** — handled at release prep per current convention (`docs: prepare X changelog` commits), matching #111.
- [x] **Gates green** — pre-commit clean; conventional PR title.

## Blast-radius note

`shell_context` gained an optional trailing param `launch_db=None` — all existing callers remain source-compatible; within-repo callers are the two `app.py` call sites plus pure-function tests, all exercised in the full suite.

## Verification

- `uv run --extra test pytest -q` → 3069 passed, 4 skipped.
- `uv run pre-commit run --all-files` → clean.
- Live repro (dashboard launched from the polaris workspace): before — picker read "Launch workspace", `/graph?scope=symbol` showed the generic empty state; after (repo build) — picker reads "polaris (launch)" and the empty state guides to the Symbol search / Focus field. Screenshot-verified in the browser.