### PR TITLE
chore: bump 0.20.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,41 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.20.0] - 2026-09-10
+
+### Added
+- The dashboard graph tab draws the whole picture instead of an empty
+  canvas whenever a scope's filter is blank:
+  - `symbol` and `impact` scopes with no focal name render the
+    workspace overview — the most-connected symbols on one canvas,
+    ranked by degree (fan-in + fan-out), capped at 50 symbols and 100
+    edges, tests excluded by default with the Include-tests toggle
+    opting back in, vendored/minified assets never candidates, and
+    edges deduplicated on `(source, target, kind)`. Metadata reports
+    `tests_included`, `truncated`, and `vendored_excluded` so a
+    count at the cap is visibly truncated. A focal name still draws
+    that symbol's neighborhood; a name that matches nothing still
+    renders the empty state.
+  - The `repo` scope with no repo id buckets every repo in the store,
+    capped at 30 buckets with an honest `truncated` flag in metadata.
+- The MCP `visualize_graph` tool rides the same viz layer: module
+  diagrams include their real internal edges, and `format="json"`
+  output for the repo scope carries the `truncated` field.
+- The dashboard sidebar's Database item has an icon (hard-drive glyph)
+  like every other nav view; a source-pinned test fails if a future
+  nav view ships without a glyph.
+
+### Fixed
+- The dashboard's workspace selector names the launch workspace (e.g.
+  `polaris (launch)`). The selector's no-selection option serves the
+  launch store — the dashboard process's own db — so the label shows
+  which workspace every view queries by default. The generic
+  `Launch workspace` label applies only to custom `--db` paths outside
+  the store registry.
+- Module- and symbol-scope edge queries apply the kept-node target
+  predicate in SQL before the 100-edge cap, so the cap lands on real
+  internal edges and the rendered edge set is stable across scans.
+
 ## [0.19.1] - 2026-09-10
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "cairn-intel"
-version = "0.19.1"
+version = "0.20.0"
 description = "Local codebase intelligence system: structural graph + compass + wiki + agent memory"
 readme = "README.md"
 license = "MIT"
@@ -235,7 +235,7 @@ select = ["F"]
 # The custom template (.cz_templates/keepachangelog.j2) renders that draft in
 # the existing `## [X.Y.Z] - YYYY-MM-DD` format rather than commitizen's
 # default `## X.Y.Z (YYYY-MM-DD)`.
-version = "0.19.1"
+version = "0.20.0"
 version_scheme = "pep440"
 tag_format = "v$version"
 update_changelog_on_bump = false

--- a/src/cairn/__init__.py
+++ b/src/cairn/__init__.py
@@ -1,3 +1,3 @@
 """Cairn: local codebase intelligence system."""
-__version__ = "0.19.1"
+__version__ = "0.20.0"
 __package_name__ = "cairn-intel"

--- a/uv.lock
+++ b/uv.lock
@@ -202,7 +202,7 @@ filecache = [
 
 [[package]]
 name = "cairn-intel"
-version = "0.19.1"
+version = "0.20.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

Release prep for 0.20.0: the [0.20.0] CHANGELOG entry (graph-tab overview scopes, empty-filter draw-all behavior, launch-workspace labeling, database nav icon, the SQL-side edge-target fix), the commitizen version bump (0.19.1 → 0.20.0), and the uv.lock sync. Tag lands on the merge commit after this merges; pushing it triggers release.yml (wheel/sdist → PyPI via Trusted Publishing → GitHub Release from the changelog section).

## Change type

- [ ] Feature / improvement
- [ ] Bugfix
- [ ] Refactor (no behavior change)
- [x] Docs / chore / CI

## Audit checklist

- [x] **Blast radius checked** — version files + changelog + lockfile only.
- [x] **Layering respected** — n/a.
- [x] **Graph updated** — current from this session.
- [ ] **Memory recorded** — release mechanics already covered by existing memory.
- [x] **Fallback/perf paths** — none touched.
- [x] **Tests** — full suite 3077 passed / 4 skipped on this tree; infra tier 201 passed / 1 skipped (release gate, PR CI skips it). No new skips.
- [x] **CHANGELOG** — this IS the changelog prep ([0.20.0] - 2026-09-10, hand-curated prose per the changelog-first rule).
- [x] **Gates green** — conventional PR title; pre-commit + CI.

## Blast-radius note

None — release plumbing.

## Verification

- `cz bump --yes` → `bump: version 0.19.1 → 0.20.0` (pyproject + `__version__`), tag v0.20.0 created locally.
- `uv lock` → `Updated cairn-intel v0.19.1 -> v0.20.0`.
- Full suite + infra tier green (counts above).