### PR TITLE
feat(dashboard): icon for the database nav view

### DIFF
--- a/src/cairn/dashboard/templates/_icons.html
+++ b/src/cairn/dashboard/templates/_icons.html
@@ -27,6 +27,8 @@
 <svg width="{{ size }}" height="{{ size }}" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20V2H6.5A2.5 2.5 0 0 0 4 4.5z"/><path d="M4 19.5A2.5 2.5 0 0 0 6.5 22H20v-5"/></svg>
 {%- elif name == "tasks" -%}
 <svg width="{{ size }}" height="{{ size }}" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M9 11l3 3L22 4"/><path d="M21 12v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11"/></svg>
+{%- elif name == "database" -%}
+<svg width="{{ size }}" height="{{ size }}" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M22 12H2"/><path d="M5.45 5.11 2 12v6a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2v-6l-3.45-6.89A2 2 0 0 0 16.76 4H7.24a2 2 0 0 0-1.79 1.11z"/><path d="M6 16h.01"/><path d="M10 16h.01"/></svg>
 {%- elif name == "embeddings" -%}
 <svg width="{{ size }}" height="{{ size }}" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m21 16-9 5-9-5V8l9-5 9 5z"/><path d="m3.3 7 8.7 5 8.7-5"/><path d="M12 22V12"/></svg>
 {%- elif name == "settings" -%}

--- a/tests/test_dashboard_shell.py
+++ b/tests/test_dashboard_shell.py
@@ -137,3 +137,20 @@ def test_shell_context_launch_label_rides_launch_db():
 
     ctx = shell_context(_stores(), "", "/graph")
     assert ctx["selector"]["launch_label"] == LAUNCH_LABEL
+
+
+def test_every_nav_view_has_an_icon_branch():
+    """The icon macro is the presentation half of NAV_SECTIONS (one glyph
+    per view id): a view without an icon branch renders a blank spot in
+    the sidebar, so the coverage is pinned at source level."""
+    from pathlib import Path
+
+    import cairn.dashboard
+
+    src = (
+        Path(cairn.dashboard.__file__).resolve().parent
+        / "templates"
+        / "_icons.html"
+    ).read_text()
+    missing = [v for v in NAV_LABELS if f'name == "{v}"' not in src]
+    assert missing == []


### PR DESCRIPTION
## Summary

The sidebar's **Database** item rendered without a glyph: `_icons.html`'s `svg` macro covered every `NAV_SECTIONS` view id except `database` (the sidebar loop and the landing launcher both render `icons.svg(item.id)` verbatim). Added a hard-drive glyph for it — the cylinder shape is already memory's icon, so the store view gets the distinct drive glyph with indicator lights. Same stroke style as every other view icon (1.8 stroke, round caps/joins, currentColor, 16px sidebar default).

## Change type

- [x] Feature / improvement
- [ ] Bugfix
- [ ] Refactor (no behavior change)
- [ ] Docs / chore / CI

## Audit checklist

- [x] **Blast radius checked** — macro consumers: the sidebar loop (base.html) and the landing launcher (index.html); `database` appears only in the nav loop, so the fix surfaces exactly there. No source changes outside the template.
- [x] **Layering respected** — template-only.
- [x] **Graph updated** — `cairn build` current from this session.
- [ ] **Memory recorded** — post-merge (batched with the other open PRs).
- [x] **Fallback/perf paths** — none touched.
- [x] **Tests** — new source-pin test `test_every_nav_view_has_an_icon_branch`: every `NAV_LABELS` id must have a branch in the macro, so the next view added without a glyph fails here instead of rendering a blank sidebar spot. Shell/restyle/accessibility suites green.
- [ ] **CHANGELOG** — handled at release prep per current convention.
- [x] **Gates green** — pre-commit clean; conventional PR title.

## Blast-radius note

None — additive template branch; no existing branch touched.

## Verification

- `uv run pre-commit run --all-files` clean; shell + restyle + accessibility suites: 48 passed.
- Screenshot-verified live: the Database item renders the glyph in the sidebar's SYSTEM group (active and inactive states).