### PR TITLE
feat(dashboard): symbol scope with no focus draws the workspace overview

### DIFF
--- a/src/cairn/dashboard/data.py
+++ b/src/cairn/dashboard/data.py
@@ -140,9 +140,10 @@ def get_graph(
     overview; the focus-driven scopes take the user's exact word instead.
     """
     if scope == "symbol":
-        if not (focus or "").strip():
+        name = (focus or "").strip()
+        if not name:
             return viz_query.get_symbol_overview(conn, include_tests=include_tests)
-        return viz_query.get_symbol_graph(conn, focus, 1 if depth is None else depth)
+        return viz_query.get_symbol_graph(conn, name, 1 if depth is None else depth)
     if scope == "module":
         return viz_query.get_module_graph(conn, focus or "", include_tests=include_tests)
     if scope == "impact":

--- a/src/cairn/dashboard/data.py
+++ b/src/cairn/dashboard/data.py
@@ -134,11 +134,15 @@ def get_graph(
     """Dispatch to a viz query scope; returns its ``{nodes, edges, metadata}``
     verbatim — the scope functions already cap result size (LIMIT 30/50,
     ``max_nodes``), and their metadata carries the possibly-truncated counts.
-    ``include_tests`` only applies to the module scope (the other scopes are
-    focus-driven, where the user asked for exactly that symbol's world).
+    The symbol scope with no focal name draws the workspace-wide overview
+    (degree-ranked, capped), matching the module scope's empty-filter
+    behavior. ``include_tests`` applies to the module scope and the symbol
+    overview; the focus-driven scopes take the user's exact word instead.
     """
     if scope == "symbol":
-        return viz_query.get_symbol_graph(conn, focus or "", 1 if depth is None else depth)
+        if not (focus or "").strip():
+            return viz_query.get_symbol_overview(conn, include_tests=include_tests)
+        return viz_query.get_symbol_graph(conn, focus, 1 if depth is None else depth)
     if scope == "module":
         return viz_query.get_module_graph(conn, focus or "", include_tests=include_tests)
     if scope == "impact":

--- a/src/cairn/dashboard/templates/graph.html
+++ b/src/cairn/dashboard/templates/graph.html
@@ -109,11 +109,7 @@
     <aside id="graph-panel" class="graph-panel" aria-live="polite" hidden></aside>
   </div>
   {% else %}
-  {%- if scope == "symbol" and not focus %}
-  <p class="empty-state">Symbol scope centers on one symbol — search in the Symbol box above or enter a name in Focus, then Apply.</p>
-  {%- else %}
   <p class="empty-state">No nodes for this scope — adjust the controls above.</p>
-  {%- endif %}
   {% endif %}
   {#- FR-003: a selected store rides the page for app.js (search and
       expansion fetches stay on that store); no selection renders the tag

--- a/src/cairn/viz/query.py
+++ b/src/cairn/viz/query.py
@@ -168,8 +168,8 @@ def get_repo_graph(conn: sqlite3.Connection, repo: str, max_nodes: int = 30) -> 
             "metadata": {"scope": "repo", "repo": repo, "node_count": len(nodes)}}
 
 
-_MODULE_CAP = 50
-_MODULE_EDGE_CAP = 100
+_SCOPE_CAP = 50
+_SCOPE_EDGE_CAP = 100
 
 # Paths whose symbols are generated or third-party noise, not hand-written
 # structure. Minified bundles dominate the degree ranking (one vendored
@@ -236,7 +236,7 @@ def get_module_graph(
         )["is_test"]:
             continue
         eligible += 1
-        if eligible > _MODULE_CAP:
+        if eligible > _SCOPE_CAP:
             continue
         _add_node(nodes, r["name"], r["kind"], r["path"], r["repo_id"])
         kept += 1
@@ -248,8 +248,10 @@ def get_module_graph(
             f"SELECT s1.name AS src, COALESCE(s2.name, e.target_name) AS tgt, e.kind "
             f"FROM edges e JOIN symbols s1 ON e.source_id = s1.id "
             f"LEFT JOIN symbols s2 ON e.target_id = s2.id "
-            f"WHERE s1.name IN ({placeholders}) LIMIT {_MODULE_EDGE_CAP}",
-            names,
+            f"WHERE s1.name IN ({placeholders}) "
+            f"AND COALESCE(s2.name, e.target_name) IN ({placeholders}) "
+            f"LIMIT {_SCOPE_EDGE_CAP}",
+            names + names,
         ).fetchall()
         for r in rows:
             if r["tgt"] in nodes:
@@ -271,7 +273,92 @@ def get_module_graph(
             "edge_count": len(edges),
             "edge_kinds": edge_kinds,
             "tests_included": include_tests,
-            "truncated": eligible > _MODULE_CAP,
+            "truncated": eligible > _SCOPE_CAP,
+            "vendored_excluded": vendored_excluded,
+        },
+    }
+
+
+def get_symbol_overview(conn: sqlite3.Connection, include_tests: bool = False) -> Dict:
+    """The workspace's most-connected symbols as one canvas — the symbol
+    scope's answer to an empty focal name (the dashboard's default landing
+    on that scope).
+
+    The same curation rules as :func:`get_module_graph` without a path
+    filter: candidates ranked by degree (fan-in + fan-out of any edges)
+    then name, so the cap lands on the symbols that carry the workspace's
+    structure. Tests are excluded by default (the ``is_test_symbol``
+    heuristics from the impact layer); ``include_tests`` opts back in.
+    Symbols from vendored/minified assets (:func:`_is_vendored_path`) are
+    never candidates. Edges are deduplicated on ``(source, target,
+    kind)`` — the join is by bare symbol name, so same-named symbols
+    across repos multiply one logical edge into many parallel rows.
+    ``metadata.tests_included``, ``metadata.truncated`` and
+    ``metadata.vendored_excluded`` report all three choices honestly.
+    """
+    from ..graph.tests import is_test_symbol
+
+    cur = conn.cursor()
+    nodes: dict[str, dict] = {}
+    edges: list[dict] = []
+    seen_edges = set()
+    vendored_excluded = 0
+    rows = cur.execute(
+        "SELECT s.name, s.kind, f.path, f.repo_id, s.qualified_name, "
+        "(SELECT COUNT(*) FROM edges e WHERE e.target_id = s.id) + "
+        "(SELECT COUNT(*) FROM edges e WHERE e.source_id = s.id) AS degree "
+        "FROM symbols s JOIN files f ON s.file_id = f.id "
+        "ORDER BY degree DESC, s.name ASC"
+    ).fetchall()
+    kept = 0
+    eligible = 0
+    for r in rows:
+        if _is_vendored_path(r["path"]):
+            vendored_excluded += 1
+            continue
+        if not include_tests and is_test_symbol(
+            r["path"], r["name"], r["qualified_name"] or ""
+        )["is_test"]:
+            continue
+        eligible += 1
+        if eligible > _SCOPE_CAP:
+            continue
+        _add_node(nodes, r["name"], r["kind"], r["path"], r["repo_id"])
+        kept += 1
+    # Edges between the kept symbols.
+    if nodes:
+        names = list(nodes.keys())
+        placeholders = ",".join("?" * len(names))
+        rows = cur.execute(
+            f"SELECT s1.name AS src, COALESCE(s2.name, e.target_name) AS tgt, e.kind "
+            f"FROM edges e JOIN symbols s1 ON e.source_id = s1.id "
+            f"LEFT JOIN symbols s2 ON e.target_id = s2.id "
+            f"WHERE s1.name IN ({placeholders}) "
+            f"AND COALESCE(s2.name, e.target_name) IN ({placeholders}) "
+            f"LIMIT {_SCOPE_EDGE_CAP}",
+            names + names,
+        ).fetchall()
+        for r in rows:
+            if r["tgt"] in nodes:
+                key = (r["src"], r["tgt"], r["kind"])
+                if key in seen_edges:
+                    continue
+                seen_edges.add(key)
+                edges.append({"source": r["src"], "target": r["tgt"], "kind": r["kind"]})
+    edge_kinds: dict[str, int] = {}
+    for e in edges:
+        edge_kinds[e["kind"]] = edge_kinds.get(e["kind"], 0) + 1
+    return {
+        "nodes": list(nodes.values()),
+        "edges": edges,
+        "metadata": {
+            "scope": "symbol",
+            "focus": "",
+            "node_count": len(nodes),
+            "edge_count": len(edges),
+            "edge_kinds": edge_kinds,
+            "tests_included": include_tests,
+            "truncated": eligible > _SCOPE_CAP,
             "vendored_excluded": vendored_excluded,
         },
     }

--- a/tests/test_dashboard_app.py
+++ b/tests/test_dashboard_app.py
@@ -249,18 +249,21 @@ def test_graph_route_unknown_scope_falls_back_to_module(tmp_path):
 
 
 @requires_vis_network
-def test_graph_route_symbol_scope_without_focus_guides_to_search(tmp_path):
-    """Symbol scope is focus-driven: with no focal name the empty state
-    says what to provide instead of the generic adjust-the-controls line
-    (which stays for every other scope/empty combination)."""
+def test_graph_route_symbol_scope_without_focus_draws_overview(tmp_path):
+    """Symbol scope with no focal name draws the workspace overview
+    (degree-ranked, capped) instead of an empty canvas — matching the
+    module scope's empty-filter behavior; a focus that names nothing
+    still renders the generic empty state."""
     client = _client(tmp_path, seed=True)
     resp = client.get("/graph", params={"scope": "symbol"})
     assert resp.status_code == 200
-    assert "Symbol box above" in resp.text
+    payload = _embedded_graph(resp.text)
+    assert payload["metadata"]["scope"] == "symbol"
+    assert {"demo_main", "demo_helper", "demo_util"} <= {
+        n["id"] for n in payload["nodes"]
+    }
     assert "No nodes for this scope" not in resp.text
 
-    # A focus that names nothing is a searched-and-missed case, not a
-    # missing focus: the generic line applies.
     resp = client.get("/graph", params={"scope": "symbol", "focus": "nope"})
     assert resp.status_code == 200
     assert "No nodes for this scope" in resp.text

--- a/tests/test_dashboard_data.py
+++ b/tests/test_dashboard_data.py
@@ -2583,6 +2583,99 @@ def test_module_scope_dedupes_cross_repo_parallel_edges(fresh_db):
     assert kinds == [("caller", "helper", "calls"), ("caller", "helper", "imports")]
 
 
+def test_symbol_scope_empty_focus_draws_the_overview(fresh_db):
+    from cairn.dashboard.data import get_graph
+
+    _seed_hubs(fresh_db)
+    graph = get_graph(fresh_db, scope="symbol")  # no focus
+
+    ids = {n["id"] for n in graph["nodes"]}
+    assert ids == {"hub_main", "in_a", "in_b", "out_a", "out_b", "pack_leaf"}
+    assert graph["metadata"]["scope"] == "symbol"
+    assert graph["metadata"]["tests_included"] is False
+    assert graph["metadata"]["node_count"] == 6
+    assert graph["metadata"]["edge_count"] == 4  # he1-he4; he5's test source is dropped
+    # Ranked by degree: the hub first, the unconnected leaf last.
+    assert graph["nodes"][0]["id"] == "hub_main"
+    assert graph["nodes"][-1]["id"] == "pack_leaf"
+
+
+def test_symbol_scope_overview_include_tests_opt_in(fresh_db):
+    from cairn.dashboard.data import get_graph
+
+    _seed_hubs(fresh_db)
+    graph = get_graph(fresh_db, scope="symbol", include_tests=True)
+
+    ids = {n["id"] for n in graph["nodes"]}
+    assert "test_case_00" in ids
+    assert "hub_main" in ids
+    assert graph["metadata"]["tests_included"] is True
+    assert graph["metadata"]["truncated"] is True  # 61 candidates > the 50 cap
+
+
+def test_symbol_scope_overview_excludes_vendored_and_minified_symbols(fresh_db):
+    from cairn.dashboard.data import get_graph
+
+    _seed_vendored(fresh_db)
+    graph = get_graph(fresh_db, scope="symbol")
+
+    ids = {n["id"] for n in graph["nodes"]}
+    # The minified pair has the workspace's top degree but is never a
+    # candidate; the dist/ dir is excluded by the same rule.
+    assert "append" not in ids and "emit" not in ids and "dist_helper" not in ids
+    assert ids == {"real_main", "real_helper"}
+    assert graph["metadata"]["vendored_excluded"] == 3
+    # The dist->real edge dies with its vendored source node.
+    assert graph["metadata"]["edge_count"] == 1
+
+
+def test_symbol_scope_overview_dedupes_cross_repo_parallel_edges(fresh_db):
+    from cairn.dashboard.data import get_graph
+
+    # Same bare names in two repos: the name-based edge join sees three
+    # rows for ONE logical edge, plus a distinct kind that must survive.
+    fresh_db.executemany(
+        "INSERT INTO repos (id, name, path, language, indexed_at) VALUES (?, ?, ?, ?, ?)",
+        [
+            ("r1", "r1", ".", "python", "2026-08-28T00:00:00"),
+            ("r2", "r2", ".", "python", "2026-08-28T00:00:00"),
+        ],
+    )
+    fresh_db.executemany(
+        "INSERT INTO files (id, repo_id, path, language, indexed_at) VALUES (?, ?, ?, ?, ?)",
+        [
+            ("f_r1", "r1", "src/one.py", "python", "2026-08-28T00:00:00"),
+            ("f_r2", "r2", "src/two.py", "python", "2026-08-28T00:00:00"),
+        ],
+    )
+    fresh_db.executemany(
+        "INSERT INTO symbols (id, file_id, name, qualified_name, kind, docstring) "
+        "VALUES (?, ?, ?, ?, ?, NULL)",
+        [
+            ("s_a1", "f_r1", "caller", "one.caller", "function"),
+            ("s_b1", "f_r1", "helper", "one.helper", "function"),
+            ("s_a2", "f_r2", "caller", "two.caller", "function"),
+            ("s_b2", "f_r2", "helper", "two.helper", "function"),
+        ],
+    )
+    fresh_db.executemany(
+        "INSERT INTO edges (id, source_id, target_id, kind) VALUES (?, ?, ?, ?)",
+        [
+            ("pe1", "s_a1", "s_b1", "calls"),
+            ("pe2", "s_a2", "s_b2", "calls"),
+            ("pe3", "s_a1", "s_b2", "calls"),
+            ("pe4", "s_a2", "s_b1", "imports"),
+        ],
+    )
+    fresh_db.commit()
+
+    graph = get_graph(fresh_db, scope="symbol")
+    # One calls edge caller->helper; the distinct-kind imports edge stays.
+    assert graph["metadata"]["edge_count"] == 2
+    kinds = sorted((e["source"], e["target"], e["kind"]) for e in graph["edges"])
+    assert kinds == [("caller", "helper", "calls"), ("caller", "helper", "imports")]
+
+
 # ---------------------------------------------------------------------------
 # Symbol inspect payload (graph-tab side panel): one call answering
 # "what is this, what feeds it, what does it touch, what breaks".


### PR DESCRIPTION
## Summary

On the graph tab, `scope=symbol` with an empty Focus rendered an empty canvas ("No nodes for this scope"). The module scope already treats an empty filter as "all" — a degree-ranked, capped canvas of the workspace's structure. The symbol scope now does the same: an empty Focus draws the workspace's most-connected symbols; a Focus that names a symbol still draws that symbol's neighborhood, and a Focus that names nothing still gets the generic empty state.

Two shipped changes:

- **New viz query `get_symbol_overview`** — same curation rules as `get_module_graph` without a path filter: candidates ranked by degree (fan-in + fan-out) then name, capped at 50 symbols / 100 edges, tests excluded by default (`include_tests` opts in, and the graph tab's Include-tests checkbox now drives it), vendored/minified symbols never candidates, edges deduplicated on `(source, target, kind)`; metadata reports `tests_included` / `truncated` / `vendored_excluded` honestly. The dashboard's symbol scope dispatches to it on empty Focus only — `get_symbol_graph` (and the MCP `visualize_graph` / hooks-viz surfaces on top of it) are untouched.
- **Scope edge queries now filter targets in SQL.** Both `get_module_graph` and the new overview `LIMIT`-ed an arbitrary slice of source-matching edges and only then checked in Python whether the target was a kept node — on real workspaces that sample can contain zero kept→kept edges even when hundreds exist (observed live: a store with 393 such edges rendered "0 edges"; module scope swung between 0 and 1 across restarts because the sample is unordered). The target predicate moved into the WHERE clause, so the cap lands on real internal edges.

## Change type

- [x] Feature / improvement
- [ ] Bugfix
- [ ] Refactor (no behavior change)
- [ ] Docs / chore / CI

## Audit checklist

- [x] **Blast radius checked** — `get_symbol_overview` is a new symbol with one caller (dashboard `get_graph` dispatch). `get_symbol_graph` untouched (6 callers incl. MCP `visualize_graph` and hooks-viz — no behavior change). `get_module_graph`'s edge query changed: callers are the dashboard dispatch and tests; exact-count seed tests still pass unchanged.
- [x] **Layering respected** — change stays in the viz query + dashboard data layers; no new imports beyond the module's existing ``graph.tests`` lazy import pattern; pinned server-stack import guard green.
- [x] **Graph updated** — `cairn build` re-run (after the known `update` stale no-op); `cairn def get_symbol_overview` resolves.
- [ ] **Memory recorded** — post-merge.
- [x] **Fallback/perf paths** — the edge-query change is a query-correctness fix, not a fallback path; `cairn doctor` exit 0 on the previous commit and nothing fallback-related changed since.
- [x] **Tests** — new: 4 data-layer tests (overview ranking/test-exclusion, include-tests opt-in + truncated flag, vendored exclusion, cross-repo edge dedupe), 1 graph-page test (empty Focus draws the overview; Focus-miss keeps the generic empty state). Supersedes #113's guidance test (that message is unreachable now). Module-scope exact-count seed tests pass unchanged. Full suite: 3073 passed, 4 skipped.
- [ ] **CHANGELOG** — handled at release prep per current convention (#111, #113).
- [x] **Gates green** — pre-commit clean; conventional PR title.

## Blast-radius note

None breaking — new symbol with a single caller; `get_module_graph`'s changed rows are a strict superset of the rows the old code could keep (same dedupe and caps). No cross-repo consumers (single-repo package).

## Verification

- `uv run pre-commit run --all-files` clean; `uv run --extra test pytest -q` → 3073 passed, 4 skipped.
- Live on a dashboard launched from the polaris workspace: `/graph?scope=symbol` now draws 48 hub nodes / 24 edges (calls 17, references 6, contains 1) with both legends, truncated flag honest; module scope on the same store went from 0–1 flickering edges to 24. Screenshot-verified.