### PR TITLE
chore: trim comments to behavior contracts

### DIFF
--- a/src/cairn/dashboard/shell.py
+++ b/src/cairn/dashboard/shell.py
@@ -8,8 +8,8 @@ test). Two owners:
 - :func:`shell_context` is the single source of truth for NAVIGATION:
   the sidebar renders from ``nav.sections`` and the command palette's
   view list from ``palette.views`` — both derive from NAV_SECTIONS, so
-  the two can never drift apart, and hrefs are composed here with the
-  store param riding exactly like the sidebar's old hand-written anchors.
+  the two can never drift apart, and every href carries the store param
+  composed here.
 - :func:`selector_context` turns :func:`enumerate_stores
   <cairn.dashboard.workspaces.enumerate_stores>` rows (stat-only, never
   probed) into the topbar workspace selector's options; the label policy
@@ -122,10 +122,9 @@ def shell_context(
     """Everything base.html's chrome renders from, for one request.
 
     ``nav.sections`` carries the grouped sidebar (each item's ``href``
-    already rides the selected store, matching the pre-shell anchors:
-    bare hrefs when nothing is selected); ``active`` flags derive from
-    the request path exactly as the old hand-written startswith checks
-    did. ``palette`` seeds the command palette: the same view list plus
+    rides the selected store: bare hrefs when nothing is selected);
+    ``active`` flags derive from the request path by prefix match.
+    ``palette`` seeds the command palette: the same view list plus
     the populated workspaces (the palette switches stores through the
     same URL-rewrite behavior as the topbar selector). ``launch_db`` is
     the app factory's launch db path; when it names a registered store,

--- a/src/cairn/viz/query.py
+++ b/src/cairn/viz/query.py
@@ -174,11 +174,8 @@ _SCOPE_CAP = 50
 _SCOPE_EDGE_CAP = 100
 
 # Paths whose symbols are generated or third-party noise, not hand-written
-# structure. Minified bundles dominate the degree ranking (one vendored
-# vis-network.min.js carried 1,060 symbols whose internal calls outrank every
-# real hub), and the scanner's dir/size layers cannot catch a vendored file
-# committed under src/ — the filename marker does. Matches the scanner's
-# DEFAULT_SKIP_DIRS intent for stores built before those layers existed.
+# structure. A vendored file can sit under src/, outside the scanner's
+# skip dirs, so the filename marker is checked on every candidate path.
 _VENDORED_SEGMENTS = {"vendor", "dist", "node_modules"}
 
 
@@ -196,20 +193,17 @@ def get_module_graph(
     """Symbols in a module + their internal edges, curated for usefulness.
 
     An empty ``module`` (the dashboard's default landing view) matches every
-    path, so "first 50 by rowid" used to fill the canvas with an arbitrary
-    sample — dominated by whichever files the indexer touched first (in
-    practice, tests). Candidates are instead ranked by degree (fan-in +
-    fan-out of any edges) then name, so the cap lands on the symbols that
-    carry the module's structure. Tests are excluded by default (the
-    ``is_test_symbol`` heuristics from the impact layer); ``include_tests``
-    opts back in. Symbols from vendored/minified assets
-    (:func:`_is_vendored_path`) are never candidates — they are generated
-    noise in every scope, so unlike tests they have no opt-in. Edges are
-    deduplicated on ``(source, target, kind)``: the join is by bare symbol
-    name, so same-named symbols across repos multiply one logical edge into
-    many parallel rows (which also destabilize vis-network's force layout
-    into a blank canvas). ``metadata.tests_included``, ``metadata.truncated``
-    and ``metadata.vendored_excluded`` report all three choices honestly.
+    path. Candidates are ranked by degree (fan-in + fan-out of any edges)
+    then name, so the cap lands on the symbols that carry the module's
+    structure. Tests are excluded by default (the ``is_test_symbol``
+    heuristics from the impact layer); ``include_tests`` opts back in.
+    Symbols from vendored/minified assets (:func:`_is_vendored_path`) are
+    never candidates — they are generated noise in every scope, so unlike
+    tests they have no opt-in. Edges are deduplicated on ``(source,
+    target, kind)``: the join is by bare symbol name, so same-named symbols
+    across repos multiply one logical edge into many parallel rows.
+    ``metadata.tests_included``, ``metadata.truncated`` and
+    ``metadata.vendored_excluded`` report all three choices honestly.
     """
     from ..graph.tests import is_test_symbol
 

--- a/tests/test_dashboard_app.py
+++ b/tests/test_dashboard_app.py
@@ -2905,8 +2905,8 @@ def test_shell_js_switch_contract_is_pinned_at_source_level():
 
 # ---------------------------------------------------------------------------
 # Grouped sidebar + command palette (shell chrome): the sidebar renders
-# from shell.NAV_SECTIONS (same href shape as the hand-written anchors it
-# replaced), collapse persists pre-paint like the theme, and the palette
+# from shell.NAV_SECTIONS with store-carrying hrefs, collapse persists
+# pre-paint like the theme, and the palette
 # opens as an Alpine <dialog> over two row sources — the server-rendered
 # seed JSON draws the initial list, typing fetches /palette/results
 # fragments (the same seed composition plus /graph/suggest's symbol

--- a/tests/test_dashboard_shell.py
+++ b/tests/test_dashboard_shell.py
@@ -1,8 +1,8 @@
 """Unit tests for the dashboard shell context (cairn.dashboard.shell).
 
 Pure-function tests, no HTTP: the nav-as-data contract (sidebar and
-palette render from one source, hrefs ride the store like the old
-hand-written anchors) and the workspace label policy.
+palette render from one source, hrefs ride the selected store) and the
+workspace label policy.
 """
 
 from cairn.dashboard.shell import (
@@ -65,8 +65,7 @@ def test_shell_context_groups_nav_and_flags_active_by_path():
     ]
     assert [item["id"] for item in active] == ["graph"]
 
-    # A wiki detail path still flags the wiki item (startswith, the old
-    # hand-written rule).
+    # A wiki detail path still flags the wiki item (prefix match).
     ctx = shell_context(_stores(), "", "/wiki/demo/overview")
     active = [
         item


### PR DESCRIPTION
## Summary

Full comment audit of every file touched by #113–#116, enforced against the comment style rule (behavior and contract only; no decision logs, no history, no stale data). Comment-only diff, zero behavior change.

Trimmed:

- `viz/query.py` — `get_module_graph` docstring carried a decision log ("first 50 by rowid **used to** fill the canvas … candidates are **instead** ranked") and a vis-network layout anecdote; the `_VENDORED_SEGMENTS` comment carried a stale one-store anecdote ("carried 1,060 symbols") and history ("for stores built before those layers existed"). Both now state only the current selection/dedup contract and the filename-marker constraint.
- `dashboard/shell.py` — module docstring and `shell_context` docstring referenced "the sidebar's old hand-written anchors" / "the pre-shell anchors … old hand-written startswith checks". Now state the href composition and prefix-match behavior directly.
- `tests/test_dashboard_shell.py` — module docstring and one inline comment repeated the same "old hand-written" history.
- `tests/test_dashboard_app.py` — shell-chrome section comment referenced "the hand-written anchors it replaced".

Audited and deliberately kept:

- FR-/US-/TC- and D-0xx spec/decision references — pervasive pre-existing repo convention across the codebase; trimming them is a separate repo-wide pass if wanted.
- "hand-written" in `_is_vendored_path`'s comment (human-written vs generated code — a contract, not history) and "the previously-newest row" in a test (relative ordering, not history).

## Change type

- [ ] Feature / improvement
- [ ] Bugfix
- [x] Refactor (no behavior change)
- [ ] Docs / chore / CI

## Audit checklist

- [x] **Blast radius checked** — comment-only diff; no symbol, signature, or string-literal assertions touched (verified: full suite green).
- [x] **Layering respected** — no code paths changed.
- [x] **Graph updated** — `cairn build` current from this session.
- [ ] **Memory recorded** — nothing new to record (policy application, not a decision).
- [x] **Fallback/perf paths** — none touched.
- [x] **Tests** — full suite: 3077 passed, 4 skipped; pre-commit clean.
- [ ] **CHANGELOG** — no behavior change; nothing to document.
- [x] **Gates green** — conventional PR title; pre-commit + CI.

## Blast-radius note

None — comments only.

## Verification

- `uv run pre-commit run --all-files` clean; `uv run --extra test pytest -q` → 3077 passed, 4 skipped.
- Swept all ten touched files for history/decision/stale-data patterns (`used to`, `previously`, `old hand-written`, `pre-shell`, anecdote counts, PR refs) — zero remaining outside the deliberately-kept convention classes above.