### PR TITLE
feat(dashboard): an empty filter draws all, per scope

### DIFF
--- a/src/cairn/dashboard/data.py
+++ b/src/cairn/dashboard/data.py
@@ -134,10 +134,13 @@ def get_graph(
     """Dispatch to a viz query scope; returns its ``{nodes, edges, metadata}``
     verbatim — the scope functions already cap result size (LIMIT 30/50,
     ``max_nodes``), and their metadata carries the possibly-truncated counts.
-    The symbol scope with no focal name draws the workspace-wide overview
-    (degree-ranked, capped), matching the module scope's empty-filter
-    behavior. ``include_tests`` applies to the module scope and the symbol
-    overview; the focus-driven scopes take the user's exact word instead.
+    An empty filter draws all of it, per scope: the symbol and impact scopes
+    with no focal name draw the workspace-wide overview (degree-ranked,
+    capped), the module scope's empty filter matches every path, and the
+    repo scope with no repo id buckets every repo in the store. Only a
+    filter that names nothing yields the empty graph. ``include_tests``
+    applies to the module scope and the overviews; the focus-driven scopes
+    take the user's exact word instead.
     """
     if scope == "symbol":
         name = (focus or "").strip()
@@ -147,7 +150,12 @@ def get_graph(
     if scope == "module":
         return viz_query.get_module_graph(conn, focus or "", include_tests=include_tests)
     if scope == "impact":
-        return viz_query.get_impact_graph(conn, focus or "", 3 if depth is None else depth)
+        name = (focus or "").strip()
+        if not name:
+            return viz_query.get_symbol_overview(
+                conn, include_tests=include_tests, scope="impact"
+            )
+        return viz_query.get_impact_graph(conn, name, 3 if depth is None else depth)
     if scope == "deps":
         return viz_query.get_deps_graph(conn)
     if scope == "repo":

--- a/src/cairn/graph/stats.py
+++ b/src/cairn/graph/stats.py
@@ -65,21 +65,34 @@ def get_tree(conn: sqlite3.Connection, repo: str, prefix: str = "") -> List[Tupl
 
 
 def group_by_top_level(conn: sqlite3.Connection, repo: str) -> List[Tuple[str, int]]:
-    """Group a repo's symbols by their top-level source directory."""
+    """Group a repo's symbols by their top-level source directory.
+
+    An empty ``repo`` spans every repo in the store — the bucket view for
+    the workspace-level scopes with no repo filter.
+    """
     cur = conn.cursor()
     # files.path is repo-relative; fetch repos.path to strip it if a DB row
     # still holds an absolute path.
-    repo_row = cur.execute(
-        "SELECT path FROM repos WHERE id = ?", (repo,)
-    ).fetchone()
+    repo_row = None
+    if repo:
+        repo_row = cur.execute(
+            "SELECT path FROM repos WHERE id = ?", (repo,)
+        ).fetchone()
     legacy_repo_root = repo_row["path"] if repo_row else ""
-    rows = cur.execute(
-        """SELECT f.path AS path, COUNT(s.id) AS symbols
-           FROM files f LEFT JOIN symbols s ON s.file_id = f.id
-           WHERE f.repo_id = ?
-           GROUP BY f.id""",
-        (repo,),
-    ).fetchall()
+    if repo:
+        rows = cur.execute(
+            """SELECT f.path AS path, COUNT(s.id) AS symbols
+               FROM files f LEFT JOIN symbols s ON s.file_id = f.id
+               WHERE f.repo_id = ?
+               GROUP BY f.id""",
+            (repo,),
+        ).fetchall()
+    else:
+        rows = cur.execute(
+            """SELECT f.path AS path, COUNT(s.id) AS symbols
+               FROM files f LEFT JOIN symbols s ON s.file_id = f.id
+               GROUP BY f.id""",
+        ).fetchall()
     # Bucket by the first 2-3 path segments.
     buckets: dict[str, int] = {}
     for r in rows:

--- a/src/cairn/viz/query.py
+++ b/src/cairn/viz/query.py
@@ -154,7 +154,8 @@ def get_deps_graph(conn: sqlite3.Connection) -> Dict:
 
 
 def get_repo_graph(conn: sqlite3.Connection, repo: str, max_nodes: int = 30) -> Dict:
-    """Module structure of a repo with symbol counts."""
+    """Module structure of a repo with symbol counts; an empty ``repo``
+    buckets every repo in the store."""
     from ..graph.queries import group_by_top_level
 
     buckets = group_by_top_level(conn, repo)
@@ -165,7 +166,8 @@ def get_repo_graph(conn: sqlite3.Connection, repo: str, max_nodes: int = 30) -> 
         _add_node(nodes, label, "module", "", repo)
     # No edges between modules at this granularity; show as a flat cluster.
     return {"nodes": list(nodes.values()), "edges": edges,
-            "metadata": {"scope": "repo", "repo": repo, "node_count": len(nodes)}}
+            "metadata": {"scope": "repo", "repo": repo, "node_count": len(nodes),
+                         "truncated": len(buckets) > max_nodes}}
 
 
 _SCOPE_CAP = 50
@@ -279,10 +281,13 @@ def get_module_graph(
     }
 
 
-def get_symbol_overview(conn: sqlite3.Connection, include_tests: bool = False) -> Dict:
+def get_symbol_overview(
+    conn: sqlite3.Connection, include_tests: bool = False, scope: str = "symbol"
+) -> Dict:
     """The workspace's most-connected symbols as one canvas — the symbol
     scope's answer to an empty focal name (the dashboard's default landing
-    on that scope).
+    on that scope). ``scope`` labels the result's metadata for the scopes
+    that dispatch here on an empty filter (impact rides along).
 
     The same curation rules as :func:`get_module_graph` without a path
     filter: candidates ranked by degree (fan-in + fan-out of any edges)
@@ -352,7 +357,7 @@ def get_symbol_overview(conn: sqlite3.Connection, include_tests: bool = False) -
         "nodes": list(nodes.values()),
         "edges": edges,
         "metadata": {
-            "scope": "symbol",
+            "scope": scope,
             "focus": "",
             "node_count": len(nodes),
             "edge_count": len(edges),

--- a/tests/test_dashboard_app.py
+++ b/tests/test_dashboard_app.py
@@ -269,6 +269,27 @@ def test_graph_route_symbol_scope_without_focus_draws_overview(tmp_path):
     assert "No nodes for this scope" in resp.text
 
 
+@requires_vis_network
+def test_graph_route_impact_and_repo_empty_filters_draw(tmp_path):
+    """Impact scope with no focal name draws the workspace overview under
+    its own label; repo scope with no repo id buckets every repo — no
+    scope lands on an empty canvas just because a filter is blank."""
+    client = _client(tmp_path, seed=True)
+
+    resp = client.get("/graph", params={"scope": "impact"})
+    assert resp.status_code == 200
+    payload = _embedded_graph(resp.text)
+    assert payload["metadata"]["scope"] == "impact"
+    assert payload["nodes"]
+
+    resp = client.get("/graph", params={"scope": "repo"})
+    assert resp.status_code == 200
+    payload = _embedded_graph(resp.text)
+    assert payload["metadata"]["scope"] == "repo"
+    assert payload["nodes"]
+    assert "No nodes for this scope" not in resp.text
+
+
 # ---------------------------------------------------------------------------
 # Layout persistence + option application (graph-nav FR-004 / US3 / TC-005):
 # /graph reads ``layout`` ∈ {force, hier} -- default force, bogus → force;

--- a/tests/test_dashboard_data.py
+++ b/tests/test_dashboard_data.py
@@ -2613,6 +2613,64 @@ def test_symbol_scope_overview_include_tests_opt_in(fresh_db):
     assert graph["metadata"]["truncated"] is True  # 61 candidates > the 50 cap
 
 
+def test_impact_scope_empty_focus_draws_the_overview(fresh_db):
+    from cairn.dashboard.data import get_graph
+
+    _seed_hubs(fresh_db)
+    graph = get_graph(fresh_db, scope="impact")  # no focus
+
+    ids = {n["id"] for n in graph["nodes"]}
+    assert ids == {"hub_main", "in_a", "in_b", "out_a", "out_b", "pack_leaf"}
+    # The overview rides under the requesting scope's label.
+    assert graph["metadata"]["scope"] == "impact"
+    assert graph["metadata"]["tests_included"] is False
+
+
+def test_repo_scope_empty_repo_buckets_every_repo(fresh_db):
+    from cairn.dashboard.data import get_graph
+
+    fresh_db.executemany(
+        "INSERT INTO repos (id, name, path, language, indexed_at) VALUES (?, ?, ?, ?, ?)",
+        [
+            ("r1", "r1", ".", "python", "2026-08-28T00:00:00"),
+            ("r2", "r2", ".", "python", "2026-08-28T00:00:00"),
+        ],
+    )
+    fresh_db.executemany(
+        "INSERT INTO files (id, repo_id, path, language, indexed_at) VALUES (?, ?, ?, ?, ?)",
+        [
+            ("f_r1a", "r1", "src/one/core.py", "python", "2026-08-28T00:00:00"),
+            ("f_r1b", "r1", "src/one/util.py", "python", "2026-08-28T00:00:00"),
+            ("f_r2a", "r2", "src/two/core.py", "python", "2026-08-28T00:00:00"),
+        ],
+    )
+    fresh_db.executemany(
+        "INSERT INTO symbols (id, file_id, name, qualified_name, kind, docstring) "
+        "VALUES (?, ?, ?, ?, ?, NULL)",
+        [
+            ("s_1a", "f_r1a", "one_core", "one.core.one_core", "function"),
+            ("s_1b", "f_r1b", "one_util", "one.util.one_util", "function"),
+            ("s_2a", "f_r2a", "two_core", "two.core.two_core", "function"),
+        ],
+    )
+    fresh_db.commit()
+
+    graph = get_graph(fresh_db, scope="repo")  # no repo id
+    ids = {n["id"] for n in graph["nodes"]}
+    # Buckets span both repos' top-level structure.
+    assert ids == {"src/one/core.py (1)", "src/one/util.py (1)", "src/two/core.py (1)"}
+    assert graph["metadata"]["repo"] == ""
+    assert graph["metadata"]["node_count"] == 3
+    assert graph["metadata"]["truncated"] is False
+
+    # A named repo still scopes to it.
+    graph = get_graph(fresh_db, scope="repo", repo="r1")
+    assert {n["id"] for n in graph["nodes"]} == {
+        "src/one/core.py (1)",
+        "src/one/util.py (1)",
+    }
+
+
 def test_symbol_scope_overview_excludes_vendored_and_minified_symbols(fresh_db):
     from cairn.dashboard.data import get_graph
 


### PR DESCRIPTION
## Summary

Follow-up to #114 (symbol scope with no focus draws the overview): no graph-tab scope should land on an empty canvas just because a filter is blank. This extends the empty-filter-draws-all behavior to the remaining scopes:

- **impact** with no focal name draws the workspace overview (the same degree-ranked, capped hub canvas) under its own label — `get_symbol_overview` gains a `scope` label param so the embedded metadata stays truthful.
- **repo** with no repo id buckets **every repo in the store**: `group_by_top_level` treats an empty repo as no repo filter, and the repo scope's metadata now carries an honest `truncated` flag (30-bucket cap).
- **deps** already draws globally; **module** already matched every path on an empty filter. Only a filter that *names nothing* still yields the generic empty state.

`include_tests` now applies to both overviews (the graph tab's Include-tests checkbox drives it).

## Change type

- [x] Feature / improvement
- [ ] Bugfix
- [ ] Refactor (no behavior change)
- [ ] Docs / chore / CI

## Audit checklist

- [x] **Blast radius checked** — `group_by_top_level` callers: `get_repo_graph` (this change) and `get_tree` (CLI `cairn tree <repo>`, repo argument is required, so no empty-repo path exists there). `get_impact_graph` unchanged and still reached by MCP `visualize_graph`; the dispatch change only reroutes the dashboard's empty-focus case.
- [x] **Layering respected** — viz query + dashboard data layers only; pinned server-stack import guard green.
- [x] **Graph updated** — `cairn build` run this session; new/changed symbols resolve.
- [ ] **Memory recorded** — post-merge (batched with #115).
- [x] **Fallback/perf paths** — none; `cairn doctor` exit 0 earlier this session.
- [x] **Tests** — new: impact-empty-focus overview (metadata under the impact label, tests excluded), repo-empty-repo all-repo buckets (+ named-repo still scopes), page-level impact/repo render test. Full suite: 3076 passed, 4 skipped; mypy clean; pre-commit clean.
- [ ] **CHANGELOG** — handled at release prep per current convention.
- [x] **Gates green** — conventional PR title; pre-commit + mypy + CI.

## Blast-radius note

`group_by_top_level`'s empty-repo branch is additive (all existing callers pass a non-empty id). `get_symbol_overview`'s new param is optional with the previous value as default.

## Verification

- `uv run --extra test pytest -q` → 3076 passed, 4 skipped; `mypy --ignore-missing-imports src` clean; pre-commit clean.
- Live on the polaris-launched dashboard: `/graph?scope=impact` → 49 nodes / 24 edges (truncated), `/graph?scope=repo` → 30 buckets across all repos ("src/test/java (2558)", "src/main/java (2273)", "tests (961)", …), `/graph?scope=deps` unchanged (15 repos). Screenshot-verified.